### PR TITLE
feat(backend): define common utility skill set with safety boundaries and composition

### DIFF
--- a/backend/src/agent-runtime/types.ts
+++ b/backend/src/agent-runtime/types.ts
@@ -154,7 +154,8 @@ export type SkillDomain =
   | 'result-postprocess'
   | 'visualization'
   | 'report-export'
-  | 'generic-fallback';
+  | 'generic-fallback'
+  | 'general';
 
 export interface SkillCompatibility {
   minRuntimeVersion: string;

--- a/backend/src/agent-skills/general/README.md
+++ b/backend/src/agent-skills/general/README.md
@@ -4,3 +4,25 @@ Purpose:
 - Memory and planning helpers
 - File read/write and replace utilities
 - Basic shell command capabilities
+
+## Skill Inventory
+
+| Skill | Safety Level | Capabilities | Depends On |
+|-------|-------------|-------------|------------|
+| memory | read-write-local | context-store, context-retrieve, context-clear | — |
+| planning | read-only | task-decompose, step-sequence, condition-gate | — |
+| read-file | read-only | file-read-text, file-read-json, file-list-dir | — |
+| write-file | read-write-local | file-write-text, file-write-json | — |
+| replace | read-write-local | text-replace, json-patch | read-file, write-file |
+| shell | restricted-exec | shell-exec | — |
+
+## Safety Levels
+
+- **read-only**: No writes, no side effects.
+- **read-write-local**: Writes to session-scoped or sandbox-scoped storage only.
+- **restricted-exec**: External process execution within a strict whitelist.
+
+## Composition with Domain Skills
+
+Utility skills are stage-agnostic helpers that domain skills may invoke during orchestration.
+See `docs/schema/utility-skills.md` for the full specification.

--- a/backend/src/agent-skills/general/memory/intent.md
+++ b/backend/src/agent-skills/general/memory/intent.md
@@ -6,7 +6,7 @@ enName: Memory
 zhDescription: 在会话内管理上下文记忆，支持存储、检索和清除对话历史与中间状态。
 enDescription: Manage in-session context memory — store, retrieve, and clear conversation history and intermediate state.
 triggers: []
-stages: ["intent"]
+stages: ["intent", "draft", "analysis", "design"]
 autoLoadByDefault: false
 domain: general
 requires: []

--- a/backend/src/agent-skills/general/memory/intent.md
+++ b/backend/src/agent-skills/general/memory/intent.md
@@ -1,0 +1,37 @@
+---
+id: memory
+structureType: unknown
+zhName: 记忆
+enName: Memory
+zhDescription: 在会话内管理上下文记忆，支持存储、检索和清除对话历史与中间状态。
+enDescription: Manage in-session context memory — store, retrieve, and clear conversation history and intermediate state.
+triggers: []
+stages: ["intent"]
+autoLoadByDefault: false
+domain: general
+requires: []
+conflicts: []
+capabilities: ["context-store", "context-retrieve", "context-clear"]
+priority: 10
+skillCategory: utility
+safetyLevel: read-write-local
+sandboxRules: ["max_entries:200", "max_entry_size_bytes:8192", "session_scoped_only:true"]
+---
+
+## Purpose
+
+The memory skill provides structured context management within a single agent session.
+It allows the orchestrator and domain skills to persist intermediate values (e.g., extracted parameters, user preferences, partial model state) and retrieve them across multiple pipeline stages.
+
+## Capabilities
+
+- **context-store**: Write a key-value pair to session-scoped memory.
+- **context-retrieve**: Read a value by key from session-scoped memory.
+- **context-clear**: Remove one or all entries from session-scoped memory.
+
+## Boundaries
+
+- Memory is session-scoped: entries do not persist beyond the current conversation (30-minute TTL).
+- Maximum 200 entries per session; each entry capped at 8 KiB.
+- No cross-session access; no filesystem or database writes.
+- Memory contents are never sent to external services; they remain within the runtime process.

--- a/backend/src/agent-skills/general/planning/intent.md
+++ b/backend/src/agent-skills/general/planning/intent.md
@@ -1,0 +1,37 @@
+---
+id: planning
+structureType: unknown
+zhName: 规划
+enName: Planning
+zhDescription: 将复杂任务分解为有序子步骤，并对执行顺序和条件进行编排。
+enDescription: Decompose complex tasks into ordered sub-steps and orchestrate execution sequence and conditions.
+triggers: []
+stages: ["intent"]
+autoLoadByDefault: false
+domain: general
+requires: []
+conflicts: []
+capabilities: ["task-decompose", "step-sequence", "condition-gate"]
+priority: 10
+skillCategory: utility
+safetyLevel: read-only
+sandboxRules: ["no_side_effects:true", "max_plan_depth:10", "max_steps_per_plan:50"]
+---
+
+## Purpose
+
+The planning skill decomposes a high-level user goal into a sequence of executable sub-steps.
+It does not execute actions itself — it produces a plan object that the orchestrator consumes to drive tool calls.
+
+## Capabilities
+
+- **task-decompose**: Break a complex request into atomic sub-goals.
+- **step-sequence**: Order sub-steps respecting data dependencies and prerequisites.
+- **condition-gate**: Attach preconditions to steps (e.g., "run code-check only if analysis succeeded").
+
+## Boundaries
+
+- Planning is pure computation with no side effects.
+- Plans are advisory: the orchestrator may skip, reorder, or override steps.
+- Maximum plan depth: 10 levels of nesting; maximum 50 steps per plan.
+- Planning does not access the filesystem, network, or database.

--- a/backend/src/agent-skills/general/planning/intent.md
+++ b/backend/src/agent-skills/general/planning/intent.md
@@ -6,7 +6,7 @@ enName: Planning
 zhDescription: 将复杂任务分解为有序子步骤，并对执行顺序和条件进行编排。
 enDescription: Decompose complex tasks into ordered sub-steps and orchestrate execution sequence and conditions.
 triggers: []
-stages: ["intent"]
+stages: ["intent", "draft"]
 autoLoadByDefault: false
 domain: general
 requires: []

--- a/backend/src/agent-skills/general/read-file/intent.md
+++ b/backend/src/agent-skills/general/read-file/intent.md
@@ -6,7 +6,7 @@ enName: Read File
 zhDescription: 在沙箱范围内读取指定文件的内容，支持文本和结构化格式。
 enDescription: Read file contents within the sandbox scope, supporting text and structured formats.
 triggers: []
-stages: ["intent"]
+stages: ["intent", "draft", "analysis"]
 autoLoadByDefault: false
 domain: general
 requires: []

--- a/backend/src/agent-skills/general/read-file/intent.md
+++ b/backend/src/agent-skills/general/read-file/intent.md
@@ -1,0 +1,38 @@
+---
+id: read-file
+structureType: unknown
+zhName: 读文件
+enName: Read File
+zhDescription: 在沙箱范围内读取指定文件的内容，支持文本和结构化格式。
+enDescription: Read file contents within the sandbox scope, supporting text and structured formats.
+triggers: []
+stages: ["intent"]
+autoLoadByDefault: false
+domain: general
+requires: []
+conflicts: []
+capabilities: ["file-read-text", "file-read-json", "file-list-dir"]
+priority: 10
+skillCategory: utility
+safetyLevel: read-only
+sandboxRules: ["allowed_roots:.runtime/workspace,.runtime/uploads", "max_file_size_bytes:2097152", "deny_patterns:**/.env,**/*.key,**/*.pem,**/secrets/**"]
+---
+
+## Purpose
+
+The read-file skill provides controlled read access to workspace files.
+Domain skills and the orchestrator use it to load user-uploaded models, configuration files, or intermediate outputs produced by earlier pipeline stages.
+
+## Capabilities
+
+- **file-read-text**: Read a file as UTF-8 text.
+- **file-read-json**: Read and parse a JSON file, returning the parsed object.
+- **file-list-dir**: List entries in a directory (names and types only, no recursion by default).
+
+## Boundaries
+
+- Access is restricted to `.runtime/workspace/` and `.runtime/uploads/` directories.
+- Maximum file size: 2 MiB per read operation.
+- Denied patterns: `.env`, `*.key`, `*.pem`, `secrets/` — these are never readable.
+- No writes, no deletions, no permission changes.
+- Symbolic links are not followed.

--- a/backend/src/agent-skills/general/replace/intent.md
+++ b/backend/src/agent-skills/general/replace/intent.md
@@ -1,0 +1,37 @@
+---
+id: replace
+structureType: unknown
+zhName: 替换
+enName: Replace
+zhDescription: 在沙箱范围内对文件内容执行精确文本替换操作。
+enDescription: Perform exact text replacement operations on file contents within the sandbox scope.
+triggers: []
+stages: ["intent"]
+autoLoadByDefault: false
+domain: general
+requires: ["read-file", "write-file"]
+conflicts: []
+capabilities: ["text-replace", "json-patch"]
+priority: 10
+skillCategory: utility
+safetyLevel: read-write-local
+sandboxRules: ["allowed_roots:.runtime/workspace", "max_file_size_bytes:2097152", "max_replacements_per_call:50", "deny_patterns:**/.env,**/*.key,**/*.pem,**/secrets/**"]
+---
+
+## Purpose
+
+The replace skill provides targeted content modification for workspace files.
+It combines read-file and write-file capabilities into an atomic read-modify-write operation, ensuring the file is not left in an inconsistent state.
+
+## Capabilities
+
+- **text-replace**: Find and replace exact text occurrences in a file.
+- **json-patch**: Apply a JSON merge-patch (RFC 7396) to a JSON file.
+
+## Boundaries
+
+- Inherits the same sandbox restrictions as read-file and write-file.
+- Maximum 50 replacement operations per call.
+- All replacements are exact-match (no regex) to avoid unintended mutations.
+- The original file is read, modified in memory, and written back atomically.
+- Requires both `read-file` and `write-file` skills to be loaded.

--- a/backend/src/agent-skills/general/replace/intent.md
+++ b/backend/src/agent-skills/general/replace/intent.md
@@ -6,7 +6,7 @@ enName: Replace
 zhDescription: 在沙箱范围内对文件内容执行精确文本替换操作。
 enDescription: Perform exact text replacement operations on file contents within the sandbox scope.
 triggers: []
-stages: ["intent"]
+stages: ["draft", "analysis"]
 autoLoadByDefault: false
 domain: general
 requires: ["read-file", "write-file"]

--- a/backend/src/agent-skills/general/shell/intent.md
+++ b/backend/src/agent-skills/general/shell/intent.md
@@ -1,0 +1,38 @@
+---
+id: shell
+structureType: unknown
+zhName: 命令执行
+enName: Shell
+zhDescription: 在受控沙箱中执行预审批的命令行操作，支持结构分析引擎调用等场景。
+enDescription: Execute pre-approved command-line operations in a controlled sandbox, supporting scenarios such as analysis engine invocation.
+triggers: []
+stages: ["intent"]
+autoLoadByDefault: false
+domain: general
+requires: []
+conflicts: []
+capabilities: ["shell-exec"]
+priority: 10
+skillCategory: utility
+safetyLevel: restricted-exec
+sandboxRules: ["allowed_commands:python,python3,opensees,OpenSees", "allowed_cwd:.runtime/workspace", "max_timeout_ms:300000", "deny_commands:rm,del,format,mkfs,sudo,su,chmod,chown,curl,wget,ssh,nc,ncat", "deny_args:--recursive,--force,-rf", "max_output_bytes:1048576"]
+---
+
+## Purpose
+
+The shell skill provides controlled command execution for scenarios that require external process invocation — primarily analysis engine runs (OpenSees, Python scripts) and post-processing tools.
+
+## Capabilities
+
+- **shell-exec**: Run a single command with arguments, capture stdout/stderr, and return the exit code.
+
+## Boundaries
+
+- **Allowed commands (whitelist)**: `python`, `python3`, `opensees`, `OpenSees` only.
+- **Working directory**: Locked to `.runtime/workspace/`.
+- **Timeout**: Maximum 300 seconds (5 minutes) per execution.
+- **Denied commands (blocklist)**: `rm`, `del`, `format`, `mkfs`, `sudo`, `su`, `chmod`, `chown`, `curl`, `wget`, `ssh`, `nc`, `ncat` — blocked unconditionally.
+- **Denied arguments**: `--recursive`, `--force`, `-rf` — blocked to prevent destructive operations.
+- **Output capture**: Maximum 1 MiB of combined stdout + stderr.
+- No background processes; no shell pipes or redirections; no environment variable injection.
+- Process runs with the same user as the backend service (no privilege escalation).

--- a/backend/src/agent-skills/general/shell/intent.md
+++ b/backend/src/agent-skills/general/shell/intent.md
@@ -6,7 +6,7 @@ enName: Shell
 zhDescription: 在受控沙箱中执行预审批的命令行操作，支持结构分析引擎调用等场景。
 enDescription: Execute pre-approved command-line operations in a controlled sandbox, supporting scenarios such as analysis engine invocation.
 triggers: []
-stages: ["intent"]
+stages: ["analysis"]
 autoLoadByDefault: false
 domain: general
 requires: []
@@ -15,7 +15,7 @@ capabilities: ["shell-exec"]
 priority: 10
 skillCategory: utility
 safetyLevel: restricted-exec
-sandboxRules: ["allowed_commands:python,python3,opensees,OpenSees", "allowed_cwd:.runtime/workspace", "max_timeout_ms:300000", "deny_commands:rm,del,format,mkfs,sudo,su,chmod,chown,curl,wget,ssh,nc,ncat", "deny_args:--recursive,--force,-rf", "max_output_bytes:1048576"]
+sandboxRules: ["allowed_commands:python,python3,opensees,OpenSees", "allowed_cwd:.runtime/workspace", "max_timeout_ms:300000", "deny_commands:rm,del,mv,cp,ln,format,mkfs,sudo,su,chmod,chown,curl,wget,ssh,nc,ncat", "deny_args:--recursive,--force,-rf", "max_output_bytes:1048576"]
 ---
 
 ## Purpose
@@ -31,7 +31,7 @@ The shell skill provides controlled command execution for scenarios that require
 - **Allowed commands (whitelist)**: `python`, `python3`, `opensees`, `OpenSees` only.
 - **Working directory**: Locked to `.runtime/workspace/`.
 - **Timeout**: Maximum 300 seconds (5 minutes) per execution.
-- **Denied commands (blocklist)**: `rm`, `del`, `format`, `mkfs`, `sudo`, `su`, `chmod`, `chown`, `curl`, `wget`, `ssh`, `nc`, `ncat` — blocked unconditionally.
+- **Denied commands (blocklist)**: `rm`, `del`, `mv`, `cp`, `ln`, `format`, `mkfs`, `sudo`, `su`, `chmod`, `chown`, `curl`, `wget`, `ssh`, `nc`, `ncat` — blocked unconditionally.
 - **Denied arguments**: `--recursive`, `--force`, `-rf` — blocked to prevent destructive operations.
 - **Output capture**: Maximum 1 MiB of combined stdout + stderr.
 - No background processes; no shell pipes or redirections; no environment variable injection.

--- a/backend/src/agent-skills/general/utility-skill-definitions.ts
+++ b/backend/src/agent-skills/general/utility-skill-definitions.ts
@@ -1,0 +1,184 @@
+/**
+ * Utility skill type definitions, safety boundary constants,
+ * and composition helpers for general-purpose (non-domain) skills.
+ */
+
+// ---------------------------------------------------------------------------
+// Safety levels
+// ---------------------------------------------------------------------------
+
+/**
+ * Safety classification for utility skills.
+ * Each level defines a boundary on what the skill is allowed to do.
+ */
+export type UtilitySkillSafetyLevel =
+  | 'read-only'          // No writes, no side effects
+  | 'read-write-local'   // Writes to session-scoped or sandbox-scoped storage
+  | 'restricted-exec';   // External process execution within whitelist
+
+// ---------------------------------------------------------------------------
+// Sandbox rule definitions
+// ---------------------------------------------------------------------------
+
+export interface FileSandboxRules {
+  /** Allowed root directories relative to project root. */
+  allowedRoots: string[];
+  /** Glob patterns that are always denied. */
+  denyPatterns: string[];
+  /** Maximum file size in bytes for a single operation. */
+  maxFileSizeBytes: number;
+}
+
+export interface ShellSandboxRules {
+  /** Whitelisted executable names (basename only, no paths). */
+  allowedCommands: string[];
+  /** Blocked commands (unconditional deny). */
+  denyCommands: string[];
+  /** Blocked argument patterns. */
+  denyArgs: string[];
+  /** Working directory (relative to project root). */
+  allowedCwd: string;
+  /** Maximum execution time in milliseconds. */
+  maxTimeoutMs: number;
+  /** Maximum combined stdout + stderr in bytes. */
+  maxOutputBytes: number;
+}
+
+export interface MemorySandboxRules {
+  /** Maximum entries per session. */
+  maxEntries: number;
+  /** Maximum size per entry in bytes. */
+  maxEntrySizeBytes: number;
+  /** Whether entries are session-scoped only. */
+  sessionScopedOnly: boolean;
+}
+
+export interface PlanningSandboxRules {
+  /** Whether the skill may have side effects. */
+  noSideEffects: boolean;
+  /** Maximum nesting depth of a plan. */
+  maxPlanDepth: number;
+  /** Maximum steps in a single plan. */
+  maxStepsPerPlan: number;
+}
+
+// ---------------------------------------------------------------------------
+// Default sandbox configurations
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_FILE_SANDBOX: FileSandboxRules = {
+  allowedRoots: ['.runtime/workspace', '.runtime/uploads'],
+  denyPatterns: ['**/.env', '**/*.key', '**/*.pem', '**/secrets/**'],
+  maxFileSizeBytes: 2 * 1024 * 1024, // 2 MiB
+};
+
+export const DEFAULT_WRITE_FILE_SANDBOX: FileSandboxRules = {
+  allowedRoots: ['.runtime/workspace'],
+  denyPatterns: ['**/.env', '**/*.key', '**/*.pem', '**/secrets/**'],
+  maxFileSizeBytes: 2 * 1024 * 1024,
+};
+
+export const DEFAULT_SHELL_SANDBOX: ShellSandboxRules = {
+  allowedCommands: ['python', 'python3', 'opensees', 'OpenSees'],
+  denyCommands: ['rm', 'del', 'format', 'mkfs', 'sudo', 'su', 'chmod', 'chown', 'curl', 'wget', 'ssh', 'nc', 'ncat'],
+  denyArgs: ['--recursive', '--force', '-rf'],
+  allowedCwd: '.runtime/workspace',
+  maxTimeoutMs: 300_000, // 5 minutes
+  maxOutputBytes: 1024 * 1024, // 1 MiB
+};
+
+export const DEFAULT_MEMORY_SANDBOX: MemorySandboxRules = {
+  maxEntries: 200,
+  maxEntrySizeBytes: 8192,
+  sessionScopedOnly: true,
+};
+
+export const DEFAULT_PLANNING_SANDBOX: PlanningSandboxRules = {
+  noSideEffects: true,
+  maxPlanDepth: 10,
+  maxStepsPerPlan: 50,
+};
+
+// ---------------------------------------------------------------------------
+// Utility skill descriptor
+// ---------------------------------------------------------------------------
+
+export interface UtilitySkillDescriptor {
+  id: string;
+  safetyLevel: UtilitySkillSafetyLevel;
+  capabilities: string[];
+  requires: string[];
+  /** Pipeline stages where this skill may be invoked. */
+  reusableInStages: string[];
+}
+
+/**
+ * Registry of all utility skills, their safety levels, dependencies,
+ * and the pipeline stages where they can be reused.
+ */
+export const UTILITY_SKILL_DESCRIPTORS: UtilitySkillDescriptor[] = [
+  {
+    id: 'memory',
+    safetyLevel: 'read-write-local',
+    capabilities: ['context-store', 'context-retrieve', 'context-clear'],
+    requires: [],
+    reusableInStages: ['intent', 'draft', 'analysis', 'design', 'report'],
+  },
+  {
+    id: 'planning',
+    safetyLevel: 'read-only',
+    capabilities: ['task-decompose', 'step-sequence', 'condition-gate'],
+    requires: [],
+    reusableInStages: ['intent', 'draft'],
+  },
+  {
+    id: 'read-file',
+    safetyLevel: 'read-only',
+    capabilities: ['file-read-text', 'file-read-json', 'file-list-dir'],
+    requires: [],
+    reusableInStages: ['intent', 'draft', 'analysis', 'report'],
+  },
+  {
+    id: 'write-file',
+    safetyLevel: 'read-write-local',
+    capabilities: ['file-write-text', 'file-write-json'],
+    requires: [],
+    reusableInStages: ['analysis', 'report'],
+  },
+  {
+    id: 'replace',
+    safetyLevel: 'read-write-local',
+    capabilities: ['text-replace', 'json-patch'],
+    requires: ['read-file', 'write-file'],
+    reusableInStages: ['draft', 'analysis'],
+  },
+  {
+    id: 'shell',
+    safetyLevel: 'restricted-exec',
+    capabilities: ['shell-exec'],
+    requires: [],
+    reusableInStages: ['analysis'],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Composition helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when a utility skill is allowed in the given pipeline stage.
+ */
+export function isUtilitySkillAllowedInStage(skillId: string, stage: string): boolean {
+  const descriptor = UTILITY_SKILL_DESCRIPTORS.find((d) => d.id === skillId);
+  if (!descriptor) {
+    return false;
+  }
+  return descriptor.reusableInStages.includes(stage);
+}
+
+/**
+ * Returns the list of utility skills that may be invoked during a given stage.
+ */
+export function listUtilitySkillsForStage(stage: string): UtilitySkillDescriptor[] {
+  return UTILITY_SKILL_DESCRIPTORS.filter((d) => d.reusableInStages.includes(stage));
+}

--- a/backend/src/agent-skills/general/utility-skill-definitions.ts
+++ b/backend/src/agent-skills/general/utility-skill-definitions.ts
@@ -3,6 +3,8 @@
  * and composition helpers for general-purpose (non-domain) skills.
  */
 
+import type { SkillStage } from '../../agent-runtime/types.js';
+
 // ---------------------------------------------------------------------------
 // Safety levels
 // ---------------------------------------------------------------------------
@@ -80,7 +82,7 @@ export const DEFAULT_WRITE_FILE_SANDBOX: FileSandboxRules = {
 
 export const DEFAULT_SHELL_SANDBOX: ShellSandboxRules = {
   allowedCommands: ['python', 'python3', 'opensees', 'OpenSees'],
-  denyCommands: ['rm', 'del', 'format', 'mkfs', 'sudo', 'su', 'chmod', 'chown', 'curl', 'wget', 'ssh', 'nc', 'ncat'],
+  denyCommands: ['rm', 'del', 'mv', 'cp', 'ln', 'format', 'mkfs', 'sudo', 'su', 'chmod', 'chown', 'curl', 'wget', 'ssh', 'nc', 'ncat'],
   denyArgs: ['--recursive', '--force', '-rf'],
   allowedCwd: '.runtime/workspace',
   maxTimeoutMs: 300_000, // 5 minutes
@@ -109,7 +111,7 @@ export interface UtilitySkillDescriptor {
   capabilities: string[];
   requires: string[];
   /** Pipeline stages where this skill may be invoked. */
-  reusableInStages: string[];
+  reusableInStages: SkillStage[];
 }
 
 /**
@@ -122,7 +124,7 @@ export const UTILITY_SKILL_DESCRIPTORS: UtilitySkillDescriptor[] = [
     safetyLevel: 'read-write-local',
     capabilities: ['context-store', 'context-retrieve', 'context-clear'],
     requires: [],
-    reusableInStages: ['intent', 'draft', 'analysis', 'design', 'report'],
+    reusableInStages: ['intent', 'draft', 'analysis', 'design'],
   },
   {
     id: 'planning',
@@ -136,14 +138,14 @@ export const UTILITY_SKILL_DESCRIPTORS: UtilitySkillDescriptor[] = [
     safetyLevel: 'read-only',
     capabilities: ['file-read-text', 'file-read-json', 'file-list-dir'],
     requires: [],
-    reusableInStages: ['intent', 'draft', 'analysis', 'report'],
+    reusableInStages: ['intent', 'draft', 'analysis'],
   },
   {
     id: 'write-file',
     safetyLevel: 'read-write-local',
     capabilities: ['file-write-text', 'file-write-json'],
     requires: [],
-    reusableInStages: ['analysis', 'report'],
+    reusableInStages: ['analysis'],
   },
   {
     id: 'replace',
@@ -168,7 +170,7 @@ export const UTILITY_SKILL_DESCRIPTORS: UtilitySkillDescriptor[] = [
 /**
  * Returns true when a utility skill is allowed in the given pipeline stage.
  */
-export function isUtilitySkillAllowedInStage(skillId: string, stage: string): boolean {
+export function isUtilitySkillAllowedInStage(skillId: string, stage: SkillStage): boolean {
   const descriptor = UTILITY_SKILL_DESCRIPTORS.find((d) => d.id === skillId);
   if (!descriptor) {
     return false;
@@ -179,6 +181,6 @@ export function isUtilitySkillAllowedInStage(skillId: string, stage: string): bo
 /**
  * Returns the list of utility skills that may be invoked during a given stage.
  */
-export function listUtilitySkillsForStage(stage: string): UtilitySkillDescriptor[] {
+export function listUtilitySkillsForStage(stage: SkillStage): UtilitySkillDescriptor[] {
   return UTILITY_SKILL_DESCRIPTORS.filter((d) => d.reusableInStages.includes(stage));
 }

--- a/backend/src/agent-skills/general/write-file/intent.md
+++ b/backend/src/agent-skills/general/write-file/intent.md
@@ -1,0 +1,37 @@
+---
+id: write-file
+structureType: unknown
+zhName: 写文件
+enName: Write File
+zhDescription: 在沙箱范围内创建或覆写指定文件，支持文本和 JSON 输出。
+enDescription: Create or overwrite files within the sandbox scope, supporting text and JSON output.
+triggers: []
+stages: ["intent"]
+autoLoadByDefault: false
+domain: general
+requires: []
+conflicts: []
+capabilities: ["file-write-text", "file-write-json"]
+priority: 10
+skillCategory: utility
+safetyLevel: read-write-local
+sandboxRules: ["allowed_roots:.runtime/workspace", "max_file_size_bytes:2097152", "max_files_per_call:10", "deny_patterns:**/.env,**/*.key,**/*.pem,**/secrets/**"]
+---
+
+## Purpose
+
+The write-file skill provides controlled write access to workspace files.
+It is used to persist pipeline outputs such as converted models, analysis results, or exported reports to disk.
+
+## Capabilities
+
+- **file-write-text**: Write a UTF-8 string to a file (create or overwrite).
+- **file-write-json**: Serialize an object to JSON and write to a file.
+
+## Boundaries
+
+- Write access is restricted to `.runtime/workspace/` only (uploads directory is read-only).
+- Maximum file size: 2 MiB per write operation; maximum 10 files per call.
+- Denied patterns: `.env`, `*.key`, `*.pem`, `secrets/` — these paths are never writable.
+- Cannot delete files, create symbolic links, or change permissions.
+- Parent directories are created automatically if they do not exist.

--- a/backend/src/agent-skills/general/write-file/intent.md
+++ b/backend/src/agent-skills/general/write-file/intent.md
@@ -6,7 +6,7 @@ enName: Write File
 zhDescription: 在沙箱范围内创建或覆写指定文件，支持文本和 JSON 输出。
 enDescription: Create or overwrite files within the sandbox scope, supporting text and JSON output.
 triggers: []
-stages: ["intent"]
+stages: ["analysis"]
 autoLoadByDefault: false
 domain: general
 requires: []

--- a/backend/tests/utility-skill-definitions.test.mjs
+++ b/backend/tests/utility-skill-definitions.test.mjs
@@ -1,0 +1,146 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  UTILITY_SKILL_DESCRIPTORS,
+  DEFAULT_FILE_SANDBOX,
+  DEFAULT_WRITE_FILE_SANDBOX,
+  DEFAULT_SHELL_SANDBOX,
+  DEFAULT_MEMORY_SANDBOX,
+  DEFAULT_PLANNING_SANDBOX,
+  isUtilitySkillAllowedInStage,
+  listUtilitySkillsForStage,
+} from '../dist/agent-skills/general/utility-skill-definitions.js';
+
+describe('utility skill definitions', () => {
+  const EXPECTED_SKILL_IDS = ['memory', 'planning', 'read-file', 'write-file', 'replace', 'shell'];
+
+  test('should define all six baseline utility skills', () => {
+    const ids = UTILITY_SKILL_DESCRIPTORS.map((d) => d.id);
+    expect(ids).toEqual(EXPECTED_SKILL_IDS);
+  });
+
+  test('every descriptor must have id, safetyLevel, capabilities, requires, and reusableInStages', () => {
+    for (const descriptor of UTILITY_SKILL_DESCRIPTORS) {
+      expect(typeof descriptor.id).toBe('string');
+      expect(descriptor.id.length).toBeGreaterThan(0);
+      expect(['read-only', 'read-write-local', 'restricted-exec']).toContain(descriptor.safetyLevel);
+      expect(Array.isArray(descriptor.capabilities)).toBe(true);
+      expect(descriptor.capabilities.length).toBeGreaterThan(0);
+      expect(Array.isArray(descriptor.requires)).toBe(true);
+      expect(Array.isArray(descriptor.reusableInStages)).toBe(true);
+      expect(descriptor.reusableInStages.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('no duplicate skill IDs', () => {
+    const ids = UTILITY_SKILL_DESCRIPTORS.map((d) => d.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test('replace skill must depend on read-file and write-file', () => {
+    const replace = UTILITY_SKILL_DESCRIPTORS.find((d) => d.id === 'replace');
+    expect(replace).toBeDefined();
+    expect(replace.requires).toContain('read-file');
+    expect(replace.requires).toContain('write-file');
+  });
+
+  test('shell skill must be restricted-exec', () => {
+    const shell = UTILITY_SKILL_DESCRIPTORS.find((d) => d.id === 'shell');
+    expect(shell).toBeDefined();
+    expect(shell.safetyLevel).toBe('restricted-exec');
+  });
+
+  test('read-only skills must not have write capabilities', () => {
+    const readOnlySkills = UTILITY_SKILL_DESCRIPTORS.filter((d) => d.safetyLevel === 'read-only');
+    for (const skill of readOnlySkills) {
+      for (const cap of skill.capabilities) {
+        expect(cap).not.toMatch(/write|store|clear|exec|replace|patch/);
+      }
+    }
+  });
+});
+
+describe('sandbox default constants', () => {
+  test('DEFAULT_FILE_SANDBOX allows workspace and uploads', () => {
+    expect(DEFAULT_FILE_SANDBOX.allowedRoots).toContain('.runtime/workspace');
+    expect(DEFAULT_FILE_SANDBOX.allowedRoots).toContain('.runtime/uploads');
+    expect(DEFAULT_FILE_SANDBOX.denyPatterns.length).toBeGreaterThan(0);
+    expect(DEFAULT_FILE_SANDBOX.maxFileSizeBytes).toBe(2 * 1024 * 1024);
+  });
+
+  test('DEFAULT_WRITE_FILE_SANDBOX allows only workspace', () => {
+    expect(DEFAULT_WRITE_FILE_SANDBOX.allowedRoots).toEqual(['.runtime/workspace']);
+    expect(DEFAULT_WRITE_FILE_SANDBOX.allowedRoots).not.toContain('.runtime/uploads');
+  });
+
+  test('DEFAULT_SHELL_SANDBOX blocks dangerous commands', () => {
+    for (const cmd of ['rm', 'del', 'sudo', 'curl', 'wget', 'ssh']) {
+      expect(DEFAULT_SHELL_SANDBOX.denyCommands).toContain(cmd);
+    }
+    expect(DEFAULT_SHELL_SANDBOX.allowedCwd).toBe('.runtime/workspace');
+    expect(DEFAULT_SHELL_SANDBOX.maxTimeoutMs).toBe(300_000);
+  });
+
+  test('DEFAULT_MEMORY_SANDBOX is session-scoped', () => {
+    expect(DEFAULT_MEMORY_SANDBOX.sessionScopedOnly).toBe(true);
+    expect(DEFAULT_MEMORY_SANDBOX.maxEntries).toBe(200);
+    expect(DEFAULT_MEMORY_SANDBOX.maxEntrySizeBytes).toBe(8192);
+  });
+
+  test('DEFAULT_PLANNING_SANDBOX has no side effects', () => {
+    expect(DEFAULT_PLANNING_SANDBOX.noSideEffects).toBe(true);
+    expect(DEFAULT_PLANNING_SANDBOX.maxPlanDepth).toBe(10);
+    expect(DEFAULT_PLANNING_SANDBOX.maxStepsPerPlan).toBe(50);
+  });
+});
+
+describe('isUtilitySkillAllowedInStage', () => {
+  test('memory is allowed in all stages', () => {
+    for (const stage of ['intent', 'draft', 'analysis', 'design', 'report']) {
+      expect(isUtilitySkillAllowedInStage('memory', stage)).toBe(true);
+    }
+  });
+
+  test('shell is only allowed in analysis', () => {
+    expect(isUtilitySkillAllowedInStage('shell', 'analysis')).toBe(true);
+    expect(isUtilitySkillAllowedInStage('shell', 'intent')).toBe(false);
+    expect(isUtilitySkillAllowedInStage('shell', 'draft')).toBe(false);
+    expect(isUtilitySkillAllowedInStage('shell', 'design')).toBe(false);
+    expect(isUtilitySkillAllowedInStage('shell', 'report')).toBe(false);
+  });
+
+  test('returns false for unknown skill IDs', () => {
+    expect(isUtilitySkillAllowedInStage('nonexistent', 'intent')).toBe(false);
+  });
+
+  test('returns false for unknown stage names', () => {
+    expect(isUtilitySkillAllowedInStage('memory', 'nonexistent-stage')).toBe(false);
+  });
+});
+
+describe('listUtilitySkillsForStage', () => {
+  test('intent stage includes memory, planning, read-file', () => {
+    const skills = listUtilitySkillsForStage('intent');
+    const ids = skills.map((s) => s.id);
+    expect(ids).toContain('memory');
+    expect(ids).toContain('planning');
+    expect(ids).toContain('read-file');
+    expect(ids).not.toContain('write-file');
+    expect(ids).not.toContain('shell');
+  });
+
+  test('analysis stage includes memory, read-file, write-file, replace, shell', () => {
+    const skills = listUtilitySkillsForStage('analysis');
+    const ids = skills.map((s) => s.id);
+    expect(ids).toContain('memory');
+    expect(ids).toContain('read-file');
+    expect(ids).toContain('write-file');
+    expect(ids).toContain('replace');
+    expect(ids).toContain('shell');
+    expect(ids).not.toContain('planning');
+  });
+
+  test('returns empty for unknown stage', () => {
+    const skills = listUtilitySkillsForStage('nonexistent-stage');
+    expect(skills).toEqual([]);
+  });
+});

--- a/backend/tests/utility-skill-definitions.test.mjs
+++ b/backend/tests/utility-skill-definitions.test.mjs
@@ -57,6 +57,14 @@ describe('utility skill definitions', () => {
       }
     }
   });
+  test('reusableInStages only contains valid SkillStage values', () => {
+    const validStages = ['intent', 'draft', 'analysis', 'design'];
+    for (const descriptor of UTILITY_SKILL_DESCRIPTORS) {
+      for (const stage of descriptor.reusableInStages) {
+        expect(validStages).toContain(stage);
+      }
+    }
+  });
 });
 
 describe('sandbox default constants', () => {
@@ -73,7 +81,7 @@ describe('sandbox default constants', () => {
   });
 
   test('DEFAULT_SHELL_SANDBOX blocks dangerous commands', () => {
-    for (const cmd of ['rm', 'del', 'sudo', 'curl', 'wget', 'ssh']) {
+    for (const cmd of ['rm', 'del', 'mv', 'cp', 'ln', 'sudo', 'curl', 'wget', 'ssh']) {
       expect(DEFAULT_SHELL_SANDBOX.denyCommands).toContain(cmd);
     }
     expect(DEFAULT_SHELL_SANDBOX.allowedCwd).toBe('.runtime/workspace');
@@ -95,7 +103,7 @@ describe('sandbox default constants', () => {
 
 describe('isUtilitySkillAllowedInStage', () => {
   test('memory is allowed in all stages', () => {
-    for (const stage of ['intent', 'draft', 'analysis', 'design', 'report']) {
+    for (const stage of ['intent', 'draft', 'analysis', 'design']) {
       expect(isUtilitySkillAllowedInStage('memory', stage)).toBe(true);
     }
   });
@@ -105,7 +113,6 @@ describe('isUtilitySkillAllowedInStage', () => {
     expect(isUtilitySkillAllowedInStage('shell', 'intent')).toBe(false);
     expect(isUtilitySkillAllowedInStage('shell', 'draft')).toBe(false);
     expect(isUtilitySkillAllowedInStage('shell', 'design')).toBe(false);
-    expect(isUtilitySkillAllowedInStage('shell', 'report')).toBe(false);
   });
 
   test('returns false for unknown skill IDs', () => {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -164,3 +164,5 @@ Regression entrypoints:
 - Chinese protocol reference: `docs/reference_CN.md`
 - Skill loading mechanism: `docs/schema/skill-loading.md`
 - Skill loading mechanism (Chinese): `docs/schema/skill-loading_CN.md`
+- Utility skill definitions: `docs/schema/utility-skills.md`
+- Utility skill definitions (Chinese): `docs/schema/utility-skills_CN.md`

--- a/docs/reference_CN.md
+++ b/docs/reference_CN.md
@@ -164,3 +164,5 @@ Chat 与消息：
 - 英文协议参考：`docs/reference.md`
 - 技能加载机制：`docs/schema/skill-loading_CN.md`
 - 技能加载机制（英文）：`docs/schema/skill-loading.md`
+- 通用工具技能定义：`docs/schema/utility-skills_CN.md`
+- 通用工具技能定义（英文）：`docs/schema/utility-skills.md`

--- a/docs/schema/utility-skills.md
+++ b/docs/schema/utility-skills.md
@@ -1,0 +1,162 @@
+# Utility Skill Definitions
+
+## 1. Overview
+
+Utility skills are general-purpose, domain-agnostic helpers that support the agent's orchestration pipeline. Unlike domain skills (structure-type, analysis, code-check, etc.), utility skills do not participate in domain-specific routing; instead, they provide foundational capabilities such as memory, planning, file I/O, content replacement, and shell execution.
+
+All utility skills live under `backend/src/agent-skills/general/`. Each skill has an `intent.md` declaring its metadata, safety level, and capability boundaries, following the same front-matter convention used by analysis and structure-type skills.
+
+Type definitions, sandbox defaults, and composition helpers are centralized in `backend/src/agent-skills/general/utility-skill-definitions.ts`.
+
+## 2. Baseline Skill Set
+
+| Skill ID | Safety Level | Capabilities | Dependencies |
+|----------|-------------|-------------|-------------|
+| `memory` | read-write-local | context-store, context-retrieve, context-clear | — |
+| `planning` | read-only | task-decompose, step-sequence, condition-gate | — |
+| `read-file` | read-only | file-read-text, file-read-json, file-list-dir | — |
+| `write-file` | read-write-local | file-write-text, file-write-json | — |
+| `replace` | read-write-local | text-replace, json-patch | read-file, write-file |
+| `shell` | restricted-exec | shell-exec | — |
+
+### 2.1 memory
+
+Stores, retrieves, and clears key-value context entries scoped to a single agent session. Useful for carrying intermediate results between pipeline stages.
+
+- **Session-scoped only**: entries do not persist beyond the current session.
+- **Limits**: ≤ 200 entries, ≤ 8 KiB per entry.
+
+### 2.2 planning
+
+Decomposes user intent into ordered step sequences and conditional gates. Read-only — no side effects, no writes.
+
+- **Maximum depth**: 10 levels of nested sub-plans.
+- **Maximum steps**: 50 steps per plan.
+
+### 2.3 read-file
+
+Reads text and JSON files or lists directories within the sandboxed workspace.
+
+- **Allowed roots**: `.runtime/workspace`, `.runtime/uploads`.
+- **Denied patterns**: `.env`, `*.key`, `*.pem`, `secrets/**`.
+- **Max file size**: 2 MiB per read.
+
+### 2.4 write-file
+
+Writes text or JSON files into the sandboxed workspace.
+
+- **Allowed root**: `.runtime/workspace` only (no uploads).
+- **Denied patterns**: same as read-file.
+- **Max file size**: 2 MiB per write.
+- **Max files per call**: 10.
+
+### 2.5 replace
+
+Performs text replacements or JSON patches on existing files. Depends on read-file and write-file for the underlying I/O.
+
+- **Max replacements per call**: 50.
+- **Match mode**: exact match only (no regex).
+
+### 2.6 shell
+
+Executes external commands in a restricted sandbox. Designed for structural analysis engine invocations.
+
+- **Whitelisted commands**: `python`, `python3`, `opensees`, `OpenSees`.
+- **Blocked commands**: `rm`, `del`, `format`, `mkfs`, `sudo`, `su`, `chmod`, `chown`, `curl`, `wget`, `ssh`, `nc`, `ncat`.
+- **Blocked arguments**: `--recursive`, `--force`, `-rf`.
+- **Working directory**: locked to `.runtime/workspace`.
+- **Timeout**: 5 minutes.
+- **Output cap**: 1 MiB combined stdout + stderr.
+
+## 3. Safety Boundaries
+
+### 3.1 Safety Levels
+
+Utility skills are classified into three safety levels:
+
+| Level | Description | Allowed Operations |
+|-------|------------|-------------------|
+| `read-only` | No writes, no side effects | Read files, list directories, decompose plans |
+| `read-write-local` | Writes to session or sandbox storage | Write files, store/clear memory entries |
+| `restricted-exec` | External process execution | Invoke whitelisted executables only |
+
+Safety level escalation is not permitted. A `read-only` skill cannot acquire write capabilities at runtime.
+
+### 3.2 Sandbox Rules
+
+Each skill type has a corresponding sandbox rule interface and a set of compiled defaults:
+
+| Sandbox | Interface | Default Constant |
+|---------|-----------|-----------------|
+| File read | `FileSandboxRules` | `DEFAULT_FILE_SANDBOX` |
+| File write | `FileSandboxRules` | `DEFAULT_WRITE_FILE_SANDBOX` |
+| Shell execution | `ShellSandboxRules` | `DEFAULT_SHELL_SANDBOX` |
+| Memory | `MemorySandboxRules` | `DEFAULT_MEMORY_SANDBOX` |
+| Planning | `PlanningSandboxRules` | `DEFAULT_PLANNING_SANDBOX` |
+
+**Invariant**: sandbox defaults may be tightened in future releases but must never be loosened without a corresponding security review.
+
+### 3.3 Enforcement Points
+
+Sandbox rules are enforced at the skill invocation boundary, before the skill handler executes. Violations are rejected with structured error payloads containing the skill ID, attempted operation, and violated rule.
+
+## 4. Composition with Domain Skills
+
+### 4.1 Stage-Based Reusability
+
+Utility skills are available in specific pipeline stages. They are invoked by domain skills or by the orchestrator, not by the user directly.
+
+The pipeline stages referenced in the composition model:
+
+| Stage | Description |
+|-------|------------|
+| `intent` | User intent parsing and disambiguation |
+| `draft` | Initial structural model generation |
+| `analysis` | Engine-based structural analysis |
+| `design` | Design optimization and detailing |
+| `report` | Report generation and export |
+
+### 4.2 Stage Mapping
+
+| Skill | intent | draft | analysis | design | report |
+|-------|--------|-------|----------|--------|--------|
+| memory | ✓ | ✓ | ✓ | ✓ | ✓ |
+| planning | ✓ | ✓ | — | — | — |
+| read-file | ✓ | ✓ | ✓ | — | ✓ |
+| write-file | — | — | ✓ | — | ✓ |
+| replace | — | ✓ | ✓ | — | — |
+| shell | — | — | ✓ | — | — |
+
+Key observations:
+
+- **memory** is the only skill available across all stages, since context carriage is universally needed.
+- **planning** is restricted to early stages (intent, draft) where decomposition matters.
+- **shell** is restricted to the analysis stage, since only analysis engines require external process execution.
+- **write-file** and **replace** are excluded from intent and design to prevent unintended side effects.
+
+### 4.3 Composition Helpers
+
+Two helper functions are exported from `utility-skill-definitions.ts`:
+
+```typescript
+// Check if a specific utility skill is allowed in a given stage
+isUtilitySkillAllowedInStage(skillId: string, stage: string): boolean
+
+// List all utility skills available at a given stage
+listUtilitySkillsForStage(stage: string): UtilitySkillDescriptor[]
+```
+
+Domain skills and the orchestrator use these helpers to determine which utility skills are available before invoking them.
+
+### 4.4 Dependency Resolution
+
+The standard `requires` / `conflicts` mechanism from `SkillPackageMetadata` applies to utility skills as well.
+
+Currently, only `replace` declares dependencies (`requires: ['read-file', 'write-file']`). If either dependency is missing or disabled, the replace skill cannot load.
+
+## 5. Related Docs
+
+- Skill loading mechanism: `docs/schema/skill-loading.md`
+- Skill loading mechanism (Chinese): `docs/schema/skill-loading_CN.md`
+- Utility skills (Chinese): `docs/schema/utility-skills_CN.md`
+- Protocol reference: `docs/reference.md`

--- a/docs/schema/utility-skills.md
+++ b/docs/schema/utility-skills.md
@@ -62,7 +62,7 @@ Performs text replacements or JSON patches on existing files. Depends on read-fi
 Executes external commands in a restricted sandbox. Designed for structural analysis engine invocations.
 
 - **Whitelisted commands**: `python`, `python3`, `opensees`, `OpenSees`.
-- **Blocked commands**: `rm`, `del`, `format`, `mkfs`, `sudo`, `su`, `chmod`, `chown`, `curl`, `wget`, `ssh`, `nc`, `ncat`.
+- **Blocked commands**: `rm`, `del`, `mv`, `cp`, `ln`, `format`, `mkfs`, `sudo`, `su`, `chmod`, `chown`, `curl`, `wget`, `ssh`, `nc`, `ncat`.
 - **Blocked arguments**: `--recursive`, `--force`, `-rf`.
 - **Working directory**: locked to `.runtime/workspace`.
 - **Timeout**: 5 minutes.
@@ -114,25 +114,24 @@ The pipeline stages referenced in the composition model:
 | `draft` | Initial structural model generation |
 | `analysis` | Engine-based structural analysis |
 | `design` | Design optimization and detailing |
-| `report` | Report generation and export |
 
 ### 4.2 Stage Mapping
 
-| Skill | intent | draft | analysis | design | report |
-|-------|--------|-------|----------|--------|--------|
-| memory | ✓ | ✓ | ✓ | ✓ | ✓ |
-| planning | ✓ | ✓ | — | — | — |
-| read-file | ✓ | ✓ | ✓ | — | ✓ |
-| write-file | — | — | ✓ | — | ✓ |
-| replace | — | ✓ | ✓ | — | — |
-| shell | — | — | ✓ | — | — |
+| Skill | intent | draft | analysis | design |
+|-------|--------|-------|----------|--------|
+| memory | ✓ | ✓ | ✓ | ✓ |
+| planning | ✓ | ✓ | — | — |
+| read-file | ✓ | ✓ | ✓ | — |
+| write-file | — | — | ✓ | — |
+| replace | — | ✓ | ✓ | — |
+| shell | — | — | ✓ | — |
 
 Key observations:
 
 - **memory** is the only skill available across all stages, since context carriage is universally needed.
 - **planning** is restricted to early stages (intent, draft) where decomposition matters.
 - **shell** is restricted to the analysis stage, since only analysis engines require external process execution.
-- **write-file** and **replace** are excluded from intent and design to prevent unintended side effects.
+- **write-file** is restricted to the analysis stage to prevent unintended side effects in other stages.
 
 ### 4.3 Composition Helpers
 

--- a/docs/schema/utility-skills_CN.md
+++ b/docs/schema/utility-skills_CN.md
@@ -1,0 +1,162 @@
+# 通用工具技能定义
+
+## 1. 概述
+
+通用工具技能是领域无关的辅助能力，用于支撑 Agent 编排流水线的运行。与领域技能（如 structure-type、analysis、code-check 等）不同，工具技能不参与领域路由，而是提供基础功能：内存管理、任务规划、文件读写、内容替换和受限命令执行。
+
+所有工具技能位于 `backend/src/agent-skills/general/` 目录下。每个技能都有一个 `intent.md` 文件声明元数据、安全等级和能力边界，遵循与分析技能和结构类型技能相同的 front-matter 约定。
+
+类型定义、沙箱默认值和组合辅助函数集中在 `backend/src/agent-skills/general/utility-skill-definitions.ts` 中。
+
+## 2. 基线技能集
+
+| 技能 ID | 安全等级 | 能力 | 依赖 |
+|---------|---------|------|------|
+| `memory` | read-write-local | context-store, context-retrieve, context-clear | — |
+| `planning` | read-only | task-decompose, step-sequence, condition-gate | — |
+| `read-file` | read-only | file-read-text, file-read-json, file-list-dir | — |
+| `write-file` | read-write-local | file-write-text, file-write-json | — |
+| `replace` | read-write-local | text-replace, json-patch | read-file, write-file |
+| `shell` | restricted-exec | shell-exec | — |
+
+### 2.1 memory（内存）
+
+在单次 Agent 会话范围内存储、检索和清除键值对上下文。用于在流水线各阶段之间传递中间结果。
+
+- **仅限会话范围**：会话结束后条目不会持久化。
+- **限制**：≤ 200 条目，单条 ≤ 8 KiB。
+
+### 2.2 planning（规划）
+
+将用户意图分解为有序步骤序列和条件门控。只读 — 无副作用，无写入操作。
+
+- **最大嵌套深度**：10 层。
+- **最大步骤数**：每个计划 50 步。
+
+### 2.3 read-file（文件读取）
+
+在沙箱化工作区中读取文本和 JSON 文件或列出目录内容。
+
+- **允许的根目录**：`.runtime/workspace`、`.runtime/uploads`。
+- **拒绝的模式**：`.env`、`*.key`、`*.pem`、`secrets/**`。
+- **单次最大文件大小**：2 MiB。
+
+### 2.4 write-file（文件写入）
+
+向沙箱化工作区写入文本或 JSON 文件。
+
+- **允许的根目录**：仅 `.runtime/workspace`（不允许 uploads）。
+- **拒绝的模式**：与 read-file 相同。
+- **单次最大文件大小**：2 MiB。
+- **单次最大写入文件数**：10 个。
+
+### 2.5 replace（内容替换）
+
+对现有文件执行文本替换或 JSON 补丁操作。依赖 read-file 和 write-file 提供底层 I/O。
+
+- **单次最大替换数**：50 次。
+- **匹配模式**：仅精确匹配（不支持正则表达式）。
+
+### 2.6 shell（命令执行）
+
+在受限沙箱中执行外部命令。专为结构分析引擎调用而设计。
+
+- **白名单命令**：`python`、`python3`、`opensees`、`OpenSees`。
+- **黑名单命令**：`rm`、`del`、`format`、`mkfs`、`sudo`、`su`、`chmod`、`chown`、`curl`、`wget`、`ssh`、`nc`、`ncat`。
+- **禁止的参数**：`--recursive`、`--force`、`-rf`。
+- **工作目录**：锁定为 `.runtime/workspace`。
+- **超时**：5 分钟。
+- **输出上限**：stdout + stderr 合计 1 MiB。
+
+## 3. 安全边界
+
+### 3.1 安全等级
+
+工具技能分为三个安全等级：
+
+| 等级 | 说明 | 允许的操作 |
+|------|------|-----------|
+| `read-only` | 无写入，无副作用 | 读取文件、列出目录、分解计划 |
+| `read-write-local` | 写入会话级或沙箱级存储 | 写入文件、存储/清除内存条目 |
+| `restricted-exec` | 外部进程执行 | 仅调用白名单中的可执行程序 |
+
+安全等级不支持升级。`read-only` 技能不允许在运行时获取写入能力。
+
+### 3.2 沙箱规则
+
+每种技能类型都有对应的沙箱规则接口和一组编译时默认值：
+
+| 沙箱 | 接口 | 默认常量 |
+|------|------|---------|
+| 文件读取 | `FileSandboxRules` | `DEFAULT_FILE_SANDBOX` |
+| 文件写入 | `FileSandboxRules` | `DEFAULT_WRITE_FILE_SANDBOX` |
+| 命令执行 | `ShellSandboxRules` | `DEFAULT_SHELL_SANDBOX` |
+| 内存 | `MemorySandboxRules` | `DEFAULT_MEMORY_SANDBOX` |
+| 规划 | `PlanningSandboxRules` | `DEFAULT_PLANNING_SANDBOX` |
+
+**不变量**：沙箱默认值在未来版本中只能收紧，不能在未经安全审查的情况下放宽。
+
+### 3.3 执行点
+
+沙箱规则在技能调用边界处、技能处理器执行之前进行检查。违规操作将被拒绝，并返回包含技能 ID、尝试的操作和被违反规则的结构化错误信息。
+
+## 4. 与领域技能的组合
+
+### 4.1 基于阶段的复用
+
+工具技能在特定的流水线阶段可用。它们由领域技能或编排器调用，而非由用户直接触发。
+
+组合模型中引用的流水线阶段：
+
+| 阶段 | 说明 |
+|------|------|
+| `intent` | 用户意图解析与消歧 |
+| `draft` | 结构模型初始生成 |
+| `analysis` | 基于引擎的结构分析 |
+| `design` | 设计优化与详细设计 |
+| `report` | 报告生成与导出 |
+
+### 4.2 阶段映射
+
+| 技能 | intent | draft | analysis | design | report |
+|------|--------|-------|----------|--------|--------|
+| memory | ✓ | ✓ | ✓ | ✓ | ✓ |
+| planning | ✓ | ✓ | — | — | — |
+| read-file | ✓ | ✓ | ✓ | — | ✓ |
+| write-file | — | — | ✓ | — | ✓ |
+| replace | — | ✓ | ✓ | — | — |
+| shell | — | — | ✓ | — | — |
+
+关键特征：
+
+- **memory** 是唯一在所有阶段都可用的技能，因为上下文传递在各阶段普遍需要。
+- **planning** 仅限于早期阶段（intent、draft），即需要执行意图分解的位置。
+- **shell** 仅限于 analysis 阶段，因为只有分析引擎需要外部进程执行。
+- **write-file** 和 **replace** 不在 intent 和 design 阶段使用，以避免意外的副作用。
+
+### 4.3 组合辅助函数
+
+`utility-skill-definitions.ts` 导出两个辅助函数：
+
+```typescript
+// 检查特定工具技能是否允许在给定阶段使用
+isUtilitySkillAllowedInStage(skillId: string, stage: string): boolean
+
+// 列出给定阶段可用的所有工具技能
+listUtilitySkillsForStage(stage: string): UtilitySkillDescriptor[]
+```
+
+领域技能和编排器使用这些辅助函数在调用前确认哪些工具技能可用。
+
+### 4.4 依赖解析
+
+标准的 `requires` / `conflicts` 机制（源自 `SkillPackageMetadata`）同样适用于工具技能。
+
+目前只有 `replace` 声明了依赖（`requires: ['read-file', 'write-file']`）。如果任一依赖缺失或被禁用，replace 技能将无法加载。
+
+## 5. 相关文档
+
+- 技能加载机制：`docs/schema/skill-loading_CN.md`
+- 技能加载机制（英文）：`docs/schema/skill-loading.md`
+- 工具技能定义（英文）：`docs/schema/utility-skills.md`
+- 协议参考：`docs/reference_CN.md`

--- a/docs/schema/utility-skills_CN.md
+++ b/docs/schema/utility-skills_CN.md
@@ -62,7 +62,7 @@
 在受限沙箱中执行外部命令。专为结构分析引擎调用而设计。
 
 - **白名单命令**：`python`、`python3`、`opensees`、`OpenSees`。
-- **黑名单命令**：`rm`、`del`、`format`、`mkfs`、`sudo`、`su`、`chmod`、`chown`、`curl`、`wget`、`ssh`、`nc`、`ncat`。
+- **黑名单命令**：`rm`、`del`、`mv`、`cp`、`ln`、`format`、`mkfs`、`sudo`、`su`、`chmod`、`chown`、`curl`、`wget`、`ssh`、`nc`、`ncat`。
 - **禁止的参数**：`--recursive`、`--force`、`-rf`。
 - **工作目录**：锁定为 `.runtime/workspace`。
 - **超时**：5 分钟。
@@ -114,25 +114,24 @@
 | `draft` | 结构模型初始生成 |
 | `analysis` | 基于引擎的结构分析 |
 | `design` | 设计优化与详细设计 |
-| `report` | 报告生成与导出 |
 
 ### 4.2 阶段映射
 
-| 技能 | intent | draft | analysis | design | report |
-|------|--------|-------|----------|--------|--------|
-| memory | ✓ | ✓ | ✓ | ✓ | ✓ |
-| planning | ✓ | ✓ | — | — | — |
-| read-file | ✓ | ✓ | ✓ | — | ✓ |
-| write-file | — | — | ✓ | — | ✓ |
-| replace | — | ✓ | ✓ | — | — |
-| shell | — | — | ✓ | — | — |
+| 技能 | intent | draft | analysis | design |
+|------|--------|-------|----------|--------|
+| memory | ✓ | ✓ | ✓ | ✓ |
+| planning | ✓ | ✓ | — | — |
+| read-file | ✓ | ✓ | ✓ | — |
+| write-file | — | — | ✓ | — |
+| replace | — | ✓ | ✓ | — |
+| shell | — | — | ✓ | — |
 
 关键特征：
 
 - **memory** 是唯一在所有阶段都可用的技能，因为上下文传递在各阶段普遍需要。
 - **planning** 仅限于早期阶段（intent、draft），即需要执行意图分解的位置。
 - **shell** 仅限于 analysis 阶段，因为只有分析引擎需要外部进程执行。
-- **write-file** 和 **replace** 不在 intent 和 design 阶段使用，以避免意外的副作用。
+- **write-file** 仅限于 analysis 阶段，以避免其他阶段产生意外副作用。
 
 ### 4.3 组合辅助函数
 


### PR DESCRIPTION
## What Changed

Define six baseline utility skills (memory, planning, read-file, write-file, replace, shell) under `backend/src/agent-skills/general/`, with typed safety boundaries, sandbox defaults, and stage-based composition rules.

## Checklist

- [x] Define baseline utility skill set (memory, planning, file IO, replacement, command execution)
- [x] Clarify sandboxing, safety, and capability exposure for each skill
- [x] Define composition model with domain skills (stage-based reusability)
- [x] Bilingual documentation (EN + CN)

## Done-When Criteria

- [x] Utility skills are documented in orchestration spec (`docs/schema/utility-skills.md`)
- [x] Safety boundaries are documented with typed constants and sandbox defaults
- [x] Utility skills are reusable across pipeline stages via composition helpers

## Impacted Areas

- `backend/` — types, skill definitions, tests
- `docs/` — schema specs, reference cross-links

## Changes

### Implementation (commit 1)
- 6 `intent.md` files with frontmatter metadata (id, domain, safetyLevel, capabilities, boundaries)
- `utility-skill-definitions.ts` with safety level types, sandbox rule interfaces, default constants, descriptors array, and composition helpers (`isUtilitySkillAllowedInStage`, `listUtilitySkillsForStage`)
- Added `'general'` to `SkillDomain` union type

### Tests (commit 2)
- 18 contract tests covering descriptor completeness, sandbox defaults, stage composition, and edge cases

### Documentation (commit 3)
- `docs/schema/utility-skills.md` (EN) and `docs/schema/utility-skills_CN.md` (CN)
- Updated `docs/reference.md` and `docs/reference_CN.md` with cross-links
- Updated `backend/src/agent-skills/general/README.md` with skill inventory table

## Commands Run

```
npm run build --prefix backend          # success
npx jest --runInBand                    # 173/174 pass (1 pre-existing timeout)
npx jest tests/utility-skill-definitions.test.mjs  # 18/18 pass
```

## Related Issue

Close #56 