### PR TITLE
Add OpenSSL 3.0 binaryTargets for Prisma on Ubuntu

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
This pull request makes a minor update to the Prisma schema configuration to improve compatibility with deployment environments.

- Added `binaryTargets = ["native", "debian-openssl-3.0.x"]` to the Prisma client generator configuration in `schema.prisma` to ensure the generated client works on both local and Debian-based production environments.