### PR TITLE
chore(backend): add debian-openssl-3.0.x binaryTarget for Ubuntu 22.04/24.04 compatibility

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
**改动内容与目的**  
Ubuntu 22.04 和 24.04 默认使用 OpenSSL 3.0.x，Prisma 默认 binaryTarget 可能导致引擎加载失败或 warning。添加 "debian-openssl-3.0.x" 确保兼容现代 Ubuntu / Docker 环境，同时保留 "native" 用于本地开发。

**影响模块**  
backend（prisma schema）

**已执行命令与结果**  
本地 Windows + WSL（Ubuntu 24.04） 容器验证正常

**参考**  
Prisma 文档：https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#binarytargets-options  
（从 Prisma 3.13.0+ 开始官方支持 debian-openssl-3.0.x）