### PR TITLE
fix(yjk): update stale intent.md docstring and fix extract_results.py wildcard import

### DIFF
--- a/backend/src/agent-skills/analysis/pkpm-static/intent.md
+++ b/backend/src/agent-skills/analysis/pkpm-static/intent.md
@@ -1,21 +1,3 @@
----
-id: pkpm-static
-zhName: PKPM 静力分析
-enName: PKPM Static Analysis
-zhDescription: 使用 PKPM SATWE 引擎执行静力分析的 skill（需安装 PKPM 及 JWSCYCLE.exe）。
-enDescription: Skill for static analysis using the PKPM SATWE engine (requires PKPM installation and JWSCYCLE.exe).
-software: pkpm
-analysisType: static
-engineId: builtin-pkpm
-adapterKey: builtin-pkpm
-priority: 130
-triggers: ["PKPM 静力分析", "PKPM 计算", "SATWE", "pkpm static", "pkpm analysis"]
-stages: ["analysis"]
-capabilities: ["analysis-policy", "analysis-execution"]
-supportedModelFamilies: ["frame", "generic"]
-autoLoadByDefault: true
-runtimeRelativePath: runtime.py
----
 # PKPM Static Analysis
 
 - `zh`: 当用户要求使用 PKPM 进行结构静力计算、设计验算、施工图生成时使用。需要已安装 PKPM 并配置 `PKPM_CYCLE_PATH` 环境变量。

--- a/backend/src/agent-skills/analysis/yjk-static/extract_results.py
+++ b/backend/src/agent-skills/analysis/yjk-static/extract_results.py
@@ -30,7 +30,7 @@ JSON schema:
 import json
 import os
 
-from YJKAPI import *
+from YJKAPI import YJKSPrePy, YJKSDsnDataPy
 
 LOAD_CASES = [1, 2, 3, 4]
 

--- a/backend/src/agent-skills/analysis/yjk-static/intent.md
+++ b/backend/src/agent-skills/analysis/yjk-static/intent.md
@@ -1,23 +1,5 @@
----
-id: yjk-static
-zhName: YJK 静力分析
-enName: YJK Static Analysis
-zhDescription: 使用 YJK (盈建科) 引擎自动建模并执行静力分析，提取节点位移、构件内力、楼层刚度等结构化结果（需安装 YJK 8.0 并配置 YJKS_ROOT 或 YJK_PATH）。
-enDescription: Automated modeling and static analysis using the YJK engine. Extracts node displacements, member forces, and floor statistics as structured results (requires YJK 8.0 and YJKS_ROOT or YJK_PATH).
-software: yjk
-analysisType: static
-engineId: builtin-yjk
-adapterKey: builtin-yjk
-priority: 125
-triggers: ["YJK 静力分析", "YJK 计算", "盈建科", "yjk static", "yjk analysis"]
-stages: ["analysis"]
-capabilities: ["analysis-policy", "analysis-execution"]
-supportedModelFamilies: ["frame", "generic"]
-autoLoadByDefault: false
-runtimeRelativePath: runtime.py
----
 # YJK Static Analysis
 
-- `zh`: 当用户要求使用 YJK（盈建科）进行结构静力计算、设计验算时使用。自动将 V2 模型转换为 YJK 格式，启动盈建科软件执行建模、前处理、整体计算，并通过 yjks_pyload 提取结构化分析结果（节点位移、构件内力、楼层刚度/受剪承载力）。需要已安装 YJK 8.0 并配置 `YJKS_ROOT` 或 `YJK_PATH` 指向安装根目录（与官方 SDK 示例一致）。
-- `en`: Use when the request asks for YJK-based structural static analysis or design checks. Automatically converts V2 model to YJK format, launches YJK for modeling, preprocessing, and full calculation, then extracts structured results (node displacements, member forces, floor stiffness/shear capacity) via yjks_pyload. Requires YJK 8.0 and `YJKS_ROOT` or `YJK_PATH` pointing to the install root (same convention as the official YJK SDK samples).
+- `zh`: 当用户要求使用 YJK（盈建科）进行结构静力计算、设计验算时使用。自动将 V2 模型转换为 YJK 格式，启动盈建科软件执行建模、前处理、整体计算，并从 .OUT 文本文件提取分析结果。需要已安装 YJK 8.0 并配置 `YJKS_ROOT` 或 `YJK_PATH` 指向安装根目录（与官方 SDK 示例一致）。
+- `en`: Use when the request asks for YJK-based structural static analysis or design checks. Automatically converts V2 model to YJK format, launches YJK for modeling, preprocessing, and full calculation, then extracts results from .OUT text files. Requires YJK 8.0 and `YJKS_ROOT` or `YJK_PATH` pointing to the install root (same convention as the official YJK SDK samples).
 - Runtime: `analysis/yjk-static/runtime.py`


### PR DESCRIPTION
## What changed

1. **yjk-static intent.md**: Removed YAML frontmatter (stage .md files should be content-only per manifest-first refactor #112). Updated description to reflect .OUT text fallback instead of stale `yjks_pyload` structured extraction reference.
2. **extract_results.py**: Replaced `from YJKAPI import *` with explicit `from YJKAPI import YJKSPrePy, YJKSDsnDataPy` for consistency with `yjk_converter.py`.
3. **pkpm-static intent.md**: Removed YAML frontmatter.

## Why

Stale docstring referenced Phase 6 `yjks_pyload` structured extraction which is not yet implemented. Wildcard import was inconsistent with the rest of the codebase.

## Impacted areas

- `backend/src/agent-skills/analysis/yjk-static/intent.md`
- `backend/src/agent-skills/analysis/yjk-static/extract_results.py`
- `backend/src/agent-skills/analysis/pkpm-static/intent.md`

Closes #128
