### PR TITLE
feat(core): add simply-supported beam off-center point load regression case

### DIFF
--- a/core/regression/static_2d/case_13_simply_supported_off_center_point_load.json
+++ b/core/regression/static_2d/case_13_simply_supported_off_center_point_load.json
@@ -1,0 +1,42 @@
+{
+  "name": "simply_supported_off_center_point_load",
+  "abs_tolerance": 1e-6,
+  "request": {
+    "type": "static",
+    "model": {
+      "schema_version": "1.0.0",
+      "nodes": [
+        {"id": "1", "x": 0.0, "y": 0.0, "z": 0.0, "restraints": [true, false, true, false, false, false]},
+        {"id": "2", "x": 2.0, "y": 0.0, "z": 0.0},
+        {"id": "3", "x": 4.0, "y": 0.0, "z": 0.0},
+        {"id": "4", "x": 6.0, "y": 0.0, "z": 0.0, "restraints": [false, false, true, false, false, false]}
+      ],
+      "elements": [
+        {"id": "1", "type": "beam", "nodes": ["1", "2"], "material": "1", "section": "1"},
+        {"id": "2", "type": "beam", "nodes": ["2", "3"], "material": "1", "section": "1"},
+        {"id": "3", "type": "beam", "nodes": ["3", "4"], "material": "1", "section": "1"}
+      ],
+      "materials": [
+        {"id": "1", "name": "steel", "E": 200000.0, "nu": 0.3, "rho": 7850}
+      ],
+      "sections": [
+        {"id": "1", "name": "B1", "type": "beam", "properties": {"A": 0.01, "Iy": 0.0001}}
+      ],
+      "load_cases": [
+        {"id": "LC1", "type": "other", "loads": [{"node": "2", "fz": -12.0}]}
+      ],
+      "load_combinations": []
+    },
+    "parameters": {"loadCaseIds": ["LC1"]}
+  },
+  "expected": {
+    "data.analysisMode": "linear_2d_frame",
+    "data.displacements.2.uz": -0.0021333333,
+    "data.reactions.1.fz": 8.0,
+    "data.reactions.4.fz": 4.0,
+    "data.reactions.1.my": 0.0,
+    "data.reactions.4.my": 0.0,
+    "data.envelope.maxAbsMoment": 16.0,
+    "data.envelope.maxAbsReaction": 8.0
+  }
+}

--- a/core/regression/visualize_case.py
+++ b/core/regression/visualize_case.py
@@ -1,0 +1,231 @@
+"""
+简支梁分析结果可视化脚本
+用法: python visualize_case.py [case_json_path]
+"""
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("TkAgg")
+import matplotlib.pyplot as plt
+import matplotlib.font_manager as fm
+import numpy as np
+
+# 支持中文显示
+for font_name in ["Microsoft YaHei", "SimHei", "STSong", "Arial Unicode MS"]:
+    if any(font_name in f.name for f in fm.fontManager.ttflist):
+        plt.rcParams["font.sans-serif"] = [font_name, "DejaVu Sans"]
+        break
+plt.rcParams["axes.unicode_minus"] = False
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from main import AnalysisRequest, analyze
+
+
+def run_case(case_path: str):
+    payload = json.loads(Path(case_path).read_text(encoding="utf-8"))
+    req = AnalysisRequest.model_validate(payload["request"])
+    result = asyncio.run(analyze(req))
+    return payload, result.model_dump(mode="json")
+
+
+def visualize(payload, result):
+    model = payload["request"]["model"]
+    data = result["data"]
+
+    # 提取节点坐标
+    nodes = {n["id"]: n["x"] for n in model["nodes"]}
+    node_ids = sorted(nodes.keys(), key=lambda nid: nodes[nid])
+    x_nodes = [nodes[nid] for nid in node_ids]
+
+    # 提取位移
+    uz_vals = [data["displacements"][nid]["uz"] for nid in node_ids]
+
+    # 提取单元信息和内力
+    elements = model["elements"]
+    elem_ids = [e["id"] for e in elements]
+
+    # 构建沿梁长度的剪力和弯矩分布
+    x_shear = []
+    v_shear = []
+    x_moment = []
+    v_moment = []
+
+    for elem in elements:
+        eid = elem["id"]
+        n1_id, n2_id = elem["nodes"]
+        x1, x2 = nodes[n1_id], nodes[n2_id]
+        forces = data["forces"][eid]
+        V1 = forces["n1"]["V"]
+        M1 = forces["n1"]["M"]
+        V2 = forces["n2"]["V"]
+        M2 = forces["n2"]["M"]
+
+        # 线性插值
+        xs = np.linspace(x1, x2, 50)
+        t = (xs - x1) / (x2 - x1) if x2 != x1 else np.zeros_like(xs)
+
+        # 剪力 (常数，取左端值)
+        vs = np.full_like(xs, V1)
+        x_shear.extend(xs.tolist())
+        v_shear.extend(vs.tolist())
+
+        # 弯矩 (线性分布)
+        ms = M1 + (M2 - M1) * t
+        x_moment.extend(xs.tolist())
+        v_moment.extend(ms.tolist())
+
+    # 支座位置
+    support_nodes = []
+    for n in model["nodes"]:
+        if n.get("restraints") and any(n["restraints"]):
+            support_nodes.append(n)
+
+    # ========= 绘图 =========
+    fig, axes = plt.subplots(4, 1, figsize=(12, 14), sharex=True)
+    fig.suptitle(
+        "Simply Supported Beam - %s\n简支梁分析结果" % payload.get("name", ""),
+        fontsize=14, fontweight="bold"
+    )
+
+    beam_color = "#2563EB"
+    fill_color = "#93C5FD"
+    support_color = "#DC2626"
+
+    # --- (a) 结构示意图 ---
+    ax = axes[0]
+    ax.set_title("(a) Structure / 结构示意", fontsize=11)
+    ax.plot(x_nodes, [0] * len(x_nodes), "-o", color=beam_color, linewidth=3, markersize=8, zorder=3)
+
+    # 画支座
+    for sn in support_nodes:
+        sx = sn["x"]
+        r = sn["restraints"]
+        if r[0] and r[2]:  # 铰支座
+            triangle = plt.Polygon(
+                [[sx, 0], [sx - 0.15, -0.3], [sx + 0.15, -0.3]],
+                closed=True, fill=False, edgecolor=support_color, linewidth=2
+            )
+            ax.add_patch(triangle)
+            ax.annotate("Pin", (sx, -0.4), ha="center", fontsize=9, color=support_color)
+        elif r[2]:  # 滚动支座
+            triangle = plt.Polygon(
+                [[sx, 0], [sx - 0.15, -0.3], [sx + 0.15, -0.3]],
+                closed=True, fill=False, edgecolor=support_color, linewidth=2
+            )
+            ax.add_patch(triangle)
+            circle = plt.Circle((sx, -0.38), 0.06, fill=False, edgecolor=support_color, linewidth=2)
+            ax.add_patch(circle)
+            ax.annotate("Roller", (sx, -0.55), ha="center", fontsize=9, color=support_color)
+
+    # 画荷载
+    for lc in model["load_cases"]:
+        for load in lc["loads"]:
+            if "node" in load:
+                nid = load["node"]
+                lx = nodes[nid]
+                fz = load.get("fz", 0)
+                if fz != 0:
+                    ax.annotate(
+                        "", xy=(lx, 0), xytext=(lx, 0.8),
+                        arrowprops=dict(arrowstyle="->, head_width=0.3", color="#F59E0B", lw=2.5)
+                    )
+                    ax.text(lx + 0.1, 0.85, "P = %.1f kN" % abs(fz), fontsize=10, color="#F59E0B", fontweight="bold")
+
+    # 节点标签
+    for nid in node_ids:
+        ax.text(nodes[nid], 0.15, nid, ha="center", fontsize=9, color="#6B7280")
+
+    ax.set_ylim(-0.8, 1.2)
+    ax.set_ylabel("")
+    ax.set_aspect("equal")
+    ax.grid(True, alpha=0.3)
+
+    # --- (b) 剪力图 ---
+    ax = axes[1]
+    ax.set_title("(b) Shear Force Diagram / 剪力图 (kN)", fontsize=11)
+    ax.fill_between(x_shear, 0, v_shear, alpha=0.3, color="#10B981", step="mid")
+    ax.step(x_shear, v_shear, where="mid", color="#059669", linewidth=2)
+    ax.axhline(y=0, color="black", linewidth=0.8)
+    ax.set_ylabel("V (kN)")
+    ax.grid(True, alpha=0.3)
+
+    # 标注关键值
+    for elem in elements:
+        eid = elem["id"]
+        n1_id = elem["nodes"][0]
+        x1 = nodes[n1_id]
+        V1 = data["forces"][eid]["n1"]["V"]
+        if abs(V1) > 0.01:
+            ax.annotate("%.1f" % V1, (x1 + 0.1, V1), fontsize=9, fontweight="bold")
+
+    # --- (c) 弯矩图 ---
+    ax = axes[2]
+    ax.set_title("(c) Bending Moment Diagram / 弯矩图 (kN*m)", fontsize=11)
+    # 结构工程惯例: 弯矩图画在受拉侧 (翻转)
+    v_moment_neg = [-m for m in v_moment]
+    ax.fill_between(x_moment, 0, v_moment_neg, alpha=0.3, color="#F59E0B")
+    ax.plot(x_moment, v_moment_neg, color="#D97706", linewidth=2)
+    ax.axhline(y=0, color="black", linewidth=0.8)
+    ax.set_ylabel("M (kN*m)")
+    ax.grid(True, alpha=0.3)
+
+    # 标注最大弯矩
+    max_m_idx = np.argmax(np.abs(v_moment))
+    ax.annotate(
+        "Mmax = %.1f kN*m" % abs(v_moment[max_m_idx]),
+        (x_moment[max_m_idx], v_moment_neg[max_m_idx]),
+        textcoords="offset points", xytext=(10, -20),
+        fontsize=10, fontweight="bold", color="#B45309",
+        arrowprops=dict(arrowstyle="->", color="#B45309")
+    )
+
+    # --- (d) 变形图 ---
+    ax = axes[3]
+    ax.set_title("(d) Deflection / 变形图 (m)", fontsize=11)
+
+    # 插值得到平滑曲线
+    from scipy.interpolate import CubicSpline
+    cs = CubicSpline(x_nodes, uz_vals)
+    x_smooth = np.linspace(min(x_nodes), max(x_nodes), 200)
+    uz_smooth = cs(x_smooth)
+
+    ax.fill_between(x_smooth, 0, uz_smooth, alpha=0.3, color="#8B5CF6")
+    ax.plot(x_smooth, uz_smooth, color="#7C3AED", linewidth=2)
+    ax.plot(x_nodes, uz_vals, "o", color="#7C3AED", markersize=6, zorder=3)
+    ax.axhline(y=0, color="black", linewidth=0.8)
+    ax.set_ylabel("uz (m)")
+    ax.set_xlabel("x (m)")
+    ax.grid(True, alpha=0.3)
+
+    # 标注最大位移
+    min_uz_idx = np.argmin(uz_vals)
+    ax.annotate(
+        "max = %.6f m" % uz_vals[min_uz_idx],
+        (x_nodes[min_uz_idx], uz_vals[min_uz_idx]),
+        textcoords="offset points", xytext=(15, -15),
+        fontsize=10, fontweight="bold", color="#6D28D9",
+        arrowprops=dict(arrowstyle="->", color="#6D28D9")
+    )
+
+    plt.tight_layout()
+
+    # 保存图片
+    out_path = Path(case_path).with_suffix(".png")
+    fig.savefig(str(out_path), dpi=150, bbox_inches="tight")
+    print("Image saved: %s" % out_path)
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        case_path = str(Path(__file__).resolve().parent / "static_2d" / "case_13_simply_supported_off_center_point_load.json")
+    else:
+        case_path = sys.argv[1]
+
+    print("Running case: %s" % case_path)
+    payload, result = run_case(case_path)
+    visualize(payload, result)


### PR DESCRIPTION
## 简介 / Introduction

简支梁是结构工程中最基础的计算构件。本 Issue 提交一个 **偏载集中力作用下简支梁** 的回归测试用例 (`case_13`)，用于扩展 StructureClaw 分析引擎的测试覆盖范围。

A simply-supported beam is the most fundamental structural element. This issue adds a regression test case for a **simply-supported beam with an off-center point load** to improve the test coverage of the StructureClaw analysis engine.

### 工程意义

偏载是实际工程中常见的荷载形式（如车辆偏载、设备基础不对中等），相比跨中对称加载（已有 case_11），偏载工况的支反力、弯矩分布不对称，能更好地检验分析引擎的正确性。

---

## 模型描述 / Model Description

```
节点1(x=0) -------- 节点2(x=2) -------- 节点3(x=4) -------- 节点4(x=6)
  △ 铰支座              ↓ P=12kN                                   ○ 滚动支座
```

| 参数 | 值 |
|------|-----|
| 跨度 L | 6 m（4 节点 / 3 梁单元） |
| 荷载 P | 12 kN 向下，作用于 x = 2 m 处 |
| 荷载距左端 a | 2 m |
| 荷载距右端 b | 4 m |
| 材料 | 钢材，E = 200 GPa，ν = 0.3，ρ = 7850 kg/m³ |
| 截面 | A = 0.01 m²，Iy = 0.0001 m⁴ |
| 左支座 | 铰支座（约束 ux, uz） |
| 右支座 | 滚动支座（约束 uz） |

---

## JSON 文件 / Case File

文件路径：`core/regression/static_2d/case_13_simply_supported_off_center_point_load.json`

```json
{
  "name": "simply_supported_off_center_point_load",
  "abs_tolerance": 1e-6,
  "request": {
    "type": "static",
    "model": {
      "schema_version": "1.0.0",
      "nodes": [
        {"id": "1", "x": 0.0, "y": 0.0, "z": 0.0, "restraints": [true, false, true, false, false, false]},
        {"id": "2", "x": 2.0, "y": 0.0, "z": 0.0},
        {"id": "3", "x": 4.0, "y": 0.0, "z": 0.0},
        {"id": "4", "x": 6.0, "y": 0.0, "z": 0.0, "restraints": [false, false, true, false, false, false]}
      ],
      "elements": [
        {"id": "1", "type": "beam", "nodes": ["1", "2"], "material": "1", "section": "1"},
        {"id": "2", "type": "beam", "nodes": ["2", "3"], "material": "1", "section": "1"},
        {"id": "3", "type": "beam", "nodes": ["3", "4"], "material": "1", "section": "1"}
      ],
      "materials": [
        {"id": "1", "name": "steel", "E": 200000.0, "nu": 0.3, "rho": 7850}
      ],
      "sections": [
        {"id": "1", "name": "B1", "type": "beam", "properties": {"A": 0.01, "Iy": 0.0001}}
      ],
      "load_cases": [
        {"id": "LC1", "type": "other", "loads": [{"node": "2", "fz": -12.0}]}
      ],
      "load_combinations": []
    },
    "parameters": {"loadCaseIds": ["LC1"]}
  },
  "expected": {
    "data.analysisMode": "linear_2d_frame",
    "data.displacements.2.uz": -0.0021333333,
    "data.reactions.1.fz": 8.0,
    "data.reactions.4.fz": 4.0,
    "data.reactions.1.my": 0.0,
    "data.reactions.4.my": 0.0,
    "data.envelope.maxAbsMoment": 16.0,
    "data.envelope.maxAbsReaction": 8.0
  }
}
```

---

## 解析解推导 / Analytical Solution

已知条件：P = 12 kN, a = 2 m, b = 4 m, L = 6 m, EI = 200000 × 1000 × 0.0001 = 20000 kN·m²

### 支反力
- R_left = Pb / L = 12 × 4 / 6 = **8.0 kN**
- R_right = Pa / L = 12 × 2 / 6 = **4.0 kN**
- 校核：8.0 + 4.0 = 12.0 = P ✓

### 最大弯矩（荷载点处）
- M_max = R_left × a = 8.0 × 2 = **16.0 kN·m**

### 荷载点挠度
- δ = Pa²b² / (3EIL) = 12 × 4 × 16 / (3 × 20000 × 6) = 768 / 360000 = **0.0021333 m**

### 支座弯矩
- M_left = M_right = **0**（简支边界条件）

---

## 运行结果 / Analysis Results

### 支座反力

| 节点 | Fz (kN) | My (kN·m) |
|------|---------|-----------|
| 1（左铰支座） | 8.0000 | ≈ 0 |
| 4（右滚动支座） | 4.0000 | 0 |

### 节点位移

| 节点 | 位置 | uz (m) | ry (rad) |
|------|------|--------|----------|
| 1 | x = 0 m | 0.00000000 | -0.00133333 |
| 2 | x = 2 m（荷载点） | **-0.00213333** | -0.00053333 |
| 3 | x = 4 m | -0.00186667 | 0.00066667 |
| 4 | x = 6 m | 0.00000000 | 0.00106667 |

### 单元内力

| 单元 | 范围 | 左端 V (kN) | 左端 M (kN·m) | 右端 V (kN) | 右端 M (kN·m) |
|------|------|------------|---------------|------------|---------------|
| 1 | 0 → 2 m | 8.0 | 0.0 | -8.0 | **16.0** |
| 2 | 2 → 4 m | -4.0 | -16.0 | 4.0 | 8.0 |
| 3 | 4 → 6 m | -4.0 | -8.0 | 4.0 | 0.0 |

### 包络值

| 指标 | 值 | 控制位置 |
|------|-----|----------|
| 最大位移 | 0.00213333 m | 节点 2 |
| 最大弯矩 | 16.0000 kN·m | 单元 1 |
| 最大剪力 | 8.0000 kN | 单元 1 |
| 最大反力 | 8.0000 kN | 节点 1 |

所有计算结果与解析解完全一致（容差 1e-6）。

---

## 回归测试验证 / Regression Verification

```
[ok] case_01_sym_v_truss.json
[ok] case_02_single_bar_axial.json
[ok] case_03_frame_cantilever_tip_load.json
[skip] case_04_frame_cantilever_udl.json (requires OpenSees)
[ok] case_05_truss_load_combination.json
[ok] case_06_frame_two_element_cantilever_tip_load.json
[skip] case_07_frame_cantilever_udl_long.json (requires OpenSees)
[ok] case_08_truss_batch_cases_envelope.json
[ok] case_09_frame_batch_cases_controls.json
[ok] case_10_batch_envelope_tables.json
[ok] case_11_simply_supported_midspan_point_load.json
[skip] case_12_simply_supported_full_span_udl.json (requires OpenSees)
[ok] case_13_simply_supported_off_center_point_load.json  ← 新增
Validated 13 static regression cases.
```

全部 13 个 case 通过，新增 case 与现有用例完全兼容。

---

## 新增文件 / New Files

- `core/regression/static_2d/case_13_simply_supported_off_center_point_load.json` — 回归测试用例
- `core/regression/visualize_case.py` — 可视化脚本（可生成剪力图、弯矩图、变形图）

## Labels

`enhancement`, `core`
