### PR TITLE
Run Prisma migrate deploy on Docker startup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,6 +31,7 @@ RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
 COPY --from=builder /app/src/agent-skills ./src/agent-skills
 
 EXPOSE ${PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,15 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    command:
+      - /bin/sh
+      - -c
+      - |
+        until npx prisma migrate deploy; do
+          echo "Prisma migrate failed, retrying in 2s..."
+          sleep 2
+        done
+        npm start
     ports:
       - "${PORT:-8000}:${PORT:-8000}"
     volumes:


### PR DESCRIPTION
This pull request updates the Docker deployment setup to improve database migration reliability and ensure all necessary dependencies are included in the backend container. The changes focus on making the Prisma migration process more robust and fixing a missing dependency in the Docker build.

**Docker build improvements:**

* Added a step in the `backend/Dockerfile` to copy the `prisma` CLI package from the builder stage to the final image, ensuring the Prisma CLI is available at runtime.

**Deployment and migration reliability:**

* Updated the `docker-compose.yml` backend service command to repeatedly attempt `npx prisma migrate deploy` until it succeeds before starting the application, improving resilience to transient database or startup issues.