### PR TITLE
fix(yjk): remove duplicate keys in _TYPE_TO_KIND

### DIFF
--- a/backend/src/agent-skills/analysis/yjk-static/yjk_converter.py
+++ b/backend/src/agent-skills/analysis/yjk-static/yjk_converter.py
@@ -67,8 +67,6 @@ _TYPE_TO_KIND: dict[str, int] = {
     "tube": 8,          # 圆管          ShapeVal "D,d"
     "pipe": 8,          # V2 alias for circular hollow section
     "hollow-circular": 8,  # V2 alias for circular hollow section
-    "pipe": 8,          # V2 alias for circular hollow section
-    "hollow-circular": 8,  # V2 alias for circular hollow section
     "double-channel": 9,  # 双槽形
     "cross-I": 10,      # 十字工
     "trapezoid": 11,    # 梯形


### PR DESCRIPTION
## What changed

Remove duplicate `pipe` and `hollow-circular` entries in `_TYPE_TO_KIND` dict in `yjk_converter.py`.

## Why

- Copy-paste error introduced during PR #123 Copilot review fix. Python silently overwrites duplicate dict keys so functionally no impact, but the dead code is misleading.

## Impacted areas

- `backend/src/agent-skills/analysis/yjk-static/yjk_converter.py` (2 lines removed)

- Closes #126