### PR TITLE
fix(agent): align beam default supportType and improve LLM test CI

### DIFF
--- a/.github/workflows/llm-integration.yml
+++ b/.github/workflows/llm-integration.yml
@@ -122,6 +122,7 @@ jobs:
           LLM_PROVIDER: ${{ vars.LLM_PROVIDER }}
           LLM_BASE_URL: ${{ vars.LLM_BASE_URL }}
           LLM_LOG_ENABLED: "true"
+          LLM_LOG_DIR: ${{ github.workspace }}/.runtime/logs
           DATABASE_URL: "file:.runtime/data/structureclaw-llm-ci.db"
         run: |
           FILTER_ARG="${{ needs.check-permission.outputs.filter_arg }}"

--- a/.github/workflows/llm-integration.yml
+++ b/.github/workflows/llm-integration.yml
@@ -28,11 +28,13 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
-  issues: write
 
 jobs:
   check-permission:
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'push' ||
@@ -85,7 +87,7 @@ jobs:
               `🚀 **[View Action Run Details](${runUrl})**`,
             ].join('\n');
 
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -94,6 +96,9 @@ jobs:
 
   llm-integration:
     needs: check-permission
+    permissions:
+      contents: read
+      issues: write
     environment: test
     runs-on: ubuntu-latest
     concurrency:
@@ -164,7 +169,7 @@ jobs:
               `📦 **[Download Logs](${runUrl})** or check the Artifacts section.`,
             ].join('\n');
 
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: issueNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/llm-integration.yml
+++ b/.github/workflows/llm-integration.yml
@@ -125,6 +125,7 @@ jobs:
           LLM_LOG_DIR: ${{ github.workspace }}/.runtime/logs
           DATABASE_URL: "file:.runtime/data/structureclaw-llm-ci.db"
         run: |
+          set -o pipefail
           FILTER_ARG="${{ needs.check-permission.outputs.filter_arg }}"
           if [ -n "$FILTER_ARG" ]; then
             node tests/runner.mjs llm-integration --filter "$FILTER_ARG" 2>&1 | tee test-output.txt

--- a/.github/workflows/llm-integration.yml
+++ b/.github/workflows/llm-integration.yml
@@ -43,6 +43,8 @@ jobs:
     outputs:
       pr_sha: ${{ steps.get-ref.outputs.sha }}
       filter_arg: ${{ steps.get-ref.outputs.filter_arg }}
+      trigger_issue_number: ${{ steps.get-ref.outputs.issue_number }}
+      trigger_comment_user: ${{ steps.get-ref.outputs.comment_user }}
     steps:
       - name: Get PR Reference
         id: get-ref
@@ -59,9 +61,13 @@ jobs:
             COMMENT="${{ github.event.comment.body }}"
             FILTER=$(echo "$COMMENT" | sed -n 's|/test-llm[[:space:]]*\(.*\)|\1|p' | xargs)
             echo "filter_arg=$FILTER" >> "$GITHUB_OUTPUT"
+            echo "issue_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+            echo "comment_user=${{ github.event.comment.user.login }}" >> "$GITHUB_OUTPUT"
           else
             echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
             echo "filter_arg=${{ github.event.inputs.filter }}" >> "$GITHUB_OUTPUT"
+            echo "issue_number=" >> "$GITHUB_OUTPUT"
+            echo "comment_user=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Reply with Action Link
@@ -104,6 +110,7 @@ jobs:
         uses: ./.github/actions/setup-env
 
       - name: Run LLM integration tests
+        id: run-tests
         env:
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
           LLM_MODEL: ${{ github.event.inputs.llm_model || vars.LLM_MODEL }}
@@ -114,10 +121,55 @@ jobs:
         run: |
           FILTER_ARG="${{ needs.check-permission.outputs.filter_arg }}"
           if [ -n "$FILTER_ARG" ]; then
-            node tests/runner.mjs llm-integration --filter "$FILTER_ARG"
+            node tests/runner.mjs llm-integration --filter "$FILTER_ARG" 2>&1 | tee test-output.txt
           else
-            node tests/runner.mjs llm-integration
+            node tests/runner.mjs llm-integration 2>&1 | tee test-output.txt
           fi
+
+      - name: Extract test summary
+        if: always()
+        id: summary
+        run: |
+          if [ ! -f test-output.txt ]; then
+            echo "summary=Tests did not produce output." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          SUMMARY=$(grep -A 3 '^Results:' test-output.txt || echo "No summary found")
+          echo "summary<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$SUMMARY" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Report results on PR
+        if: always() && needs.check-permission.outputs.trigger_issue_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = Number('${{ needs.check-permission.outputs.trigger_issue_number }}');
+            const commentUser = '${{ needs.check-permission.outputs.trigger_comment_user }}';
+            const success = '${{ steps.run-tests.outcome }}' === 'success';
+            const summary = `${{ steps.summary.outputs.summary }}`;
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const icon = success ? '✅' : '❌';
+            const status = success ? 'PASSED' : 'FAILED';
+            const body = [
+              `${icon} **LLM Integration Tests ${status}**`,
+              ``,
+              `@${commentUser}, the test run has completed.`,
+              ``,
+              `\`\`\``,
+              summary,
+              `\`\`\``,
+              ``,
+              `📦 **[Download Logs](${runUrl})** or check the Artifacts section.`,
+            ].join('\n');
+
+            github.rest.issues.createComment({
+              issue_number: issueNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })
 
       - name: Upload LLM call logs
         if: always()

--- a/.github/workflows/llm-integration.yml
+++ b/.github/workflows/llm-integration.yml
@@ -154,7 +154,7 @@ jobs:
             const issueNumber = Number('${{ needs.check-permission.outputs.trigger_issue_number }}');
             const commentUser = '${{ needs.check-permission.outputs.trigger_comment_user }}';
             const success = '${{ steps.run-tests.outcome }}' === 'success';
-            const summary = `${{ steps.summary.outputs.summary }}`;
+            const summary = ${{ toJson(steps.summary.outputs.summary) }};
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             const icon = success ? '✅' : '❌';
@@ -183,6 +183,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: llm-logs-ubuntu
-          path: .runtime/logs/llm-calls.jsonl
+          path: .runtime/logs/*.jsonl
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/llm-integration.yml
+++ b/.github/workflows/llm-integration.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Get PR Reference
         id: get-ref
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" == "issue_comment" ]; then
@@ -60,8 +62,7 @@ jobs:
               exit 1
             fi
             echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-            COMMENT="${{ github.event.comment.body }}"
-            FILTER=$(echo "$COMMENT" | sed -n 's|/test-llm[[:space:]]*\(.*\)|\1|p' | xargs)
+            FILTER=$(echo "$COMMENT_BODY" | sed -n 's|/test-llm[[:space:]]*\(.*\)|\1|p' | xargs)
             echo "filter_arg=$FILTER" >> "$GITHUB_OUTPUT"
             echo "issue_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
             echo "comment_user=${{ github.event.comment.user.login }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/llm-integration.yml
+++ b/.github/workflows/llm-integration.yml
@@ -29,6 +29,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  issues: write
 
 jobs:
   check-permission:
@@ -62,6 +63,28 @@ jobs:
             echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
             echo "filter_arg=${{ github.event.inputs.filter }}" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Reply with Action Link
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `✅ **LLM Integration Tests Triggered!**`,
+              ``,
+              `@${context.payload.comment.user.login}, I've started the workflow for you.`,
+              `Please click the link below to monitor progress and **approve the deployment** to the test environment:`,
+              ``,
+              `🚀 **[View Action Run Details](${runUrl})**`,
+            ].join('\n');
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })
 
   llm-integration:
     needs: check-permission

--- a/backend/src/agent-skills/structure-type/beam/draft.md
+++ b/backend/src/agent-skills/structure-type/beam/draft.md
@@ -15,7 +15,7 @@
 - "简支" / "simply supported" / "简支梁" → `"supportType": "simply-supported"`
 - "悬臂" / "cantilever" / "悬臂梁" → `"supportType": "cantilever"`
 - "两端固" / "fixed-fixed" → `"supportType": "fixed-fixed"`
-- 未指定支座类型时默认 `"supportType": "simply-supported"`
+- 未指定支座类型时默认 / Default to `"supportType": "simply-supported"` when unspecified
 
 ### loadKN（荷载大小）
 - "20kN/m" / "均布荷载20kN/m" → `"loadKN": 20`

--- a/backend/src/agent-skills/structure-type/beam/draft.md
+++ b/backend/src/agent-skills/structure-type/beam/draft.md
@@ -15,7 +15,7 @@
 - "简支" / "simply supported" / "简支梁" → `"supportType": "simply-supported"`
 - "悬臂" / "cantilever" / "悬臂梁" → `"supportType": "cantilever"`
 - "两端固" / "fixed-fixed" → `"supportType": "fixed-fixed"`
-- 未指定支座类型时默认 `"supportType": "cantilever"`
+- 未指定支座类型时默认 `"supportType": "simply-supported"`
 
 ### loadKN（荷载大小）
 - "20kN/m" / "均布荷载20kN/m" → `"loadKN": 20`

--- a/backend/src/utils/llm-logger.ts
+++ b/backend/src/utils/llm-logger.ts
@@ -1,7 +1,10 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { config } from '../config/index.js';
 import { logger } from './logger.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 interface LlmLogEntry {
   timestamp: string;
@@ -34,8 +37,9 @@ class LlmCallLogger {
     }
 
     try {
+      // __dirname = backend/dist/utils/ (compiled) → resolve to repo-root/.runtime/logs
       const dir = config.llmLogDir
-        || path.resolve(process.cwd(), '../.runtime/logs');
+        || path.resolve(__dirname, '../../../.runtime/logs');
       fs.mkdirSync(dir, { recursive: true });
       const filePath = path.join(dir, 'llm-calls.jsonl');
       this.stream = fs.createWriteStream(filePath, { flags: 'a' });

--- a/backend/tests/llm-logger-coverage.test.mjs
+++ b/backend/tests/llm-logger-coverage.test.mjs
@@ -539,9 +539,14 @@ describe('llmCallLogger.log edge cases', () => {
         });
       }
 
-      await new Promise((resolve) => setTimeout(resolve, 200));
-
-      const lines = readJsonlLines(path.join(tmpDir, 'llm-calls.jsonl'));
+      // Wait for WriteStream to flush; retry on slow CI (especially Windows).
+      const jsonlPath = path.join(tmpDir, 'llm-calls.jsonl');
+      let lines = [];
+      for (let attempt = 0; attempt < 10; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        lines = readJsonlLines(jsonlPath);
+        if (lines.length >= 50) break;
+      }
       expect(lines).toHaveLength(50);
       expect(lines[0].model).toBe('model-0');
       expect(lines[49].model).toBe('model-49');

--- a/backend/tests/llm-logger-coverage.test.mjs
+++ b/backend/tests/llm-logger-coverage.test.mjs
@@ -544,7 +544,11 @@ describe('llmCallLogger.log edge cases', () => {
       let lines = [];
       for (let attempt = 0; attempt < 10; attempt++) {
         await new Promise((resolve) => setTimeout(resolve, 100));
-        lines = readJsonlLines(jsonlPath);
+        try {
+          lines = readJsonlLines(jsonlPath);
+        } catch {
+          lines = [];
+        }
         if (lines.length >= 50) break;
       }
       expect(lines).toHaveLength(50);

--- a/tests/llm-integration/lib/real-llm-client.cjs
+++ b/tests/llm-integration/lib/real-llm-client.cjs
@@ -65,15 +65,29 @@ function wrapWithLogging(model, context) {
   const modelName = context.env.LLM_MODEL || process.env.LLM_MODEL || "unknown";
   const originalInvoke = model.invoke.bind(model);
 
+  function safeStringify(val) {
+    try {
+      return typeof val === "string" ? val : JSON.stringify(val);
+    } catch {
+      return String(val);
+    }
+  }
+
+  function writeLogEntry(entry) {
+    try {
+      stream.write(JSON.stringify(entry) + "\n");
+    } catch {
+      // Non-blocking: never crash on log write failure.
+    }
+  }
+
   model.invoke = async function (input, options) {
-    const promptStr = typeof input === "string" ? input : JSON.stringify(input);
+    const promptStr = safeStringify(input);
     const start = Date.now();
     try {
       const result = await originalInvoke(input, options);
-      const content = typeof result.content === "string"
-        ? result.content
-        : JSON.stringify(result.content);
-      stream.write(JSON.stringify({
+      const content = safeStringify(result.content);
+      writeLogEntry({
         timestamp: new Date().toISOString(),
         model: modelName,
         prompt: promptStr,
@@ -82,10 +96,10 @@ function wrapWithLogging(model, context) {
         responseChars: content.length,
         durationMs: Date.now() - start,
         success: true,
-      }) + "\n");
+      });
       return result;
     } catch (error) {
-      stream.write(JSON.stringify({
+      writeLogEntry({
         timestamp: new Date().toISOString(),
         model: modelName,
         prompt: promptStr,
@@ -95,7 +109,7 @@ function wrapWithLogging(model, context) {
         durationMs: Date.now() - start,
         success: false,
         error: String(error),
-      }) + "\n");
+      });
       throw error;
     }
   };

--- a/tests/llm-integration/lib/real-llm-client.cjs
+++ b/tests/llm-integration/lib/real-llm-client.cjs
@@ -53,7 +53,7 @@ function ensureLogStream(rootDir) {
   try {
     const dir = process.env.LLM_LOG_DIR || path.join(rootDir, ".runtime", "logs");
     fs.mkdirSync(dir, { recursive: true });
-    _logStream = fs.createWriteStream(path.join(dir, "llm-calls.jsonl"), { flags: "a" });
+    _logStream = fs.createWriteStream(path.join(dir, "llm-calls-test.jsonl"), { flags: "a" });
     _logStream.on("error", () => { _logDisabled = true; _logStream = null; });
     return _logStream;
   } catch {

--- a/tests/llm-integration/lib/real-llm-client.cjs
+++ b/tests/llm-integration/lib/real-llm-client.cjs
@@ -1,10 +1,14 @@
 const { createRequire } = require("node:module");
+const fs = require("node:fs");
 const path = require("node:path");
 
 /**
  * Create a real LLM client using the backend's @langchain/openai dependency.
  * Uses `apiKey` (v1.x) parameter name. Reads config from process.env which
  * must be set before calling this function.
+ *
+ * The returned client is wrapped with LLM call logging so that every
+ * invoke() call is recorded to .runtime/logs/llm-calls.jsonl.
  *
  * @param {object} context - Integration context with env vars
  * @param {number} [temperature=0] - LLM temperature (0 for deterministic)
@@ -31,6 +35,70 @@ function createRealLlmClient(context, temperature = 0) {
       baseURL: context.env.LLM_BASE_URL || process.env.LLM_BASE_URL || undefined,
     },
   });
+
+  return wrapWithLogging(model, context);
+}
+
+/**
+ * Self-contained LLM call logger. Writes one JSON line per invoke() call
+ * to <rootDir>/.runtime/logs/llm-calls.jsonl — same format as the backend's
+ * LlmCallLogger so the CI artifact upload picks it up automatically.
+ */
+let _logStream = null;
+function ensureLogStream(rootDir) {
+  if (_logStream) return _logStream;
+  if (process.env.LLM_LOG_ENABLED === "false") return null;
+  try {
+    const dir = process.env.LLM_LOG_DIR || path.join(rootDir, ".runtime", "logs");
+    fs.mkdirSync(dir, { recursive: true });
+    _logStream = fs.createWriteStream(path.join(dir, "llm-calls.jsonl"), { flags: "a" });
+    return _logStream;
+  } catch {
+    return null;
+  }
+}
+
+function wrapWithLogging(model, context) {
+  const stream = ensureLogStream(context.rootDir);
+  if (!stream) return model;
+
+  const modelName = context.env.LLM_MODEL || process.env.LLM_MODEL || "unknown";
+  const originalInvoke = model.invoke.bind(model);
+
+  model.invoke = async function (input, options) {
+    const promptStr = typeof input === "string" ? input : JSON.stringify(input);
+    const start = Date.now();
+    try {
+      const result = await originalInvoke(input, options);
+      const content = typeof result.content === "string"
+        ? result.content
+        : JSON.stringify(result.content);
+      stream.write(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        model: modelName,
+        prompt: promptStr,
+        response: content,
+        promptChars: promptStr.length,
+        responseChars: content.length,
+        durationMs: Date.now() - start,
+        success: true,
+      }) + "\n");
+      return result;
+    } catch (error) {
+      stream.write(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        model: modelName,
+        prompt: promptStr,
+        response: null,
+        promptChars: promptStr.length,
+        responseChars: 0,
+        durationMs: Date.now() - start,
+        success: false,
+        error: String(error),
+      }) + "\n");
+      throw error;
+    }
+  };
 
   return model;
 }

--- a/tests/llm-integration/lib/real-llm-client.cjs
+++ b/tests/llm-integration/lib/real-llm-client.cjs
@@ -45,15 +45,19 @@ function createRealLlmClient(context, temperature = 0) {
  * LlmCallLogger so the CI artifact upload picks it up automatically.
  */
 let _logStream = null;
+let _logDisabled = false;
 function ensureLogStream(rootDir) {
+  if (_logDisabled) return null;
   if (_logStream) return _logStream;
-  if (process.env.LLM_LOG_ENABLED === "false") return null;
+  if (process.env.LLM_LOG_ENABLED === "false") { _logDisabled = true; return null; }
   try {
     const dir = process.env.LLM_LOG_DIR || path.join(rootDir, ".runtime", "logs");
     fs.mkdirSync(dir, { recursive: true });
     _logStream = fs.createWriteStream(path.join(dir, "llm-calls.jsonl"), { flags: "a" });
+    _logStream.on("error", () => { _logDisabled = true; _logStream = null; });
     return _logStream;
   } catch {
+    _logDisabled = true;
     return null;
   }
 }

--- a/tests/llm-integration/lib/real-llm-client.cjs
+++ b/tests/llm-integration/lib/real-llm-client.cjs
@@ -8,7 +8,7 @@ const path = require("node:path");
  * must be set before calling this function.
  *
  * The returned client is wrapped with LLM call logging so that every
- * invoke() call is recorded to .runtime/logs/llm-calls.jsonl.
+ * invoke() call is recorded to .runtime/logs/llm-calls-test.jsonl.
  *
  * @param {object} context - Integration context with env vars
  * @param {number} [temperature=0] - LLM temperature (0 for deterministic)
@@ -41,7 +41,7 @@ function createRealLlmClient(context, temperature = 0) {
 
 /**
  * Self-contained LLM call logger. Writes one JSON line per invoke() call
- * to <rootDir>/.runtime/logs/llm-calls.jsonl — same format as the backend's
+ * to <rootDir>/.runtime/logs/llm-calls-test.jsonl — same format as the backend's
  * LlmCallLogger so the CI artifact upload picks it up automatically.
  */
 let _logStream = null;
@@ -70,8 +70,10 @@ function wrapWithLogging(model, context) {
   const originalInvoke = model.invoke.bind(model);
 
   function safeStringify(val) {
+    if (typeof val === "string") return val;
     try {
-      return typeof val === "string" ? val : JSON.stringify(val);
+      const result = JSON.stringify(val);
+      return result === undefined ? String(val) : result;
     } catch {
       return String(val);
     }


### PR DESCRIPTION
## Summary
- **Fix `beam-clarify-zh` test failure**: `draft.md` instructed the LLM to default to `"cantilever"` when support type is unspecified, but `handler.ts`, `executor.ts` prompt, and test fixtures all expect `"simply-supported"`.
- **Improve LLM integration CI**: trigger reply, post-run result reporting, permission scoping, LLM call logging, and pipeline reliability fixes.

## Changes

| Commit | Description |
|--------|-------------|
| `7554be8` | Align `draft.md` default `supportType` from `"cantilever"` to `"simply-supported"` |
| `e91d88b` | Add bilingual (zh/en) text to the default instruction line |
| `8e77881` | Add trigger reply comment with action link on `/test-llm` |
| `507ade8` | Post test results (pass/fail + summary) as PR comment after run completes |
| `49d6c20` | Scope `issues: write` to job level; add `await` to async comment calls |
| `5e9e6ac` | Enable LLM call logging: fix log directory resolution (`__dirname` instead of `cwd`), add logging wrapper to test client, add `LLM_LOG_DIR` env var |
| `9b9c7e8` | Add `set -o pipefail` for correct exit code propagation; add `safeStringify` to prevent non-serializable values from crashing logging |

## Test plan
- [x] Gemini review comment addressed (bilingual consistency)
- [x] Copilot review comments addressed (permissions, await, pipefail, serialization)
- [ ] Verify `beam-clarify-zh` passes in LLM Integration CI (`/test-llm clarification`)
- [ ] Confirm trigger reply and result reporting work via `/test-llm` on a PR
- [ ] Confirm `llm-calls.jsonl` artifact is uploaded after CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)