### PR TITLE
fix(yjk,pkpm): restore engines and fix section/material mapping

### DIFF
--- a/backend/src/agent-runtime/manifest-schema.ts
+++ b/backend/src/agent-runtime/manifest-schema.ts
@@ -35,7 +35,7 @@ export const skillManifestFileSchema = z.object({
     minRuntimeVersion: z.string().trim().min(1),
     skillApiVersion: z.string().trim().min(1),
   }),
-  software: z.enum(['opensees', 'simplified']).optional(),
+  software: z.enum(['opensees', 'pkpm', 'yjk', 'simplified']).optional(),
   analysisType: analysisTypeSchema.optional(),
   engineId: z.string().trim().min(1).optional(),
   adapterKey: z.string().trim().min(1).optional(),

--- a/backend/src/agent-skills/analysis/pkpm-static/intent.md
+++ b/backend/src/agent-skills/analysis/pkpm-static/intent.md
@@ -1,0 +1,23 @@
+---
+id: pkpm-static
+zhName: PKPM 静力分析
+enName: PKPM Static Analysis
+zhDescription: 使用 PKPM SATWE 引擎执行静力分析的 skill（需安装 PKPM 及 JWSCYCLE.exe）。
+enDescription: Skill for static analysis using the PKPM SATWE engine (requires PKPM installation and JWSCYCLE.exe).
+software: pkpm
+analysisType: static
+engineId: builtin-pkpm
+adapterKey: builtin-pkpm
+priority: 130
+triggers: ["PKPM 静力分析", "PKPM 计算", "SATWE", "pkpm static", "pkpm analysis"]
+stages: ["analysis"]
+capabilities: ["analysis-policy", "analysis-execution"]
+supportedModelFamilies: ["frame", "generic"]
+autoLoadByDefault: true
+runtimeRelativePath: runtime.py
+---
+# PKPM Static Analysis
+
+- `zh`: 当用户要求使用 PKPM 进行结构静力计算、设计验算、施工图生成时使用。需要已安装 PKPM 并配置 `PKPM_CYCLE_PATH` 环境变量。
+- `en`: Use when the request asks for PKPM-based structural static analysis, design checks, or construction drawing generation. Requires PKPM installation and the `PKPM_CYCLE_PATH` environment variable.
+- Runtime: `analysis/pkpm-static/runtime.py`

--- a/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
@@ -108,16 +108,40 @@ def _make_section_shape(shape: dict) -> tuple[Any, APIPyInterface.SectionShape]:
     return sec_kind, sh
 
 
+def _infer_section_roles(data: dict) -> dict[str, str]:
+    """Build {section_id: "col"|"beam"} by scanning element types.
+
+    Falls back to sec.get("purpose") when no element references the section.
+    A section used by both columns and beams is registered as "col" so that
+    PKPM's AddColumn() receives a ColumnSection index.
+    """
+    roles: dict[str, str] = {}
+    for elem in data.get("elements", []):
+        sec_id = elem.get("section", "")
+        if not sec_id:
+            continue
+        etype = elem.get("type", "beam")
+        if etype == "column":
+            roles[sec_id] = "col"   # column wins over beam
+        elif sec_id not in roles:
+            roles[sec_id] = "beam"
+    return roles
+
+
 def _register_section(
     model: APIPyInterface.Model,
     sec: dict,
+    inferred_role: str,
 ) -> tuple[str, int]:
     """
     Register one V2 section entry.
     Returns (role, pm_section_idx) where role is "col" or "beam".
+
+    The role is determined by the caller via _infer_section_roles() so that
+    sections used by column elements are always registered as ColumnSection,
+    regardless of whether sec["purpose"] is set.
     """
-    purpose = sec.get("purpose", "beam")
-    role = "col" if purpose == "column" else "beam"
+    role = inferred_role
 
     std_name: str | None = sec.get("standard_steel_name")
     shape_dict: dict | None = sec.get("shape")
@@ -149,12 +173,18 @@ def _register_section(
 def _build_section_registry(
     model: APIPyInterface.Model,
     sections: list[dict],
+    data: dict,
 ) -> dict[str, tuple[str, int]]:
     """Register all sections. Returns {sec_id: (role, pm_idx)}."""
+    inferred = _infer_section_roles(data)
     registry: dict[str, tuple[str, int]] = {}
     for sec in sections:
-        role, pm_idx = _register_section(model, sec)
-        registry[sec["id"]] = (role, pm_idx)
+        # Use element-inferred role; fall back to sec["purpose"] if not referenced
+        purpose = sec.get("purpose", "beam")
+        fallback_role = "col" if purpose == "column" else "beam"
+        role = inferred.get(sec["id"], fallback_role)
+        r, pm_idx = _register_section(model, sec, role)
+        registry[sec["id"]] = (r, pm_idx)
     return registry
 
 
@@ -267,7 +297,7 @@ def convert_v2_to_jws(
         mat_id_to_grade[mat["id"]] = grade
 
     # ---- Sections ----
-    sec_registry = _build_section_registry(model, data.get("sections", []))
+    sec_registry = _build_section_registry(model, data.get("sections", []), data)
 
     # Collect first col/beam section index for fallback when element has no section
     fallback_col_idx = next(

--- a/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
@@ -49,14 +49,26 @@ def _resolve_steel_grade(grade_str: str) -> Any:
 # ---------------------------------------------------------------------------
 
 _KIND_MAP: dict[str, Any] = {
-    "H":         "IDSec_I",
-    "I":         "IDSec_I",
-    "Box":       "IDSec_Box",
-    "Tube":      "IDSec_Tube",
-    "Rectangle": "IDSec_Rectangle",
-    "Circle":    "IDSec_Circle",
-    "T":         "IDSec_T",
-    "L":         "IDSec_L",
+    # PascalCase (legacy / internal)
+    "H":           "IDSec_I",
+    "I":           "IDSec_I",
+    "Box":         "IDSec_Box",
+    "Tube":        "IDSec_Tube",
+    "Rectangle":   "IDSec_Rectangle",
+    "Circle":      "IDSec_Circle",
+    "T":           "IDSec_T",
+    "L":           "IDSec_L",
+    # V2 schema lowercase aliases
+    "h":           "IDSec_I",
+    "i":           "IDSec_I",
+    "box":         "IDSec_Box",
+    "tube":        "IDSec_Tube",
+    "pipe":        "IDSec_Tube",   # V2 uses "pipe" for circular hollow
+    "hollow-circular": "IDSec_Tube",
+    "rectangular": "IDSec_Rectangle",
+    "circular":    "IDSec_Circle",
+    "t":           "IDSec_T",
+    "l":           "IDSec_L",
 }
 
 
@@ -69,12 +81,12 @@ def _make_section_shape(shape: dict) -> tuple[Any, APIPyInterface.SectionShape]:
     sec_kind_attr = _KIND_MAP.get(kind, "IDSec_I")
     sec_kind = getattr(sk, sec_kind_attr, sk.IDSec_Rectangle)
 
-    H  = shape.get("H")
-    B  = shape.get("B")
-    T  = shape.get("T")  # wall/flange thickness (Box/Tube) or flange (T-section)
+    H  = shape.get("H") or shape.get("h")
+    B  = shape.get("B") or shape.get("b")
+    T  = shape.get("T") or shape.get("t")  # wall/flange thickness (Box/Tube) or flange (T-section)
     tw = shape.get("tw")
     tf = shape.get("tf")
-    D  = shape.get("D")
+    D  = shape.get("D") or shape.get("d")  # V2 uses lowercase "d" for diameter
 
     if H  is not None: sh.Set_H(int(H))
     if B  is not None: sh.Set_B(int(B))

--- a/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
@@ -1,0 +1,341 @@
+"""
+V2 StructureModelV2 JSON → PKPM JWS (via APIPyInterface)
+
+支持的结构类型: frame, braced-frame
+支持的截面:
+  - H/I 型: kind="H" 或 IDSec_I (HW, HN, HM 等)
+  - 箱型:   kind="Box"  → IDSec_Box
+  - 管型:   kind="Tube" → IDSec_Tube
+  - 矩形:   kind="Rectangle" → IDSec_Rectangle
+  标准型钢名称(standard_steel_name)优先于参数化 shape。
+支持的钢材牌号: Q235, Q345, Q355, Q390, Q420, Q460 及 GJ 系列
+多层处理: 单标准层模板 + N 个自然层（楼层截面相同时适用）
+         不同楼层截面不同时，需手动分多个标准层（待扩展）
+
+单位约定:
+  - V2 JSON: 坐标(m), 截面尺寸(mm), 力(kN), 应力(MPa)
+  - PKPM APIPyInterface: 坐标(mm), 截面尺寸(mm)
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import APIPyInterface
+
+
+# ---------------------------------------------------------------------------
+# Steel grade helpers
+# ---------------------------------------------------------------------------
+
+_GRADE_ALIASES: dict[str, str] = {
+    "Q355B": "Q355",
+    "Q345B": "Q345",
+}
+
+
+def _resolve_steel_grade(grade_str: str) -> Any:
+    """Map V2 steel grade string to APIPyInterface.SteelGrade enum value."""
+    sg = APIPyInterface.SteelGrade
+    key = _GRADE_ALIASES.get(grade_str.strip().upper(), grade_str.strip().upper())
+    if hasattr(sg, key):
+        return getattr(sg, key)
+    return sg.Q345
+
+
+# ---------------------------------------------------------------------------
+# Section helpers
+# ---------------------------------------------------------------------------
+
+_KIND_MAP: dict[str, Any] = {
+    "H":         "IDSec_I",
+    "I":         "IDSec_I",
+    "Box":       "IDSec_Box",
+    "Tube":      "IDSec_Tube",
+    "Rectangle": "IDSec_Rectangle",
+    "Circle":    "IDSec_Circle",
+    "T":         "IDSec_T",
+    "L":         "IDSec_L",
+}
+
+
+def _make_section_shape(shape: dict) -> tuple[Any, APIPyInterface.SectionShape]:
+    """Build (SectionKind, SectionShape) from a V2 shape dict."""
+    sk = APIPyInterface.SectionKind
+    sh = APIPyInterface.SectionShape()
+
+    kind = shape.get("kind", "Rectangle")
+    sec_kind_attr = _KIND_MAP.get(kind, "IDSec_I")
+    sec_kind = getattr(sk, sec_kind_attr, sk.IDSec_Rectangle)
+
+    H  = shape.get("H")
+    B  = shape.get("B")
+    T  = shape.get("T")  # wall/flange thickness (Box/Tube) or flange (T-section)
+    tw = shape.get("tw")
+    tf = shape.get("tf")
+    D  = shape.get("D")
+
+    if H  is not None: sh.Set_H(int(H))
+    if B  is not None: sh.Set_B(int(B))
+    if D  is not None: sh.Set_D(int(D))
+
+    if kind in ("H", "I"):
+        # H/I section: H=total height, B=flange width, tf=flange thickness, tw=web thickness
+        if tf is not None: sh.Set_T(int(tf))
+        if tw is not None: sh.Set_Tw(int(tw))
+    elif kind == "Box":
+        # Box section: H, B, T=wall thickness
+        if T is not None: sh.Set_T(int(T))
+    elif kind == "Tube":
+        # Tube: D=outer diameter, T=wall thickness
+        if T is not None: sh.Set_T(int(T))
+    else:
+        if T is not None: sh.Set_T(int(T))
+
+    return sec_kind, sh
+
+
+def _register_section(
+    model: APIPyInterface.Model,
+    sec: dict,
+) -> tuple[str, int]:
+    """
+    Register one V2 section entry.
+    Returns (role, pm_section_idx) where role is "col" or "beam".
+    """
+    purpose = sec.get("purpose", "beam")
+    role = "col" if purpose == "column" else "beam"
+
+    std_name: str | None = sec.get("standard_steel_name")
+    shape_dict: dict | None = sec.get("shape")
+
+    if role == "col":
+        csec = APIPyInterface.ColumnSection()
+        if std_name:
+            csec.SetStandSteelSect(std_name, APIPyInterface.SectionShape())
+        elif shape_dict:
+            sec_kind, sh = _make_section_shape(shape_dict)
+            csec.SetUserSect(sec_kind, sh)
+        else:
+            raise ValueError(f"Section '{sec['id']}' has no standard_steel_name or shape.")
+        pm_idx = model.AddColumnSection(csec)
+    else:
+        bsec = APIPyInterface.BeamSection()
+        if std_name:
+            bsec.SetStandSteelSect(std_name, APIPyInterface.SectionShape())
+        elif shape_dict:
+            sec_kind, sh = _make_section_shape(shape_dict)
+            bsec.SetUserSect(sec_kind, sh)
+        else:
+            raise ValueError(f"Section '{sec['id']}' has no standard_steel_name or shape.")
+        pm_idx = model.AddBeamSection(bsec)
+
+    return role, pm_idx
+
+
+def _build_section_registry(
+    model: APIPyInterface.Model,
+    sections: list[dict],
+) -> dict[str, tuple[str, int]]:
+    """Register all sections. Returns {sec_id: (role, pm_idx)}."""
+    registry: dict[str, tuple[str, int]] = {}
+    for sec in sections:
+        role, pm_idx = _register_section(model, sec)
+        registry[sec["id"]] = (role, pm_idx)
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# Plan (x,y) node mapping
+# ---------------------------------------------------------------------------
+
+def _build_plan_nodes(
+    floor: APIPyInterface.StandFloor,
+    nodes: list[dict],
+) -> tuple[dict[str, int], dict[str, tuple[float, float]]]:
+    """
+    Deduplicate nodes by (x,y) plan position and add them to the PKPM floor.
+    Returns:
+      v2_to_pm:  {v2_node_id → pm_node_id}
+      v2_to_xy:  {v2_node_id → (x_mm, y_mm)}
+    """
+    m_to_mm = 1000.0
+    xy_to_pm: dict[tuple[float, float], int] = {}
+    v2_to_pm: dict[str, int] = {}
+    v2_to_xy: dict[str, tuple[float, float]] = {}
+
+    for n in nodes:
+        x_mm = round(float(n["x"]) * m_to_mm, 3)
+        y_mm = round(float(n["y"]) * m_to_mm, 3)
+        xy = (x_mm, y_mm)
+
+        if xy not in xy_to_pm:
+            pm_node = floor.AddNode(x_mm, y_mm)
+            xy_to_pm[xy] = pm_node.GetID()
+
+        pm_id = xy_to_pm[xy]
+        v2_to_pm[n["id"]] = pm_id
+        v2_to_xy[n["id"]] = xy
+
+    return v2_to_pm, v2_to_xy
+
+
+# ---------------------------------------------------------------------------
+# Beam direction angle
+# ---------------------------------------------------------------------------
+
+def _beam_angle(
+    na: str,
+    nb: str,
+    v2_to_xy: dict[str, tuple[float, float]],
+) -> float:
+    """Return 0.0 for X-direction beams, 90.0 for Y-direction beams."""
+    xa, ya = v2_to_xy[na]
+    xb, yb = v2_to_xy[nb]
+    if abs(yb - ya) < 1.0:   # same Y → X-direction
+        return 0.0
+    if abs(xb - xa) < 1.0:   # same X → Y-direction
+        return 90.0
+    # diagonal: use dominant axis
+    return 0.0 if abs(xb - xa) >= abs(yb - ya) else 90.0
+
+
+# ---------------------------------------------------------------------------
+# Element default steel grade fallback
+# ---------------------------------------------------------------------------
+
+def _elem_grade(elem: dict, mat_id_to_grade: dict[str, str]) -> Any:
+    """Resolve steel grade for one element."""
+    grade = (
+        elem.get("steel_grade")
+        or mat_id_to_grade.get(elem.get("material", ""), "Q345")
+    )
+    return _resolve_steel_grade(grade)
+
+
+# ---------------------------------------------------------------------------
+# Main converter
+# ---------------------------------------------------------------------------
+
+def convert_v2_to_jws(
+    data: dict,
+    work_dir: Path,
+    project_name: str,
+) -> Path:
+    """
+    Convert V2 StructureModelV2 JSON dict to a PKPM JWS file.
+
+    Args:
+        data:         Parsed V2 JSON (dict).
+        work_dir:     Directory where PKPM will write JWS and support files.
+        project_name: Base name for the JWS project (no extension).
+
+    Returns:
+        Path to the generated .JWS file.
+
+    Raises:
+        ImportError:  If APIPyInterface is not available.
+        ValueError:   If required model data is missing.
+        RuntimeError: If PKPM API reports an error.
+    """
+    work_dir = work_dir.resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+    jws_path = work_dir / f"{project_name}.JWS"
+
+    # ---- Setup ----
+    model = APIPyInterface.Model()
+    model.CreatNewModel(str(work_dir), project_name)
+    model.OpenPMModel(str(jws_path))
+
+    # ---- Material → grade lookup ----
+    mat_id_to_grade: dict[str, str] = {}
+    for mat in data.get("materials", []):
+        grade = mat.get("grade") or mat.get("name", "Q345")
+        mat_id_to_grade[mat["id"]] = grade
+
+    # ---- Sections ----
+    sec_registry = _build_section_registry(model, data.get("sections", []))
+
+    # Collect first col/beam section index for fallback when element has no section
+    fallback_col_idx = next(
+        (pm_idx for _, (role, pm_idx) in sec_registry.items() if role == "col"), -1
+    )
+    fallback_beam_idx = next(
+        (pm_idx for _, (role, pm_idx) in sec_registry.items() if role == "beam"), -1
+    )
+
+    # ---- Standard floor 1 (plan template) ----
+    model.SetCurrentStandFloor(1)
+    floor = model.GetCurrentStandFloor()
+
+    nodes = data.get("nodes", [])
+    v2_to_pm, v2_to_xy = _build_plan_nodes(floor, nodes)
+
+    elements = data.get("elements", [])
+
+    # Track which plan nodes already have a column so we don't double-add
+    plan_nodes_with_col: set[int] = set()
+    # Track beam nets to avoid duplicates
+    added_nets: dict[tuple[int, int], int] = {}  # (pm_a, pm_b) → net_id
+
+    for elem in elements:
+        etype = elem.get("type", "")
+        sec_id = elem.get("section", "")
+        role, pm_sec_idx = sec_registry.get(sec_id, ("beam", -1))
+        node_ids = elem.get("nodes", [])
+        grade = _elem_grade(elem, mat_id_to_grade)
+
+        if etype == "column":
+            if pm_sec_idx < 0:
+                pm_sec_idx = fallback_col_idx
+            # Columns: use base (lower) plan node
+            pm_node_id = v2_to_pm.get(node_ids[0], -1) if node_ids else -1
+            if pm_node_id < 0:
+                continue
+            if pm_node_id not in plan_nodes_with_col:
+                col_obj = floor.AddColumn(pm_sec_idx, pm_node_id)
+                col_obj.SetSteelGrade(grade)
+                plan_nodes_with_col.add(pm_node_id)
+
+        elif etype == "beam":
+            if pm_sec_idx < 0:
+                pm_sec_idx = fallback_beam_idx
+            if len(node_ids) < 2:
+                continue
+            na, nb = node_ids[0], node_ids[1]
+            pm_a = v2_to_pm.get(na, -1)
+            pm_b = v2_to_pm.get(nb, -1)
+            if pm_a < 0 or pm_b < 0 or pm_a == pm_b:
+                continue
+
+            net_key = (min(pm_a, pm_b), max(pm_a, pm_b))
+            if net_key not in added_nets:
+                net_obj = floor.AddLineNet(pm_a, pm_b)
+                added_nets[net_key] = net_obj.GetID()
+
+            net_id = added_nets[net_key]
+            angle = _beam_angle(na, nb, v2_to_xy)
+            beam_obj = floor.AddBeamEx(pm_sec_idx, net_id, 0, 0, 0, angle)
+            beam_obj.SetSteelGrade(grade)
+
+        elif etype == "brace":
+            # Braces: log a note, skip silently for now
+            print(f"[pkpm_converter] brace '{elem.get('id')}' skipped "
+                  f"(AddBrace layer mapping not yet supported)")
+
+    # ---- Natural floors (stories → real floors) ----
+    stories = sorted(
+        data.get("stories", []),
+        key=lambda s: float(s.get("elevation", 0)),
+    )
+    m_to_mm = 1000.0
+    for st in stories:
+        rf = APIPyInterface.RealFloor()
+        rf.SetFloorHeight(float(st["height"]) * m_to_mm)
+        rf.SetBottomElevation(float(st.get("elevation", 0)))
+        rf.SetStandFloorIndex(1)
+        model.AddNaturalFloor(rf)
+
+    model.SavePMModel()
+    return jws_path

--- a/backend/src/agent-skills/analysis/pkpm-static/runtime.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/runtime.py
@@ -1,0 +1,140 @@
+"""PKPM static analysis skill — runtime.
+
+Converts a V2 StructureModelV2 JSON payload into a PKPM JWS project file
+via APIPyInterface, then invokes JWSCYCLE.exe for structural analysis.
+
+Environment variables
+---------------------
+PKPM_CYCLE_PATH : str
+    Full path to JWSCYCLE.exe on the local machine.
+PKPM_WORK_DIR : str, optional
+    Directory where PKPM project files are written.
+    Defaults to a 'pkpm_projects' subfolder in the system temp directory.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any, Dict
+
+from contracts import EngineNotAvailableError
+
+
+def _check_pkpm_available() -> str:
+    """Return PKPM_CYCLE_PATH or raise EngineNotAvailableError."""
+    cycle_path = os.getenv("PKPM_CYCLE_PATH", "").strip()
+    if not cycle_path:
+        raise EngineNotAvailableError(
+            engine="pkpm",
+            reason=(
+                "PKPM_CYCLE_PATH environment variable is not set. "
+                "Set it to the full path of JWSCYCLE.exe."
+            ),
+        )
+    if not Path(cycle_path).is_file():
+        raise EngineNotAvailableError(
+            engine="pkpm",
+            reason=f"JWSCYCLE.exe not found at: {cycle_path}",
+        )
+    return cycle_path
+
+
+def _import_apipyinterface() -> None:
+    """Ensure APIPyInterface can be imported; raise EngineNotAvailableError if not."""
+    try:
+        import APIPyInterface  # noqa: F401
+    except ImportError as exc:
+        raise EngineNotAvailableError(
+            engine="pkpm",
+            reason=f"APIPyInterface Python extension not found: {exc}",
+        ) from exc
+
+
+def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert V2 model to PKPM JWS and run SATWE static analysis.
+
+    Parameters
+    ----------
+    model : dict
+        Deserialized StructureModelV2 payload (raw dict, not Pydantic instance).
+    parameters : dict
+        Analysis parameters forwarded from the API request.
+
+    Returns
+    -------
+    dict
+        AnalysisResult-shaped dict with status / summary / detailed / warnings.
+
+    Raises
+    ------
+    EngineNotAvailableError
+        When PKPM is not installed or APIPyInterface is unavailable.
+    RuntimeError
+        When JWS generation or SATWE analysis fails.
+    """
+    cycle_path = _check_pkpm_available()
+    _import_apipyinterface()
+
+    from pkpm_converter import convert_v2_to_jws  # local import after availability check
+
+    # ---- Determine working directory ----
+    base_work_dir = Path(
+        os.getenv("PKPM_WORK_DIR", "").strip()
+        or Path(tempfile.gettempdir()) / "pkpm_projects"
+    )
+    project_name = f"sc_{uuid.uuid4().hex[:8]}"
+    work_dir = base_work_dir / project_name
+
+    warnings: list[str] = []
+
+    # ---- Phase 1: Generate JWS ----
+    try:
+        jws_path = convert_v2_to_jws(model, work_dir, project_name)
+    except Exception as exc:
+        raise RuntimeError(f"PKPM JWS generation failed: {exc}") from exc
+
+    # ---- Phase 2: Run SATWE via JWSCYCLE.exe ----
+    try:
+        result = subprocess.run(
+            [cycle_path, str(jws_path)],
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        if result.returncode != 0:
+            stderr_snippet = (result.stderr or "")[:500]
+            raise RuntimeError(
+                f"JWSCYCLE.exe exited with code {result.returncode}. "
+                f"stderr: {stderr_snippet}"
+            )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("PKPM analysis timed out after 600 s") from exc
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"Cannot launch JWSCYCLE.exe: {exc}") from exc
+
+    # ---- Phase 3: Collect results ----
+    result_files = list(work_dir.glob("*.OUT")) + list(work_dir.glob("*.out"))
+    summary_lines: list[str] = []
+    for rfile in result_files[:3]:
+        try:
+            text = rfile.read_text(encoding="gbk", errors="replace")
+            summary_lines.append(f"=== {rfile.name} ===\n{text[:2000]}")
+        except Exception as read_exc:
+            warnings.append(f"Could not read result file {rfile.name}: {read_exc}")
+
+    return {
+        "status": "success",
+        "summary": {
+            "engine": "pkpm-static",
+            "jws_path": str(jws_path),
+            "work_dir": str(work_dir),
+            "output_files": [str(p) for p in result_files],
+        },
+        "detailed": {
+            "raw_output": "\n\n".join(summary_lines) if summary_lines else "(no .OUT files found)",
+        },
+        "warnings": warnings,
+    }

--- a/backend/src/agent-skills/analysis/pkpm-static/skill.yaml
+++ b/backend/src/agent-skills/analysis/pkpm-static/skill.yaml
@@ -1,0 +1,45 @@
+id: pkpm-static
+domain: analysis
+source: builtin
+name:
+  zh: PKPM 静力分析
+  en: PKPM Static Analysis
+description:
+  zh: 使用 PKPM SATWE 引擎执行静力分析的 skill（需安装 PKPM 及 JWSCYCLE.exe）。
+  en: Skill for static analysis using the PKPM SATWE engine (requires PKPM installation and JWSCYCLE.exe).
+triggers:
+  - PKPM 静力分析
+  - PKPM 计算
+  - SATWE
+  - pkpm static
+  - pkpm analysis
+stages:
+  - analysis
+structureType: unknown
+structuralTypeKeys: []
+capabilities:
+  - analysis-policy
+  - analysis-execution
+grants:
+  - run_analysis
+providesTools: []
+requires: []
+conflicts: []
+autoLoadByDefault: true
+priority: 130
+compatibility:
+  minRuntimeVersion: 0.1.0
+  skillApiVersion: v1
+software: pkpm
+analysisType: static
+engineId: builtin-pkpm
+adapterKey: builtin-pkpm
+runtimeRelativePath: runtime.py
+supportedAnalysisTypes:
+  - static
+supportedModelFamilies:
+  - frame
+  - generic
+materialFamilies: []
+aliases: []
+toolHints: {}

--- a/backend/src/agent-skills/analysis/pkpm-static/skill.yaml
+++ b/backend/src/agent-skills/analysis/pkpm-static/skill.yaml
@@ -14,6 +14,7 @@ triggers:
   - pkpm static
   - pkpm analysis
 stages:
+  - intent
   - analysis
 structureType: unknown
 structuralTypeKeys: []

--- a/backend/src/agent-skills/analysis/registry.ts
+++ b/backend/src/agent-skills/analysis/registry.ts
@@ -122,6 +122,20 @@ export const BUILTIN_ANALYSIS_ENGINES: AnalysisEngineDefinition[] = [
     constraints: { requiresOpenSees: true },
   }),
   buildEngineDefinition(BUILTIN_ANALYSIS_SKILLS, {
+    id: 'builtin-pkpm',
+    name: 'PKPM Builtin',
+    priority: 90,
+    routingHints: ['commercial', 'design-code'],
+    constraints: { requiresPKPM: true },
+  }),
+  buildEngineDefinition(BUILTIN_ANALYSIS_SKILLS, {
+    id: 'builtin-yjk',
+    name: 'YJK Builtin',
+    priority: 85,
+    routingHints: ['commercial', 'design-code'],
+    constraints: { requiresYJK: true },
+  }),
+  buildEngineDefinition(BUILTIN_ANALYSIS_SKILLS, {
     id: 'builtin-simplified',
     name: 'Simplified Builtin',
     priority: 10,

--- a/backend/src/agent-skills/analysis/types.ts
+++ b/backend/src/agent-skills/analysis/types.ts
@@ -17,9 +17,9 @@ export interface LocalAnalysisEngineClient {
   get<T = any>(path: string): Promise<{ data: T }>;
 }
 
-export type BuiltInAnalysisEngineId = 'builtin-opensees' | 'builtin-simplified';
+export type BuiltInAnalysisEngineId = 'builtin-opensees' | 'builtin-pkpm' | 'builtin-yjk' | 'builtin-simplified';
 export type AnalysisRuntimeAdapterKey = BuiltInAnalysisEngineId;
-export type AnalysisSoftware = 'opensees' | 'simplified';
+export type AnalysisSoftware = 'opensees' | 'pkpm' | 'yjk' | 'simplified';
 export type AnalysisModelFamily = 'frame' | 'truss' | 'generic';
 
 export interface AnalysisSkillManifest {

--- a/backend/src/agent-skills/analysis/yjk-static/extract_results.py
+++ b/backend/src/agent-skills/analysis/yjk-static/extract_results.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""YJK result extraction -- runs INSIDE the YJK process via yjks_pyload.
+
+Invocation (from remote-control driver):
+    YJKSControl.RunCmd("yjks_pyload", script_path, "extract")
+
+The script writes ``results.json`` next to itself.  The driver reads
+that file after execution completes.
+
+JSON schema:
+{
+  "meta":   { "n_floors", "n_nodes", "load_cases" },
+  "nodes":  [ {"id", "x", "y", "z"} ],
+  "node_disp": {
+      "lc_<N>": [ {"id", "ux","uy","uz","rx","ry","rz"} ]
+  },
+  "members": {
+      "columns": [ {"id","floor","node_i","node_j"} ],
+      "beams":   [ {"id","floor","node_i","node_j"} ],
+      "braces":  [ {"id","floor","node_i","node_j"} ]
+  },
+  "member_forces": {
+      "columns": { "lc_<N>": [ {"id","floor","sections":[[Mx,My,Qx,Qy,N,T],...]} ] },
+      "beams":   { ... },
+      "braces":  { ... }
+  },
+  "floor_stats": [ {"floor","stiffness_x","stiffness_y","shear_cap_x","shear_cap_y"} ]
+}
+"""
+import json
+import os
+
+from YJKAPI import *
+
+LOAD_CASES = [1, 2, 3, 4]
+
+
+def _safe(fn, *args, default=None):
+    try:
+        return fn(*args)
+    except Exception:
+        return default
+
+
+def extract():
+    """Entry point called by ``yjks_pyload``."""
+    pre = YJKSPrePy()
+    YJKSDsnDataPy.dsnInitData()
+
+    n_floors = pre.NZRC()
+    n_nodes = pre.NJD()
+    out_dir = os.path.dirname(os.path.abspath(__file__))
+
+    result = {
+        "meta": {
+            "n_floors": n_floors,
+            "n_nodes": n_nodes,
+            "load_cases": LOAD_CASES,
+        },
+        "nodes": [],
+        "node_disp": {},
+        "members": {"columns": [], "beams": [], "braces": []},
+        "member_forces": {"columns": {}, "beams": {}, "braces": {}},
+        "floor_stats": [],
+    }
+
+    # 1. Node coordinates (mm)
+    for jd in range(1, n_nodes + 1):
+        xyz = _safe(pre.XYZ, jd, default=None)
+        if xyz is None:
+            x = _safe(pre.X, jd, default=0.0)
+            y = _safe(pre.Y, jd, default=0.0)
+            z = _safe(pre.Z, jd, default=0.0)
+        else:
+            x, y, z = float(xyz[0]), float(xyz[1]), float(xyz[2])
+        result["nodes"].append({"id": jd, "x": x, "y": y, "z": z})
+
+    # 2. Node displacements per load case (mm / rad)
+    for lc in LOAD_CASES:
+        key = f"lc_{lc}"
+        disp_list = []
+        for jd in range(1, n_nodes + 1):
+            d = _safe(YJKSDsnDataPy.dsnGetNodeDis, jd, lc, default=None)
+            if d and len(d) >= 6:
+                disp_list.append({
+                    "id": jd,
+                    "ux": float(d[0]), "uy": float(d[1]), "uz": float(d[2]),
+                    "rx": float(d[3]), "ry": float(d[4]), "rz": float(d[5]),
+                })
+        result["node_disp"][key] = disp_list
+
+    # 3. Member topology and internal forces
+    for lc in LOAD_CASES:
+        result["member_forces"]["columns"][f"lc_{lc}"] = []
+        result["member_forces"]["beams"][f"lc_{lc}"] = []
+        result["member_forces"]["braces"][f"lc_{lc}"] = []
+
+    for iFlr in range(1, n_floors + 1):
+        _safe(YJKSDsnDataPy.dsnReadFloorPJ, iFlr)
+
+        # -- Columns --
+        col_ids = _safe(pre.FlrColumns, iFlr, default=[]) or []
+        for cid in col_ids:
+            jd_pair = _safe(pre.ColumnJD, cid, default=None)
+            entry = {
+                "id": int(cid), "floor": iFlr,
+                "node_i": int(jd_pair[0]) if jd_pair else -1,
+                "node_j": int(jd_pair[1]) if jd_pair else -1,
+            }
+            if not any(c["id"] == entry["id"] for c in result["members"]["columns"]):
+                result["members"]["columns"].append(entry)
+            for lc in LOAD_CASES:
+                raw = _safe(
+                    YJKSDsnDataPy.dsnGetColumnStdForce,
+                    iFlr, cid, lc, 1, default=(0, []),
+                ) or (0, [])
+                nSect, Force = raw
+                sects = (
+                    [[float(v) for v in Force[s]] for s in range(nSect)]
+                    if nSect else []
+                )
+                result["member_forces"]["columns"][f"lc_{lc}"].append(
+                    {"id": int(cid), "floor": iFlr, "sections": sects}
+                )
+
+        # -- Beams --
+        beam_ids = _safe(pre.FlrBeams, iFlr, default=[]) or []
+        for bid in beam_ids:
+            jd_pair = _safe(pre.BeamJD, bid, default=None)
+            entry = {
+                "id": int(bid), "floor": iFlr,
+                "node_i": int(jd_pair[0]) if jd_pair else -1,
+                "node_j": int(jd_pair[1]) if jd_pair else -1,
+            }
+            if not any(b["id"] == entry["id"] for b in result["members"]["beams"]):
+                result["members"]["beams"].append(entry)
+            for lc in LOAD_CASES:
+                raw = _safe(
+                    YJKSDsnDataPy.dsnGetBeamStdForce,
+                    iFlr, bid, lc, 1, default=(0, []),
+                ) or (0, [])
+                nSect, Force = raw
+                sects = (
+                    [[float(v) for v in Force[s]] for s in range(nSect)]
+                    if nSect else []
+                )
+                result["member_forces"]["beams"][f"lc_{lc}"].append(
+                    {"id": int(bid), "floor": iFlr, "sections": sects}
+                )
+
+        # -- Braces --
+        brace_ids = _safe(pre.FlrBraces, iFlr, default=[]) or []
+        for rid in brace_ids:
+            jd_pair = _safe(pre.BraceJD, rid, default=None)
+            entry = {
+                "id": int(rid), "floor": iFlr,
+                "node_i": int(jd_pair[0]) if jd_pair else -1,
+                "node_j": int(jd_pair[1]) if jd_pair else -1,
+            }
+            if not any(r["id"] == entry["id"] for r in result["members"]["braces"]):
+                result["members"]["braces"].append(entry)
+            for lc in LOAD_CASES:
+                raw = _safe(
+                    YJKSDsnDataPy.dsnGetBraceStdForce,
+                    iFlr, rid, lc, 1, default=(0, []),
+                ) or (0, [])
+                nSect, Force = raw
+                sects = (
+                    [[float(v) for v in Force[s]] for s in range(nSect)]
+                    if nSect else []
+                )
+                result["member_forces"]["braces"][f"lc_{lc}"].append(
+                    {"id": int(rid), "floor": iFlr, "sections": sects}
+                )
+
+    # 4. Floor statistics: stiffness and shear capacity
+    for iFlr in range(1, n_floors + 1):
+        stiff = _safe(YJKSDsnDataPy.dsnGetFlrStiff, iFlr, 1, default=([0, 0], [0, 0]))
+        shear = _safe(YJKSDsnDataPy.dsnGetFlrShearCapacity, iFlr, 1, default=[0, 0])
+        dSC = stiff[1] if stiff else [0, 0]
+        result["floor_stats"].append({
+            "floor": iFlr,
+            "stiffness_x": float(dSC[0]) if dSC else 0.0,
+            "stiffness_y": float(dSC[1]) if dSC else 0.0,
+            "shear_cap_x": float(shear[0]) if shear else 0.0,
+            "shear_cap_y": float(shear[1]) if shear else 0.0,
+        })
+
+    # 5. Write JSON
+    out_path = os.path.join(out_dir, "results.json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+    print("Results exported:", out_path)
+    return out_path

--- a/backend/src/agent-skills/analysis/yjk-static/intent.md
+++ b/backend/src/agent-skills/analysis/yjk-static/intent.md
@@ -1,0 +1,23 @@
+---
+id: yjk-static
+zhName: YJK 静力分析
+enName: YJK Static Analysis
+zhDescription: 使用 YJK (盈建科) 引擎自动建模并执行静力分析，提取节点位移、构件内力、楼层刚度等结构化结果（需安装 YJK 8.0 并配置 YJKS_ROOT 或 YJK_PATH）。
+enDescription: Automated modeling and static analysis using the YJK engine. Extracts node displacements, member forces, and floor statistics as structured results (requires YJK 8.0 and YJKS_ROOT or YJK_PATH).
+software: yjk
+analysisType: static
+engineId: builtin-yjk
+adapterKey: builtin-yjk
+priority: 125
+triggers: ["YJK 静力分析", "YJK 计算", "盈建科", "yjk static", "yjk analysis"]
+stages: ["analysis"]
+capabilities: ["analysis-policy", "analysis-execution"]
+supportedModelFamilies: ["frame", "generic"]
+autoLoadByDefault: false
+runtimeRelativePath: runtime.py
+---
+# YJK Static Analysis
+
+- `zh`: 当用户要求使用 YJK（盈建科）进行结构静力计算、设计验算时使用。自动将 V2 模型转换为 YJK 格式，启动盈建科软件执行建模、前处理、整体计算，并通过 yjks_pyload 提取结构化分析结果（节点位移、构件内力、楼层刚度/受剪承载力）。需要已安装 YJK 8.0 并配置 `YJKS_ROOT` 或 `YJK_PATH` 指向安装根目录（与官方 SDK 示例一致）。
+- `en`: Use when the request asks for YJK-based structural static analysis or design checks. Automatically converts V2 model to YJK format, launches YJK for modeling, preprocessing, and full calculation, then extracts structured results (node displacements, member forces, floor stiffness/shear capacity) via yjks_pyload. Requires YJK 8.0 and `YJKS_ROOT` or `YJK_PATH` pointing to the install root (same convention as the official YJK SDK samples).
+- Runtime: `analysis/yjk-static/runtime.py`

--- a/backend/src/agent-skills/analysis/yjk-static/runtime.py
+++ b/backend/src/agent-skills/analysis/yjk-static/runtime.py
@@ -238,6 +238,7 @@ def _ensure_v2_model(model_dict: dict) -> dict:
         sec_name = (sec.get("name") or "").strip()
 
         if sec_name and _STD_STEEL_RE.match(sec_name):
+            normalized_sec_name = sec_name.upper().replace("×", "X").replace("x", "X")
             m = _H_DIMS_RE.match(sec_name)
             if m:
                 H_val = int(m.group(1))
@@ -260,14 +261,16 @@ def _ensure_v2_model(model_dict: dict) -> dict:
                     props.pop("standard_steel_name", None)
                     sec["properties"] = props
                 else:
-                    props.setdefault("standard_steel_name",
-                                     sec_name.upper().replace("×", "X").replace("x", "X"))
+                    # Write to both top-level (V2 canonical) and properties (legacy compat)
+                    sec.setdefault("standard_steel_name", normalized_sec_name)
+                    props.setdefault("standard_steel_name", normalized_sec_name)
                     sec["properties"] = props
                     if not sec.get("type") or sec.get("type") == "beam":
                         sec["type"] = "H"
             else:
-                props.setdefault("standard_steel_name",
-                                 sec_name.upper().replace("×", "X").replace("x", "X"))
+                # Write to both top-level (V2 canonical) and properties (legacy compat)
+                sec.setdefault("standard_steel_name", normalized_sec_name)
+                props.setdefault("standard_steel_name", normalized_sec_name)
                 sec["properties"] = props
                 if not sec.get("type") or sec.get("type") == "beam":
                     sec["type"] = "H"

--- a/backend/src/agent-skills/analysis/yjk-static/runtime.py
+++ b/backend/src/agent-skills/analysis/yjk-static/runtime.py
@@ -294,6 +294,9 @@ def _ensure_v2_model(model_dict: dict) -> dict:
                     sec["height"] = side
 
     # --- Enrich elements with column type based on vertical (Z) orientation ---
+    # NOTE: This block runs AFTER the V1->V2 coordinate remap above, so
+    # n["z"] is already the vertical axis for both V1 and native V2 payloads.
+    # dz = vertical delta → column; dx/dy dominant → beam.
     node_map = {n["id"]: n for n in nodes}
     for elem in v2.get("elements", []):
         if elem.get("type") in ("beam", "column"):

--- a/backend/src/agent-skills/analysis/yjk-static/runtime.py
+++ b/backend/src/agent-skills/analysis/yjk-static/runtime.py
@@ -1,0 +1,398 @@
+"""YJK static analysis skill -- runtime.
+
+Delegates the actual YJKAPI work to a subprocess running YJK's
+bundled Python 3.10 (``yjk_driver.py``).  This module runs under the
+project's own venv Python and therefore cannot import YJKAPI directly.
+
+Environment variables
+---------------------
+YJKS_ROOT or YJK_PATH : str
+    YJK 8.0 installation root (``yjks.exe`` and ``Python310`` live here).
+    The official YJK SDK samples use ``YJKS_ROOT``; ``YJK_PATH`` is an
+    alias supported for compatibility.
+YJKS_EXE : str, optional
+    Direct path to ``yjks.exe``.  Overrides root-directory derivation.
+YJK_PYTHON_BIN : str, optional
+    Direct path to YJK's Python 3.10 interpreter.
+    Defaults to ``<install_root>/Python310/python.exe``.
+YJK_WORK_DIR : str, optional
+    Base directory for YJK project files.
+    Defaults to ``<tempdir>/yjk_projects``.
+YJK_VERSION : str, optional
+    YJK version string passed to ControlConfig.  Default ``8.0.0``.
+YJK_TIMEOUT_S : str, optional
+    Subprocess timeout in seconds.  Default ``600``.
+YJK_INVISIBLE : str, optional
+    Set to ``"1"`` to launch YJK headlessly (no GUI window).
+    Default ``"0"`` — YJK GUI is visible so the user can observe the run.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any, Dict
+
+from contracts import EngineNotAvailableError
+
+
+def _yjk_install_root() -> str:
+    """Resolve install root: ``YJK_PATH`` if set, else ``YJKS_ROOT``."""
+    return (os.getenv("YJK_PATH", "").strip() or os.getenv("YJKS_ROOT", "").strip())
+
+
+def _resolve_yjk_python() -> str:
+    """Return the path to YJK's bundled Python 3.10 executable."""
+    explicit = os.getenv("YJK_PYTHON_BIN", "").strip()
+    if explicit and Path(explicit).is_file():
+        return explicit
+
+    root = _yjk_install_root()
+    if not root:
+        raise EngineNotAvailableError(
+            engine="yjk",
+            reason="YJK install root not set (set YJKS_ROOT or YJK_PATH)",
+        )
+    if not Path(root).is_dir():
+        raise EngineNotAvailableError(
+            engine="yjk",
+            reason=f"YJK install directory does not exist: {root}",
+        )
+
+    python_exe = Path(root) / "Python310" / "python.exe"
+    if not python_exe.is_file():
+        raise EngineNotAvailableError(
+            engine="yjk",
+            reason=f"YJK Python 3.10 not found at {python_exe}",
+        )
+    return str(python_exe)
+
+
+def _resolve_work_dir() -> Path:
+    """Return a per-run subdirectory under YJK_WORK_DIR.
+
+    YJK_WORK_DIR should be set by the user so that generated project files,
+    .OUT results, and logs land in a known, reviewable location.
+    Falls back to the system temp directory when unset (not recommended).
+    """
+    import warnings
+    base = os.getenv("YJK_WORK_DIR", "").strip()
+    if not base:
+        fallback = str(Path(tempfile.gettempdir()) / "yjk_projects")
+        warnings.warn(
+            "YJK_WORK_DIR is not set; using system temp directory as fallback: "
+            f"{fallback}. Set YJK_WORK_DIR in .env to a persistent location.",
+            stacklevel=2,
+        )
+        base = fallback
+    project_name = f"sc_{uuid.uuid4().hex[:8]}"
+    work = Path(base) / project_name
+    work.mkdir(parents=True, exist_ok=True)
+    return work
+
+
+def _extract_last_json(text: str) -> dict | None:
+    """Extract the last complete JSON object from text.
+
+    YJK's Python runtime may print non-JSON lines (copyright banners,
+    init messages) to stdout before our _emit_json() call.  We scan
+    backwards for the last '{' ... '}' block that parses cleanly.
+    """
+    # Fast path: the whole string is valid JSON
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # Scan for the last '{' and try progressively larger suffixes
+    last_brace = text.rfind('{')
+    if last_brace == -1:
+        return None
+    try:
+        return json.loads(text[last_brace:])
+    except json.JSONDecodeError:
+        pass
+
+    # Fallback: try each line from the end
+    lines = text.splitlines()
+    for i in range(len(lines) - 1, -1, -1):
+        candidate = '\n'.join(lines[i:]).strip()
+        if candidate.startswith('{'):
+            try:
+                return json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+    return None
+
+
+def _ensure_v2_model(model_dict: dict) -> dict:
+    """Convert a V1 model dict to V2-compatible format for the YJK converter.
+
+    The YJK converter expects V2 fields (stories, V2-style sections with
+    width/height, materials with category).  V1 models from draft_model
+    lack these.  This function synthesizes the missing V2 fields from V1
+    data so the converter can proceed.
+
+    Coordinate system: V1 frame handler uses (x=X, y=vertical, z=Y).
+    V2 / YJK expects (x=X, y=Y, z=vertical).  We detect and remap.
+    """
+    if model_dict.get("schema_version", "").startswith("2"):
+        return model_dict
+
+    from copy import deepcopy
+    v2 = deepcopy(model_dict)
+    v2["schema_version"] = "2.0.0"
+
+    nodes = v2.get("nodes", [])
+
+    # --- Synthesize stories from node Z coordinates (vertical) ---
+    if not v2.get("stories") and nodes:
+        z_vals = sorted({round(float(n.get("z", 0)), 3) for n in nodes})
+        elevations = [z for z in z_vals if z > 0]
+        if not elevations:
+            max_z = max((float(n.get("z", 0)) for n in nodes), default=3.0)
+            elevations = [max_z] if max_z > 0 else [3.0]
+
+        stories = []
+        prev_elev = 0.0
+        for i, elev in enumerate(elevations):
+            story_id = f"F{i + 1}"
+            height = round(elev - prev_elev, 3)
+            if height <= 0:
+                height = 3.0
+            stories.append({
+                "id": story_id,
+                "height": height,
+                "elevation": elev,
+                "floor_loads": [
+                    {"type": "dead", "value": 5.0},
+                    {"type": "live", "value": 2.0},
+                ],
+            })
+            prev_elev = elev
+        v2["stories"] = stories
+
+        elev_to_story = {round(s["elevation"], 3): s["id"] for s in stories}
+        for n in nodes:
+            nz = round(float(n.get("z", 0)), 3)
+            if nz in elev_to_story and not n.get("story"):
+                n["story"] = elev_to_story[nz]
+
+    # --- Enrich materials with category ---
+    import re as _re_mat
+    for mat in v2.get("materials", []):
+        if not mat.get("category"):
+            name = (mat.get("name", "") or "").upper()
+            if _re_mat.match(r'^(Q|S|A)\d', name) or "STEEL" in name or "钢" in name:
+                mat["category"] = "steel"
+            elif _re_mat.match(r'^C\d', name) or "CONCRETE" in name or "混凝土" in name:
+                mat["category"] = "concrete"
+            else:
+                mat["category"] = "steel"
+
+    # --- Enrich sections: recognize standard steel names and geometry ---
+    import re
+    _STD_STEEL_RE = re.compile(
+        r'^(HW|HN|HM|HP|HT|I|C|L|TW|TN)\d+[Xx×]\d+',
+        re.IGNORECASE,
+    )
+    _H_DIMS_RE = re.compile(
+        r'^(?:HW|HN|HM|HP|HT)(\d+)[Xx×](\d+)(?:[Xx×](\d+)[Xx×](\d+))?',
+        re.IGNORECASE,
+    )
+
+    for sec in v2.get("sections", []):
+        props = sec.get("properties", {})
+        sec_name = (sec.get("name") or "").strip()
+
+        if sec_name and _STD_STEEL_RE.match(sec_name):
+            m = _H_DIMS_RE.match(sec_name)
+            if m:
+                H_val = int(m.group(1))
+                B_val = int(m.group(2))
+                tw_val = int(m.group(3)) if m.group(3) else None
+                tf_val = int(m.group(4)) if m.group(4) else None
+                if not sec.get("height"):
+                    sec["height"] = H_val
+                if not sec.get("width"):
+                    sec["width"] = B_val
+
+                if tw_val and tf_val:
+                    sec["type"] = "H"
+                    props.setdefault("tw", tw_val)
+                    props.setdefault("H", H_val)
+                    props.setdefault("B1", B_val)
+                    props.setdefault("B2", B_val)
+                    props.setdefault("tf1", tf_val)
+                    props.setdefault("tf2", tf_val)
+                    props.pop("standard_steel_name", None)
+                    sec["properties"] = props
+                else:
+                    props.setdefault("standard_steel_name",
+                                     sec_name.upper().replace("×", "X").replace("x", "X"))
+                    sec["properties"] = props
+                    if not sec.get("type") or sec.get("type") == "beam":
+                        sec["type"] = "H"
+            else:
+                props.setdefault("standard_steel_name",
+                                 sec_name.upper().replace("×", "X").replace("x", "X"))
+                sec["properties"] = props
+                if not sec.get("type") or sec.get("type") == "beam":
+                    sec["type"] = "H"
+            continue
+
+        if not sec.get("width") and "B" in props:
+            sec["width"] = float(props["B"])
+        if not sec.get("height") and "H" in props:
+            sec["height"] = float(props["H"])
+        if not sec.get("width") and "b" in props:
+            sec["width"] = float(props["b"])
+        if not sec.get("height") and "h" in props:
+            sec["height"] = float(props["h"])
+        if not sec.get("width") and not sec.get("height"):
+            a = props.get("A", 0)
+            if a and not props.get("B") and not props.get("H"):
+                import math
+                side = round(math.sqrt(float(a)) * 1000, 0)
+                if side > 0:
+                    sec["width"] = side
+                    sec["height"] = side
+
+    # --- Enrich elements with column type based on vertical (Z) orientation ---
+    node_map = {n["id"]: n for n in nodes}
+    for elem in v2.get("elements", []):
+        if elem.get("type") in ("beam", "column"):
+            nids = elem.get("nodes", [])
+            if len(nids) >= 2:
+                n1 = node_map.get(nids[0], {})
+                n2 = node_map.get(nids[1], {})
+                dz = abs(float(n2.get("z", 0)) - float(n1.get("z", 0)))
+                dx = abs(float(n2.get("x", 0)) - float(n1.get("x", 0)))
+                dy = abs(float(n2.get("y", 0)) - float(n1.get("y", 0)))
+                if dz > 0 and dz >= max(dx, dy, 0.001):
+                    elem["type"] = "column"
+                elif elem.get("type") != "column":
+                    elem["type"] = "beam"
+
+    return v2
+
+
+def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str, Any]:
+    """Entry point called by the analysis registry.
+
+    Parameters
+    ----------
+    model : dict
+        Deserialized StructureModelV2 payload (raw dict).
+    parameters : dict
+        Analysis parameters forwarded from the API request.
+
+    Returns
+    -------
+    dict
+        AnalysisResult-shaped dict with status / summary / detailed / warnings.
+    """
+    yjk_python = _resolve_yjk_python()
+    work_dir = _resolve_work_dir()
+    timeout = int(os.getenv("YJK_TIMEOUT_S", "600").strip() or "600")
+
+    # Write V2 model JSON to work directory.
+    # `model` may arrive as a Pydantic object (StructureModelV1); serialize it first.
+    model_dict = model.model_dump(mode="json") if hasattr(model, "model_dump") else model
+    # The YJK converter expects V2 format. If the model is V1, convert it.
+    model_dict = _ensure_v2_model(model_dict)
+    model_path = work_dir / "model.json"
+    model_path.write_text(json.dumps(model_dict, ensure_ascii=False), encoding="utf-8")
+
+    # Locate the driver script (sibling of this file)
+    driver_path = Path(__file__).resolve().parent / "yjk_driver.py"
+    if not driver_path.is_file():
+        raise RuntimeError(f"YJK driver script not found: {driver_path}")
+
+    # Build environment for the subprocess.
+    # Ensure both YJKS_ROOT and YJK_PATH are set for SDK scripts / driver.
+    env = os.environ.copy()
+    root = _yjk_install_root()
+    if root:
+        env.setdefault("YJKS_ROOT", root)
+        env.setdefault("YJK_PATH", root)
+    for key in ("YJKS_EXE", "YJK_VERSION", "YJK_PYTHON_BIN", "YJK_INVISIBLE"):
+        val = os.getenv(key, "").strip()
+        if val:
+            env[key] = val
+
+    warnings: list[str] = []
+
+    # Launch the driver under YJK's Python 3.10
+    try:
+        result = subprocess.run(
+            [yjk_python, str(driver_path), str(model_path), str(work_dir)],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+            cwd=str(work_dir),
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"YJK analysis timed out after {timeout}s")
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"Cannot launch YJK Python: {exc}")
+
+    # Parse stdout as JSON result.
+    # The driver writes only ONE JSON blob to stdout; all progress/debug
+    # output goes to stderr so the user can see it in the backend log.
+    stdout = result.stdout.strip()
+    stderr = result.stderr.strip()
+
+    if stderr:
+        import logging
+        logging.getLogger("yjk-runtime").info("YJK driver stderr:\n%s", stderr)
+
+    if result.returncode != 0 and not stdout:
+        stderr_snippet = stderr[:800] if stderr else "(no stderr)"
+        raise RuntimeError(
+            f"YJK driver exited with code {result.returncode}.\n"
+            f"stderr: {stderr_snippet}"
+        )
+
+    if not stdout:
+        stderr_snippet = stderr[:800] if stderr else "(no stderr)"
+        raise RuntimeError(
+            f"YJK driver produced no stdout output.\n"
+            f"stderr: {stderr_snippet}"
+        )
+
+    # YJK's Python runtime may print non-JSON text (copyright banners,
+    # init messages) to stdout before our _emit_json() call.  Extract
+    # the last complete JSON object from stdout so those lines don't
+    # break parsing.
+    output = _extract_last_json(stdout)
+    if output is None:
+        raise RuntimeError(
+            f"YJK driver output is not valid JSON.\n"
+            f"stdout (first 500 chars): {stdout[:500]}\n"
+            f"stderr (first 500 chars): {stderr[:500]}"
+        )
+
+    status = output.get("status", "error")
+    if status == "error":
+        error_msg = output.get("detailed", {}).get("error", "Unknown YJK error")
+        raise RuntimeError(f"YJK analysis failed: {error_msg}")
+
+    if stderr:
+        warnings.append(f"YJK stderr: {stderr[:300]}")
+
+    existing_warnings = output.get("warnings", [])
+    if isinstance(existing_warnings, list):
+        warnings.extend(existing_warnings)
+
+    return {
+        "status": output.get("status", "success"),
+        "summary": output.get("summary", {}),
+        "data": output.get("data", {}),
+        "detailed": output.get("detailed", {}),
+        "warnings": warnings,
+    }

--- a/backend/src/agent-skills/analysis/yjk-static/runtime.py
+++ b/backend/src/agent-skills/analysis/yjk-static/runtime.py
@@ -136,8 +136,24 @@ def _ensure_v2_model(model_dict: dict) -> dict:
     lack these.  This function synthesizes the missing V2 fields from V1
     data so the converter can proceed.
 
-    Coordinate system: V1 frame handler uses (x=X, y=vertical, z=Y).
-    V2 / YJK expects (x=X, y=Y, z=vertical).  We detect and remap.
+    Coordinate system
+    -----------------
+    V1 frame handler (frame/model.ts) uses:
+        x = X-axis (horizontal span)
+        y = vertical (storey height)   <-- vertical axis
+        z = Y-axis (plan depth, 0 for 2-D models)
+
+    V2 / YJK expects:
+        x = X-axis
+        y = Y-axis (plan depth)
+        z = vertical                   <-- vertical axis
+
+    We detect V1 models by checking whether any node has a non-zero y
+    value while z is uniformly 0 (2-D) or z carries plan-depth values
+    (3-D).  When detected, we remap:
+        V2.x = V1.x
+        V2.y = V1.z   (plan Y-axis)
+        V2.z = V1.y   (vertical)
     """
     if model_dict.get("schema_version", "").startswith("2"):
         return model_dict
@@ -148,7 +164,20 @@ def _ensure_v2_model(model_dict: dict) -> dict:
 
     nodes = v2.get("nodes", [])
 
-    # --- Synthesize stories from node Z coordinates (vertical) ---
+    # --- Remap V1 coordinates (x,y=vertical,z=planY) -> V2 (x,y=planY,z=vertical) ---
+    # Detect V1 layout: at least one node has y > 0 (storey elevation) and
+    # the vertical axis is y, not z.
+    needs_remap = nodes and any(float(n.get("y", 0)) > 0 for n in nodes)
+    if needs_remap:
+        for n in nodes:
+            v1_x = float(n.get("x", 0))
+            v1_y = float(n.get("y", 0))  # vertical in V1
+            v1_z = float(n.get("z", 0))  # plan-Y in V1
+            n["x"] = v1_x
+            n["y"] = v1_z   # plan-Y becomes V2.y
+            n["z"] = v1_y   # vertical becomes V2.z
+
+    # --- Synthesize stories from node Z coordinates (vertical after remap) ---
     if not v2.get("stories") and nodes:
         z_vals = sorted({round(float(n.get("z", 0)), 3) for n in nodes})
         elevations = [z for z in z_vals if z > 0]

--- a/backend/src/agent-skills/analysis/yjk-static/skill.yaml
+++ b/backend/src/agent-skills/analysis/yjk-static/skill.yaml
@@ -14,8 +14,8 @@ triggers:
   - yjk static
   - yjk analysis
 stages:
+  - intent
   - analysis
-structureType: unknown
 structuralTypeKeys: []
 capabilities:
   - analysis-policy

--- a/backend/src/agent-skills/analysis/yjk-static/skill.yaml
+++ b/backend/src/agent-skills/analysis/yjk-static/skill.yaml
@@ -5,8 +5,8 @@ name:
   zh: YJK 静力分析
   en: YJK Static Analysis
 description:
-  zh: 使用 YJK (盈建科) 引擎自动建模并执行静力分析，提取节点位移、构件内力、楼层刚度等结构化结果（需安装 YJK 8.0 并配置 YJKS_ROOT 或 YJK_PATH）。
-  en: Automated modeling and static analysis using the YJK engine. Extracts node displacements, member forces, and floor statistics as structured results (requires YJK 8.0 and YJKS_ROOT or YJK_PATH).
+  zh: 使用 YJK (盈建科) 引擎自动建模并执行静力分析，返回分析输出结果（当前为 YJK .OUT 文本输出；需安装 YJK 8.0 并配置 YJKS_ROOT 或 YJK_PATH）。
+  en: Automated modeling and static analysis using the YJK engine. Returns analysis output results (currently YJK .OUT text output; requires YJK 8.0 and YJKS_ROOT or YJK_PATH).
 triggers:
   - YJK 静力分析
   - YJK 计算

--- a/backend/src/agent-skills/analysis/yjk-static/skill.yaml
+++ b/backend/src/agent-skills/analysis/yjk-static/skill.yaml
@@ -1,0 +1,45 @@
+id: yjk-static
+domain: analysis
+source: builtin
+name:
+  zh: YJK 静力分析
+  en: YJK Static Analysis
+description:
+  zh: 使用 YJK (盈建科) 引擎自动建模并执行静力分析，提取节点位移、构件内力、楼层刚度等结构化结果（需安装 YJK 8.0 并配置 YJKS_ROOT 或 YJK_PATH）。
+  en: Automated modeling and static analysis using the YJK engine. Extracts node displacements, member forces, and floor statistics as structured results (requires YJK 8.0 and YJKS_ROOT or YJK_PATH).
+triggers:
+  - YJK 静力分析
+  - YJK 计算
+  - 盈建科
+  - yjk static
+  - yjk analysis
+stages:
+  - analysis
+structureType: unknown
+structuralTypeKeys: []
+capabilities:
+  - analysis-policy
+  - analysis-execution
+grants:
+  - run_analysis
+providesTools: []
+requires: []
+conflicts: []
+autoLoadByDefault: false
+priority: 125
+compatibility:
+  minRuntimeVersion: 0.1.0
+  skillApiVersion: v1
+software: yjk
+analysisType: static
+engineId: builtin-yjk
+adapterKey: builtin-yjk
+runtimeRelativePath: runtime.py
+supportedAnalysisTypes:
+  - static
+supportedModelFamilies:
+  - frame
+  - generic
+materialFamilies: []
+aliases: []
+toolHints: {}

--- a/backend/src/agent-skills/analysis/yjk-static/yjk_converter.py
+++ b/backend/src/agent-skills/analysis/yjk-static/yjk_converter.py
@@ -1,0 +1,468 @@
+# -*- coding: utf-8 -*-
+"""V2 StructureModelV2 JSON -> YJK .ydb via YJKAPI DataFunc.
+
+Runs under YJK's bundled Python 3.10.  Imported by yjk_driver.py.
+
+Supported section kinds (YJK 8.0 API):
+  Basic geometry:
+    kind=1  矩形        ShapeVal "B,H"
+    kind=2  工字形/H形   ShapeVal "tw,H,B,tf1,B2,tf2" (6 params)
+    kind=3  圆形        ShapeVal "D"
+    kind=4  正多边形     ShapeVal (per YJK docs)
+    kind=5  槽形        ShapeVal (per YJK docs)
+    kind=6  十字形       ShapeVal (per YJK docs)
+    kind=7  箱型        ShapeVal "B,H,U,T,D,F" (6 params; equal-thickness: B,H,t,t,t,t)
+    kind=8  圆管        ShapeVal "D,d" (outer, inner) or "D,t" (outer, wall)
+    kind=9  双槽形       ShapeVal (per YJK docs)
+    kind=10 十字工       ShapeVal (per YJK docs)
+    kind=11 梯形        ShapeVal (per YJK docs)
+    kind=28 L形         ShapeVal (per YJK docs)
+    kind=29 T形         ShapeVal (per YJK docs)
+  Composite / SRC:
+    kind=12 钢管混凝土   kind=13 工字劲   kind=14 箱形劲
+    kind=-14 方管混凝土  kind=15 十字劲
+    kind=24 带盖板钢组合  kind=25 组合截面
+  Tapered:
+    kind=21 矩形变截面   kind=22 H形变截面  kind=23 箱形变截面
+    kind=33 正多边形变截面 kind=52 工字劲变截面
+  Library:
+    kind=26 型钢 (热轧库截面, ShapeVal="", name=规格名)
+    kind=303 薄壁型钢    kind=304 薄壁型钢组合  kind=306 铝合金梁
+
+Unit conventions:
+  V2 JSON coordinates: meters   -> YJK: mm  (multiply by 1000)
+  V2 section dims:     mm       -> YJK: mm  (pass through)
+  V2 floor heights:    meters   -> YJK: mm  (multiply by 1000)
+  V2 floor loads:      kN/m2    -> YJK: kN/m2 (pass through)
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from YJKAPI import DataFunc, Hi_AddToAndReadYjk
+
+M_TO_MM = 1000.0
+
+# material category -> YJK mat type
+_CATEGORY_TO_MAT: dict[str, int] = {
+    "steel": 5,
+    "concrete": 6,
+    "rebar": 6,
+    "other": 6,
+}
+
+# V2 section type string -> YJK section kind integer
+# Reference: YJK 8.0 建模接口说明 + 案例/二次开发
+_TYPE_TO_KIND: dict[str, int] = {
+    # --- 基本型钢 / 几何截面 ---
+    "rectangular": 1,   # 矩形          ShapeVal "B,H"
+    "I": 2,             # 工字形         ShapeVal "tw,H,B,tf1,B2,tf2"
+    "H": 2,             # H形 (同工字形)
+    "circular": 3,      # 圆形          ShapeVal "D"
+    "polygon": 4,       # 正多边形
+    "channel": 5,       # 槽形
+    "cross": 6,         # 十字形
+    "box": 7,           # 箱型          ShapeVal "B,H,U,T,D,F" (等厚: B,H,t,t,t,t)
+    "tube": 8,          # 圆管          ShapeVal "D,d"
+    "double-channel": 9,  # 双槽形
+    "cross-I": 10,      # 十字工
+    "trapezoid": 11,    # 梯形
+    "L": 28,            # L形 (角钢)
+    "T": 29,            # T形
+    # --- 组合 / 劲性 / 钢管混凝土 ---
+    "CFT": 12,          # 钢管混凝土
+    "SRC-I": 13,        # 工字劲
+    "SRC-box": 14,      # 箱形劲
+    "CFT-square": -14,  # 方管混凝土
+    "SRC-cross": 15,    # 十字劲
+    "steel-cap": 24,    # 带盖板钢组合截面
+    "composite": 25,    # 组合截面
+    # --- 变截面 ---
+    "tapered-rect": 21,     # 矩形变截面
+    "tapered-H": 22,        # H形变截面
+    "tapered-box": 23,      # 箱形变截面
+    "tapered-polygon": 33,  # 正多边形变截面
+    "tapered-SRC-I": 52,    # 工字劲变截面
+    # --- 型钢库 / 薄壁 / 铝合金 ---
+    "standard": 26,     # 型钢 (热轧库截面, ShapeVal="", name=规格名)
+    "cold-formed": 303, # 薄壁型钢
+    "cold-formed-composite": 304,  # 薄壁型钢组合
+    "aluminum": 306,    # 铝合金梁截面
+}
+
+
+def _get_floor_loads(story: dict) -> tuple[float, float]:
+    """Extract dead and live load values from a V2 story dict."""
+    dead = 5.0
+    live = 2.0
+    for fl in story.get("floor_loads", []):
+        if fl.get("type") == "dead":
+            dead = float(fl["value"])
+        elif fl.get("type") == "live":
+            live = float(fl["value"])
+    return dead, live
+
+
+def _infer_section_roles(data: dict) -> dict[str, str]:
+    """Build {section_id: "column"|"beam"} by scanning element types."""
+    roles: dict[str, str] = {}
+    for elem in data.get("elements", []):
+        sec_id = elem.get("section", "")
+        etype = elem.get("type", "beam")
+        if etype == "column" and roles.get(sec_id) != "column":
+            roles[sec_id] = "column"
+        elif sec_id not in roles:
+            roles[sec_id] = "beam"
+    return roles
+
+
+def _resolve_mat_type(sec: dict, data: dict) -> int:
+    """Determine YJK material type integer for a section."""
+    props = sec.get("properties", {})
+    if "mat" in props:
+        return int(props["mat"])
+
+    mat_map: dict[str, dict] = {m["id"]: m for m in data.get("materials", [])}
+    for elem in data.get("elements", []):
+        if elem.get("section") == sec["id"]:
+            mat = mat_map.get(elem.get("material", ""))
+            if mat:
+                cat = mat.get("category", "steel")
+                return _CATEGORY_TO_MAT.get(cat, 6)
+            break
+    return 5
+
+
+# --- Precise H-section lookup table (GB/T 11263 hot-rolled H-beams) ---
+# (H, B, tw, tf) in mm.
+_H_SECTION_DIMS: dict[str, tuple[int, int, int, int]] = {
+    # HW 宽翼缘 (H≈B)
+    "HW100X100": (100, 100, 6, 8),
+    "HW125X125": (125, 125, 6, 9),
+    "HW150X150": (150, 150, 7, 10),
+    "HW175X175": (175, 175, 7, 11),
+    "HW200X200": (200, 200, 8, 12),
+    "HW250X250": (250, 250, 9, 14),
+    "HW300X300": (300, 300, 10, 15),
+    "HW350X350": (350, 350, 12, 19),
+    "HW400X400": (400, 400, 13, 21),
+    # HN 窄翼缘
+    "HN150X75":  (150, 75, 5, 7),
+    "HN200X100": (200, 100, 5, 8),
+    "HN250X125": (250, 125, 6, 9),
+    "HN300X150": (300, 150, 6, 9),
+    "HN350X175": (350, 175, 7, 11),
+    "HN400X200": (400, 200, 8, 13),
+    "HN450X200": (450, 200, 9, 14),
+    "HN500X200": (500, 200, 10, 16),
+    "HN600X200": (600, 200, 11, 17),
+    "HN700X300": (700, 300, 13, 24),
+    "HN800X300": (800, 300, 14, 26),
+    "HN900X300": (900, 300, 16, 28),
+    # HM 中翼缘
+    "HM200X150": (200, 150, 6, 9),
+    "HM250X175": (250, 175, 7, 11),
+    "HM300X200": (300, 200, 8, 12),
+    "HM350X250": (350, 250, 9, 14),
+    "HM400X300": (400, 300, 10, 16),
+    "HM450X300": (450, 300, 11, 18),
+    "HM500X300": (500, 300, 11, 15),
+    "HM600X300": (600, 300, 12, 17),
+}
+
+
+def _build_shape_val(sec: dict, kind: int) -> tuple[int, str, str]:
+    """Return (kind, ShapeVal, name) for a V2 section dict.
+
+    Priority:
+      1. standard_steel_name -> lookup in _H_SECTION_DIMS for exact geometry,
+         fallback to kind=26 library name
+      2. properties with detailed geometry -> build ShapeVal per kind
+      3. top-level width/height -> rectangular fallback (kind=1)
+
+    ShapeVal formats (YJK 8.0, verified from SDK examples):
+      kind=1  矩形:     "B,H"
+      kind=2  工字形:    "tw,H,B,tf1,B2,tf2"
+      kind=3  圆形:     "D"
+      kind=7  箱型:     "B,H,U,T,D,F" (等厚时 "B,H,t,t,t,t")
+      kind=8  圆管:     "D,d" (外径,内径)
+      kind=26 型钢库:   ShapeVal="", name=规格名
+    """
+    import re
+
+    props = sec.get("properties", {})
+    extra = sec.get("extra", {})
+
+    std_name = (
+        props.get("standard_steel_name")
+        or extra.get("standard_steel_name")
+        or ""
+    )
+
+    if std_name:
+        normalized_name = std_name.upper().replace("\u00d7", "X").replace("x", "X")
+        # Try exact lookup first
+        dims = _H_SECTION_DIMS.get(normalized_name)
+        if dims:
+            H, B, tw, tf = dims
+            return 2, f"{tw},{H},{B},{tf},{B},{tf}", ""
+
+        # Try regex parse for names not in the table
+        hw_match = re.match(r"^(HW|HN|HM|HP|HT)(\d+)[Xx\u00d7](\d+)", std_name, re.IGNORECASE)
+        if hw_match:
+            prefix = hw_match.group(1).upper()
+            H = int(hw_match.group(2))
+            B = int(hw_match.group(3))
+            if prefix == "HW":
+                tw = max(8, H // 30)
+                tf = max(12, H // 20)
+            elif prefix == "HN":
+                tw = max(6, H // 40)
+                tf = max(9, H // 30)
+            else:
+                tw = max(7, H // 35)
+                tf = max(11, H // 25)
+            return 2, f"{tw},{H},{B},{tf},{B},{tf}", ""
+
+        # Unrecognized standard name -> try kind=26 library lookup
+        return 26, "", str(std_name)
+
+    # PKPM-style shape dict
+    shape = props.get("shape") or sec.get("shape")
+    if isinstance(shape, dict):
+        sk = shape.get("kind", "")
+        if sk in ("H", "I") or kind == 2:
+            tw = shape.get("tw", 10)
+            H = shape.get("H", sec.get("height", 400))
+            B1 = shape.get("B1", shape.get("B", sec.get("width", 200)))
+            tf1 = shape.get("tf1", shape.get("tf", 14))
+            B2 = shape.get("B2", B1)
+            tf2 = shape.get("tf2", tf1)
+            return 2, f"{int(tw)},{int(H)},{int(B1)},{int(tf1)},{int(B2)},{int(tf2)}", ""
+        if sk == "Box" or kind == 7:
+            # kind=7 箱型: ShapeVal "B,H,U,T,D,F" (等厚时后四项相同)
+            H = shape.get("H", sec.get("height", 400))
+            B = shape.get("B", sec.get("width", 400))
+            t = shape.get("T", shape.get("t", 20))
+            U = shape.get("U", t)
+            T_val = shape.get("T_bottom", t)
+            D = shape.get("D", t)
+            F = shape.get("F", t)
+            return 7, f"{int(B)},{int(H)},{int(U)},{int(T_val)},{int(D)},{int(F)}", ""
+        if sk == "Tube" or kind == 8:
+            D = shape.get("D", 200)
+            d = shape.get("d", D - 20)
+            return 8, f"{int(D)},{int(d)}", ""
+
+    # --- Build ShapeVal from properties by kind ---
+    if kind == 2:
+        tw = props.get("tw", 10)
+        H = props.get("H", sec.get("height", 400))
+        B1 = props.get("B1", props.get("B", sec.get("width", 200)))
+        tf1 = props.get("tf1", props.get("tf", 14))
+        B2 = props.get("B2", B1)
+        tf2 = props.get("tf2", tf1)
+        return 2, f"{int(tw)},{int(H)},{int(B1)},{int(tf1)},{int(B2)},{int(tf2)}", ""
+
+    if kind == 7:
+        # 箱型: "B,H,U,T,D,F"
+        H = props.get("H", sec.get("height", 400))
+        B = props.get("B", sec.get("width", 400))
+        t = props.get("t", props.get("T", 20))
+        return 7, f"{int(B)},{int(H)},{int(t)},{int(t)},{int(t)},{int(t)}", ""
+
+    if kind == 8:
+        D = props.get("D", sec.get("diameter", 200))
+        d = props.get("d", D - 20 if D else 180)
+        return 8, f"{int(D)},{int(d)}", ""
+
+    if kind == 3:
+        D = sec.get("diameter") or props.get("D", 400)
+        return 3, f"{int(D)}", ""
+
+    # Fallback: rectangular (kind=1) "B,H"
+    w = sec.get("width") or props.get("B", 400)
+    h = sec.get("height") or props.get("H", 600)
+    return 1, f"{int(w)},{int(h)}", sec.get("name", "")
+
+
+def _extract_grid_spans(nodes: list[dict]) -> tuple[list[int], list[int]]:
+    """Derive axis-grid span arrays from V2 node coordinates (meters -> mm)."""
+    xs: set[float] = set()
+    ys: set[float] = set()
+    for n in nodes:
+        xs.add(round(float(n["x"]) * M_TO_MM, 1))
+        ys.add(round(float(n["y"]) * M_TO_MM, 1))
+
+    sorted_x = sorted(xs)
+    sorted_y = sorted(ys)
+
+    if len(sorted_x) < 2 or len(sorted_y) < 2:
+        raise ValueError(
+            f"Need at least 2 unique X and 2 unique Y coordinates, "
+            f"got {len(sorted_x)} X and {len(sorted_y)} Y"
+        )
+
+    xspans = [int(sorted_x[0])]
+    for i in range(1, len(sorted_x)):
+        xspans.append(int(round(sorted_x[i] - sorted_x[i - 1])))
+
+    yspans = [int(sorted_y[0])]
+    for i in range(1, len(sorted_y)):
+        yspans.append(int(round(sorted_y[i] - sorted_y[i - 1])))
+
+    return xspans, yspans
+
+
+def convert_v2_to_ydb(
+    data: dict[str, Any],
+    work_dir: str,
+    ydb_filename: str = "model.ydb",
+) -> str:
+    """Convert a V2 StructureModelV2 JSON dict to a YJK .ydb file.
+
+    Returns the absolute path to the generated .ydb.
+    """
+    import sys
+    def _log(msg: str) -> None:
+        print(f"[yjk_converter] {msg}", file=sys.stderr, flush=True)
+
+    os.makedirs(work_dir, exist_ok=True)
+    warnings: list[str] = []
+
+    stories = sorted(
+        data.get("stories", []),
+        key=lambda s: float(s.get("elevation", 0)),
+    )
+    if not stories:
+        raise ValueError("V2 model has no stories defined")
+
+    first_story = stories[0]
+    height_mm = int(round(float(first_story["height"]) * M_TO_MM))
+    dead, live = _get_floor_loads(first_story)
+    _log(f"Story height: {height_mm}mm, dead={dead}, live={live}")
+
+    data_func = DataFunc()
+    std_flr = data_func.StdFlr_Generate(height_mm, dead, live)
+    _log(f"StdFlr_Generate returned: {std_flr}")
+
+    section_roles = _infer_section_roles(data)
+    _log(f"Section roles: {section_roles}")
+
+    col_defs: dict[str, Any] = {}
+    beam_defs: dict[str, Any] = {}
+
+    for sec in data.get("sections", []):
+        sec_id = sec["id"]
+        role = section_roles.get(sec_id, "beam")
+
+        sec_type_str = sec.get("type", "rectangular")
+        kind = _TYPE_TO_KIND.get(sec_type_str, 1)
+        mat = _resolve_mat_type(sec, data)
+
+        kind, shape_val, name = _build_shape_val(sec, kind)
+        _log(f"Section '{sec_id}' ({role}): mat={mat}, kind={kind}, shape_val='{shape_val}', name='{name}'")
+
+        try:
+            if role == "column":
+                result = data_func.ColSect_Def(mat, kind, shape_val, name)
+                col_defs[sec_id] = result
+                _log(f"  ColSect_Def returned: {result}")
+            else:
+                result = data_func.BeamSect_Def(mat, kind, shape_val, name)
+                beam_defs[sec_id] = result
+                _log(f"  BeamSect_Def returned: {result}")
+        except Exception as exc:
+            _log(f"  ERROR: Section '{sec_id}' definition failed: {exc}")
+            warnings.append(f"Section '{sec_id}' definition failed: {exc}")
+
+    if not col_defs:
+        _log("WARNING: No column sections defined; using fallback")
+        # mat=5 (steel), kind=2 (H-section), ShapeVal: tw=20,H=650,B=400,tf1=28,B2=400,tf2=28
+        col_defs["_fallback_col"] = data_func.ColSect_Def(5, 2, "20,650,400,28,400,28", "Fallback Column")
+        warnings.append("No column sections defined; using default steel I-section")
+    if not beam_defs:
+        _log("WARNING: No beam sections defined; using fallback")
+        # mat=5 (steel), kind=2 (H-section), ShapeVal: tw=18,H=900,B=300,tf1=26,B2=300,tf2=26
+        beam_defs["_fallback_beam"] = data_func.BeamSect_Def(5, 2, "18,900,300,26,300,26", "Fallback Beam")
+        warnings.append("No beam sections defined; using default steel I-section")
+
+    nodes = data.get("nodes", [])
+    if not nodes:
+        raise ValueError("V2 model has no nodes")
+
+    xspans, yspans = _extract_grid_spans(nodes)
+    _log(f"Grid spans: xspans={xspans}, yspans={yspans}")
+
+    nodelist = data_func.node_generate(xspans, yspans, std_flr)
+    _log(f"node_generate returned: {nodelist} (type: {type(nodelist)})")
+
+    first_col = next(iter(col_defs.values()))
+    _log(f"Arranging columns with section: {first_col}")
+    # NOTE: YJK DataFunc.column_arrange / beam_arrange applies one section to all
+    # members in the grid at once.  Per-element section assignment is not supported
+    # by this API level; the first defined section is used as the representative
+    # section for the whole building.  Models with multiple distinct sections will
+    # have their primary section applied uniformly here.
+    try:
+        col_result = data_func.column_arrange(nodelist, first_col)
+        _log(f"column_arrange returned: {col_result}")
+    except Exception as exc:
+        _log(f"ERROR: column_arrange failed: {exc}")
+        raise
+
+    first_beam = next(iter(beam_defs.values()))
+    _log(f"Arranging beams with section: {first_beam}")
+    # Same API constraint as columns above — one section per grid arrangement call.
+    try:
+        grid_x = data_func.grid_generate(nodelist, 0, 1)
+        _log(f"grid_generate(0,1) returned: {grid_x}")
+        grid_y = data_func.grid_generate(nodelist, 1, 0)
+        _log(f"grid_generate(1,0) returned: {grid_y}")
+        beam_x_result = data_func.beam_arrange(grid_x, first_beam)
+        _log(f"beam_arrange(grid_x) returned: {beam_x_result}")
+        beam_y_result = data_func.beam_arrange(grid_y, first_beam)
+        _log(f"beam_arrange(grid_y) returned: {beam_y_result}")
+    except Exception as exc:
+        _log(f"ERROR: beam arrangement failed: {exc}")
+        raise
+
+    # Assemble floors story by story to support varying story heights.
+    # Each story gets its own StdFlr with the correct height and loads.
+    # If all stories share the same height the loop degenerates to a single call.
+    for i, story in enumerate(stories):
+        s_height_mm = int(round(float(story.get("height", first_story["height"])) * M_TO_MM))
+        if s_height_mm <= 0:
+            s_height_mm = height_mm
+        s_dead, s_live = _get_floor_loads(story)
+        s_flr = data_func.StdFlr_Generate(s_height_mm, s_dead, s_live) if (
+            s_height_mm != height_mm or s_dead != dead or s_live != live
+        ) else std_flr
+        _log(f"Assembling floor {i + 1}/{len(stories)}: height={s_height_mm}mm, dead={s_dead}, live={s_live}")
+        try:
+            data_func.Floors_Assemb(i, s_flr, 1, s_height_mm)
+        except Exception as exc:
+            _log(f"ERROR: Floors_Assemb failed for story {i + 1}: {exc}")
+            raise
+    _log("Floors_Assemb completed")
+
+    _log("Assigning model to database...")
+    try:
+        data_func.DbModel_Assign()
+        _log("DbModel_Assign completed")
+    except Exception as exc:
+        _log(f"ERROR: DbModel_Assign failed: {exc}")
+        raise
+
+    _log("Getting model data...")
+    model = data_func.GetDbModelData()
+    _log(f"GetDbModelData returned: {model}")
+
+    _log(f"Creating YDB file: {ydb_filename}")
+    reader = Hi_AddToAndReadYjk(model)
+    reader.CreateYDB(work_dir, ydb_filename)
+
+    ydb_path = os.path.join(work_dir, ydb_filename)
+    _log(f"YDB file created: {ydb_path}")
+    return ydb_path

--- a/backend/src/agent-skills/analysis/yjk-static/yjk_converter.py
+++ b/backend/src/agent-skills/analysis/yjk-static/yjk_converter.py
@@ -67,6 +67,8 @@ _TYPE_TO_KIND: dict[str, int] = {
     "tube": 8,          # 圆管          ShapeVal "D,d"
     "pipe": 8,          # V2 alias for circular hollow section
     "hollow-circular": 8,  # V2 alias for circular hollow section
+    "pipe": 8,          # V2 alias for circular hollow section
+    "hollow-circular": 8,  # V2 alias for circular hollow section
     "double-channel": 9,  # 双槽形
     "cross-I": 10,      # 十字工
     "trapezoid": 11,    # 梯形

--- a/backend/src/agent-skills/analysis/yjk-static/yjk_converter.py
+++ b/backend/src/agent-skills/analysis/yjk-static/yjk_converter.py
@@ -65,6 +65,8 @@ _TYPE_TO_KIND: dict[str, int] = {
     "cross": 6,         # 十字形
     "box": 7,           # 箱型          ShapeVal "B,H,U,T,D,F" (等厚: B,H,t,t,t,t)
     "tube": 8,          # 圆管          ShapeVal "D,d"
+    "pipe": 8,          # V2 alias for circular hollow section
+    "hollow-circular": 8,  # V2 alias for circular hollow section
     "double-channel": 9,  # 双槽形
     "cross-I": 10,      # 十字工
     "trapezoid": 11,    # 梯形
@@ -195,8 +197,9 @@ def _build_shape_val(sec: dict, kind: int) -> tuple[int, str, str]:
     extra = sec.get("extra", {})
 
     std_name = (
-        props.get("standard_steel_name")
-        or extra.get("standard_steel_name")
+        sec.get("standard_steel_name")       # V2 canonical top-level field
+        or props.get("standard_steel_name")  # legacy: written into properties
+        or extra.get("standard_steel_name")  # extra dict fallback
         or ""
     )
 

--- a/backend/src/agent-skills/analysis/yjk-static/yjk_driver.py
+++ b/backend/src/agent-skills/analysis/yjk-static/yjk_driver.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+"""YJK analysis driver -- subprocess entry point.
+
+Must run under YJK's bundled Python 3.10.  Do NOT add extra CLI
+arguments; YJKAPI uses sys.argv[1] for internal state and will
+break if unexpected args are present.
+
+Usage (called by runtime.py via subprocess):
+    <YJK_PYTHON> yjk_driver.py <model.json> <work_dir>
+
+Reads the V2 model JSON, converts to .ydb, launches YJK GUI, runs a
+full static analysis, extracts structured results via yjks_pyload,
+and outputs the combined result JSON to stdout.
+
+The sequence below strictly follows the proven three_story_steel_frame.py
+pattern from the YJK SDK.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import traceback
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _emit_json(payload: dict) -> None:
+    """Write the final result JSON to stdout (the ONLY stdout we produce).
+
+    Flush stderr first so any YJKAPI noise that leaked to stdout is
+    already written, then write our JSON on its own line.
+    """
+    sys.stderr.flush()
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def _error(message: str) -> None:
+    _emit_json({
+        "status": "error",
+        "summary": {"engine": "yjk-static"},
+        "data": {},
+        "detailed": {"error": message},
+        "warnings": [message],
+    })
+
+
+def _setup_paths() -> str:
+    """Set up sys.path and os.environ["PATH"] for YJK.
+
+    Returns the resolved YJKS_ROOT directory.
+    """
+    yjks_root = os.environ.get(
+        "YJKS_ROOT",
+        os.environ.get("YJK_PATH", r"D:\YJKS\YJKS_8_0_0"),
+    ).strip().strip('"')
+
+    yjks_exe_env = os.environ.get("YJKS_EXE", "").strip().strip('"')
+    if yjks_exe_env and os.path.isfile(yjks_exe_env):
+        root = os.path.dirname(os.path.abspath(yjks_exe_env))
+    elif os.path.isdir(yjks_root):
+        root = yjks_root
+    else:
+        root = yjks_root
+
+    # DLL search path
+    os.environ["PATH"] = root + os.pathsep + os.environ.get("PATH", "")
+
+    # Python import paths: YJKS_ROOT itself (for native wrappers) and
+    # the driver's own directory (for yjk_converter).
+    for p in (root, SCRIPT_DIR):
+        if p and p not in sys.path:
+            sys.path.insert(0, p)
+
+    return root
+
+
+def _find_yjks_exe(root: str) -> str | None:
+    for name in ("yjks.exe", "YJKS.exe"):
+        p = os.path.join(root, name)
+        if os.path.isfile(p):
+            return p
+    return None
+
+
+def _run_cmd(cmd: str, arg: str = "") -> bool:
+    """Execute a YJK command and return success status.
+
+    Returns True if the command succeeded, False if YJK is no longer running.
+    """
+    from YJKAPI import YJKSControl
+    print(f"[yjk_driver] RunCmd({cmd!r}, {arg!r})", file=sys.stderr, flush=True)
+    try:
+        YJKSControl.RunCmd(cmd, arg)
+        # Check if YJK is still running after the command
+        if not _is_yjk_running():
+            print(f"[yjk_driver] WARNING: YJK process terminated after {cmd}", file=sys.stderr, flush=True)
+            return False
+        return True
+    except Exception as exc:
+        print(f"[yjk_driver] ERROR in RunCmd({cmd}): {exc}", file=sys.stderr, flush=True)
+        return False
+
+
+def _is_yjk_running() -> bool:
+    """Check if the YJK process is still running."""
+    import subprocess
+    try:
+        # Use tasklist to check if yjks.exe is running
+        result = subprocess.run(
+            ["tasklist", "/FI", "IMAGENAME eq yjks.exe"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return "yjks.exe" in result.stdout.lower()
+    except Exception:
+        return True  # Assume running if we can't check
+
+
+def _collect_out_files(work_dir: str) -> str:
+    """Read .OUT/.out files under work_dir as fallback result text."""
+    lines: list[str] = []
+    for dirpath, _dirs, files in os.walk(work_dir):
+        for f in sorted(files):
+            if f.upper().endswith(".OUT"):
+                fp = os.path.join(dirpath, f)
+                try:
+                    text = open(fp, encoding="gbk", errors="replace").read()
+                    lines.append(f"=== {f} ===\n{text[:3000]}")
+                except Exception:
+                    pass
+    return "\n\n".join(lines) if lines else "(no .OUT files found)"
+
+
+def main() -> int:
+    # -- Parse arguments ------------------------------------------------
+    if len(sys.argv) < 3:
+        _error("Usage: yjk_driver.py <model.json> <work_dir>")
+        return 1
+
+    model_path = sys.argv[1]
+    work_dir = sys.argv[2]
+
+    # Strip our arguments so YJKAPI sees no stray sys.argv[1]
+    sys.argv = [sys.argv[0]]
+
+    yjks_root = _setup_paths()
+
+    try:
+        return _run(model_path, work_dir, yjks_root)
+    except Exception:
+        _error(f"Unhandled exception in yjk_driver:\n{traceback.format_exc()}")
+        return 1
+
+
+def _run(model_path: str, work_dir: str, yjks_root: str) -> int:
+    # -- Import YJKAPI (requires sys.path set up by _setup_paths) ------
+    # Redirect stdout during import so any YJKAPI banner/init messages
+    # go to stderr and don't corrupt our JSON output channel.
+    import io
+    _real_stdout = sys.stdout
+    sys.stdout = io.TextIOWrapper(sys.stderr.buffer, encoding=sys.stderr.encoding or "utf-8")
+    try:
+        from YJKAPI import ControlConfig, YJKSControl
+    finally:
+        sys.stdout = _real_stdout
+
+    # -- Read V2 model JSON ---------------------------------------------
+    with open(model_path, "r", encoding="utf-8") as f:
+        model_data = json.load(f)
+
+    project = model_data.get("project")
+    project_name = (
+        project.get("name", "sc_model") if isinstance(project, dict) else "sc_model"
+    ) or "sc_model"
+    ydb_filename = f"{project_name}.ydb"
+
+    # -- Phase 1: Convert V2 -> .ydb ------------------------------------
+    print("[yjk_driver] Phase 1: V2 -> YDB conversion", file=sys.stderr, flush=True)
+    from yjk_converter import convert_v2_to_ydb
+
+    try:
+        ydb_path = convert_v2_to_ydb(model_data, work_dir, ydb_filename)
+    except Exception as exc:
+        _error(f"V2 -> YDB conversion failed: {exc}")
+        return 1
+    print(f"[yjk_driver] ydb_path = {ydb_path}", file=sys.stderr, flush=True)
+
+    # -- Phase 2: Launch YJK (control.py test01 pattern) ----------------
+    yjks_exe_env = os.environ.get("YJKS_EXE", "").strip().strip('"')
+    yjks_exe = (
+        yjks_exe_env if yjks_exe_env and os.path.isfile(yjks_exe_env)
+        else _find_yjks_exe(yjks_root)
+    )
+    if not yjks_exe or not os.path.isfile(yjks_exe):
+        _error(f"yjks.exe not found (YJKS_ROOT={yjks_root})")
+        return 1
+
+    version = os.environ.get("YJK_VERSION", "8.0.0").strip()
+
+    # Default: show the YJK GUI so the user can observe the full workflow.
+    # Set YJK_INVISIBLE=1 in .env to run fully headless (CI / unattended).
+    cfg = ControlConfig()
+    cfg.Version = version
+    cfg.Invisible = os.environ.get("YJK_INVISIBLE", "0").strip() == "1"
+    YJKSControl.initConfig(cfg)
+
+    print(f"[yjk_driver] Phase 2: RunYJK({yjks_exe})", file=sys.stderr, flush=True)
+    msg = YJKSControl.RunYJK(yjks_exe)
+    print(f"[yjk_driver] RunYJK returned: {msg}", file=sys.stderr, flush=True)
+
+    # -- Phase 3: Open/create project + import ydb ----------------------
+    project_dir = os.path.dirname(os.path.abspath(ydb_path))
+    yjk_project = os.path.join(project_dir, f"{project_name}.yjk")
+
+    print(f"[yjk_driver] Phase 3: project = {yjk_project}", file=sys.stderr, flush=True)
+    if os.path.isfile(yjk_project):
+        if not _run_cmd("UIOpen", yjk_project):
+            _error("YJK crashed while opening project")
+            return 1
+    else:
+        if not _run_cmd("UINew", yjk_project):
+            _error("YJK crashed while creating new project")
+            return 1
+
+    if not _run_cmd("yjk_importydb", ydb_path):
+        _error("YJK crashed while importing YDB file - the model may have invalid geometry or sections")
+        return 1
+
+    # -- Phase 4: Model preparation (exact three_story_steel_frame.py) --
+    print("[yjk_driver] Phase 4: model repair / prep", file=sys.stderr, flush=True)
+    if not _run_cmd("yjk_repair"):
+        _error("YJK crashed during model repair")
+        return 1
+    if not _run_cmd("yjk_save"):
+        _error("YJK crashed during save")
+        return 1
+    if not _run_cmd("yjk_formslab_alllayer"):
+        _error("YJK crashed during slab formation")
+        return 1
+    if not _run_cmd("yjk_setlayersupport"):
+        _error("YJK crashed during layer support setup")
+        return 1
+
+    # -- Phase 5: Preprocessing + full analysis -------------------------
+    print("[yjk_driver] Phase 5: preprocessing + calculation", file=sys.stderr, flush=True)
+    if not _run_cmd("yjkspre_genmodrel"):
+        _error("YJK crashed during model relation generation")
+        return 1
+    if not _run_cmd("yjktransload_tlplan"):
+        _error("YJK crashed during plan load transfer")
+        return 1
+    if not _run_cmd("yjktransload_tlvert"):
+        _error("YJK crashed during vertical load transfer")
+        return 1
+    if not _run_cmd("SetCurrentLabel", "IDSPRE_ROOT"):
+        _error("YJK crashed during label switch")
+        return 1
+    if not _run_cmd("yjkdesign_dsncalculating_all"):
+        _error("YJK crashed during design calculation - this often happens when the model has no valid structural data or missing sections")
+        return 1
+    if not _run_cmd("SetCurrentLabel", "IDDSN_DSP"):
+        _error("YJK crashed during final label switch")
+        return 1
+
+    print("[yjk_driver] Phase 5 complete: analysis finished", file=sys.stderr, flush=True)
+
+    # -- Phase 6: Skip result extraction for now -------------------------
+    # TODO: implement structured result extraction via yjks_pyload
+    print("[yjk_driver] Phase 6: result extraction skipped (not yet implemented)", file=sys.stderr, flush=True)
+
+    # -- Phase 7: Build final output ------------------------------------
+    warnings: list[str] = []
+    warnings.append("Structured result extraction not yet implemented; returning .OUT files as fallback")
+
+    output: dict = {
+        "status": "success",
+        "summary": {
+            "engine": "yjk-static",
+            "ydb_path": ydb_path,
+            "yjk_project": yjk_project,
+            "work_dir": work_dir,
+        },
+        "data": {},
+        "detailed": {"raw_output": _collect_out_files(work_dir)},
+        "warnings": warnings,
+    }
+
+    _emit_json(output)
+    print("[yjk_driver] done", file=sys.stderr, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/src/agent-skills/analysis/yjk-static/yjk_driver.py
+++ b/backend/src/agent-skills/analysis/yjk-static/yjk_driver.py
@@ -9,8 +9,8 @@ Usage (called by runtime.py via subprocess):
     <YJK_PYTHON> yjk_driver.py <model.json> <work_dir>
 
 Reads the V2 model JSON, converts to .ydb, launches YJK GUI, runs a
-full static analysis, extracts structured results via yjks_pyload,
-and outputs the combined result JSON to stdout.
+full static analysis, collects available .OUT text as fallback result
+content, and outputs the final result JSON to stdout.
 
 The sequence below strictly follows the proven three_story_steel_frame.py
 pattern from the YJK SDK.

--- a/backend/src/agent-skills/structure-type/frame/model.ts
+++ b/backend/src/agent-skills/structure-type/frame/model.ts
@@ -30,7 +30,7 @@ const H_SECTION_PROPERTIES: Record<string, { A: number; Iy: number; Iz: number; 
 };
 
 type SteelGradeProps = { E: number; G: number; nu: number; rho: number; fy: number };
-type SectionProps = { name: string; A: number; Iy: number; Iz: number; J: number; G: number };
+type SectionProps = { name: string; A: number; Iy: number; Iz: number; J: number; G: number; substituted?: string };
 
 export function getDefaultColumnSection(storyCount: number): string {
   if (storyCount > 10) return 'HW400X400';
@@ -64,13 +64,15 @@ function resolveSectionProps(
   role: 'column' | 'beam',
   storyCount: number,
   matG: number,
-): SectionProps {
+): SectionProps & { substituted?: string } {
   const defaultSection = role === 'column'
     ? getDefaultColumnSection(storyCount)
     : getDefaultBeamSection(storyCount);
   const normalized = section ? normalizeSectionName(section) : defaultSection;
-  const sectionKey = H_SECTION_PROPERTIES[normalized] ? normalized : defaultSection;
-  return { name: sectionKey, ...H_SECTION_PROPERTIES[sectionKey]!, G: matG };
+  const found = Boolean(H_SECTION_PROPERTIES[normalized]);
+  const sectionKey = found ? normalized : defaultSection;
+  const substituted = (section && !found) ? `${normalized} not in builtin library, substituted with ${sectionKey}` : undefined;
+  return { name: sectionKey, ...H_SECTION_PROPERTIES[sectionKey]!, G: matG, substituted };
 }
 
 function accumulateCoords(lengths: number[]): number[] {
@@ -170,6 +172,9 @@ function buildFrame2dLocalModel(
       storyCount: storyHeights.length,
       bayCount: bayWidths.length,
       geometry: { storyHeightsM: storyHeights, bayWidthsM: bayWidths },
+      ...(colProps.substituted || beamProps.substituted ? {
+        sectionSubstitutions: [colProps.substituted, beamProps.substituted].filter(Boolean),
+      } : {}),
     },
   };
 }
@@ -271,6 +276,9 @@ function buildFrame3dLocalModel(
       bayCountX: bayWidthsX.length,
       bayCountY: bayWidthsY.length,
       geometry: { storyHeightsM: storyHeights, bayWidthsXM: bayWidthsX, bayWidthsYM: bayWidthsY },
+      ...(colProps.substituted || beamProps.substituted ? {
+        sectionSubstitutions: [colProps.substituted, beamProps.substituted].filter(Boolean),
+      } : {}),
     },
   };
 }

--- a/backend/src/agent-skills/structure-type/frame/model.ts
+++ b/backend/src/agent-skills/structure-type/frame/model.ts
@@ -64,7 +64,7 @@ function resolveSectionProps(
   role: 'column' | 'beam',
   storyCount: number,
   matG: number,
-): SectionProps & { substituted?: string } {
+): SectionProps {
   const defaultSection = role === 'column'
     ? getDefaultColumnSection(storyCount)
     : getDefaultBeamSection(storyCount);

--- a/backend/tests/analysis-skill-registry.test.mjs
+++ b/backend/tests/analysis-skill-registry.test.mjs
@@ -38,15 +38,18 @@ describe('analysis skill registry', () => {
   });
 
   test('should derive runtime adapter keys from builtin analysis engines', () => {
-    expect(BUILTIN_ANALYSIS_ENGINES.map((engine) => engine.id)).toEqual([
-      'builtin-opensees',
-      'builtin-simplified',
-    ]);
-    expect(BUILTIN_ANALYSIS_RUNTIME_ADAPTER_KEYS).toEqual([
-      'builtin-opensees',
-      'builtin-simplified',
-    ]);
-    expect(BUILTIN_ANALYSIS_ENGINES[0].skillIds).toContain('opensees-static');
-    expect(BUILTIN_ANALYSIS_ENGINES[1].skillIds).toContain('simplified-static');
+    const engineIds = BUILTIN_ANALYSIS_ENGINES.map((engine) => engine.id);
+    expect(engineIds).toContain('builtin-opensees');
+    expect(engineIds).toContain('builtin-pkpm');
+    expect(engineIds).toContain('builtin-yjk');
+    expect(engineIds).toContain('builtin-simplified');
+    expect(BUILTIN_ANALYSIS_RUNTIME_ADAPTER_KEYS).toContain('builtin-opensees');
+    expect(BUILTIN_ANALYSIS_RUNTIME_ADAPTER_KEYS).toContain('builtin-pkpm');
+    expect(BUILTIN_ANALYSIS_RUNTIME_ADAPTER_KEYS).toContain('builtin-yjk');
+    expect(BUILTIN_ANALYSIS_RUNTIME_ADAPTER_KEYS).toContain('builtin-simplified');
+    expect(BUILTIN_ANALYSIS_ENGINES.find((e) => e.id === 'builtin-opensees').skillIds).toContain('opensees-static');
+    expect(BUILTIN_ANALYSIS_ENGINES.find((e) => e.id === 'builtin-simplified').skillIds).toContain('simplified-static');
+    expect(BUILTIN_ANALYSIS_ENGINES.find((e) => e.id === 'builtin-yjk').skillIds).toContain('yjk-static');
+    expect(BUILTIN_ANALYSIS_ENGINES.find((e) => e.id === 'builtin-pkpm').skillIds).toContain('pkpm-static');
   });
 });


### PR DESCRIPTION
## Summary

After the manifest-first refactor (#112), YJK and PKPM analysis engines were dropped from the skill loader and engine registry. This PR restores them and fixes several incorrect YJK section mappings.

## Changes

**Engine restoration**
- Add `skill.yaml` for `yjk-static` and `pkpm-static` (required by new manifest-first loader)
- Restore `builtin-yjk` and `builtin-pkpm` in `BUILTIN_ANALYSIS_ENGINES`
- Add `pkpm` and `yjk` to `software` enum in `manifest-schema.ts`

**YJK converter section fixes**
- Fix wrong kind values: box `4->7`, L `6->28`, T `5->29`
- Expand `_TYPE_TO_KIND` from 7 to 30+ entries covering all YJK 8.0 section kinds
- Add `_H_SECTION_DIMS` lookup table (30 GB/T 11263 H-sections) for exact tw/tf
- Fix box ShapeVal: `H,B,T` (3 params) -> `B,H,U,T,D,F` (6 params per YJK SDK)

**Material category detection**
- Replace hardcoded 5-grade list with regex (`Q/S/A` -> steel, `C` -> concrete)

**Frame model**
- Add `sectionSubstitutions` warning in metadata when section falls back to default

## Impacted areas
`backend`  analysis registry, manifest schema, yjk converter, frame model builder

## Verification
- `npm run build --prefix backend`  pass
- Python syntax check on `yjk_converter.py`  pass