### PR TITLE
feat(backend): enable chat to present analysis results directly

### DIFF
--- a/backend/src/services/agent.ts
+++ b/backend/src/services/agent.ts
@@ -1860,7 +1860,7 @@ export class AgentService {
       const promptParts = [
         this.localize(locale, '你是结构工程 Agent 的结果解释器。', 'You explain results produced by the structural engineering agent.'),
         hasData
-          ? this.localize(locale, '请用中文在 250 字以内，根据用户意图从分析数据中提取用户关心的结果并回答。只引用数据中存在的数值，不要杜撰。', 'Respond in English within 250 words. Extract and present the results the user cares about from the analysis data. Only cite values present in the data; do not invent data.')
+          ? this.localize(locale, '请用中文在 250 字以内，根据用户意图从分析数据中提取用户关心的结果并回答。只引用数据中存在的数值，不要杜撰。若用户询问的数据未在当前分析数据中提供，请明确说明，并引导用户查看结构化数据结果与可视化界面。', 'Respond in English within 250 words. Extract and present the results the user cares about from the analysis data. Only cite values present in the data; do not invent data. If the requested value is not available in the current analysis data, say so clearly and direct the user to the structured results and visualization view.')
           : this.localize(locale, '请用中文在 80 字以内给出结论，不要杜撰未出现的数据。', 'Respond in English within 80 words and do not invent data that was not provided.'),
       ];
       if (conversationContext) {


### PR DESCRIPTION
## Summary

After analysis, the chat only replied "analysis completed successfully" because `renderSummary` received no numerical data. This PR fixes it by:

1. **Passing FEM results to LLM** — `reactions`, `forces`, `displacements`, `envelope` are injected into the prompt so the LLM can cite actual values.
2. **Including conversation history** — the most recent 6 messages are queried as context for multi-turn intent understanding.

## Scope

`backend/src/services/agent.ts` only (~40 lines changed).

## Notes

- Word limit: 80 → 250 chars when analysis data is present; original 80-char prompt unchanged for other paths.
- History lookup is non-blocking; silently skipped on failure.
- All prompt text is bilingual (zh/en).

## Test

- [x] `tsc` compiles clean
- [x] Docker rebuild + health check passed