### PR TITLE
feat(code-check): enhance gb50017 skill with real computation logic

### DIFF
--- a/backend/src/agent-skills/code-check/gb50017/__tests__/test_code_check.py
+++ b/backend/src/agent-skills/code-check/gb50017/__tests__/test_code_check.py
@@ -1,0 +1,550 @@
+"""Unit tests for GB50017-2017 钢结构构件校核模块。
+
+可直接运行: python -m pytest backend/src/agent-skills/code-check/gb50017/__tests__/test_code_check.py
+或: python backend/src/agent-skills/code-check/gb50017/__tests__/test_code_check.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure the skill module is importable
+_SKILL_DIR = str(Path(__file__).resolve().parent.parent)
+if _SKILL_DIR not in sys.path:
+    sys.path.insert(0, _SKILL_DIR)
+
+# Parent code_check.py dir for CodeChecker
+_PARENT_DIR = str(Path(__file__).resolve().parent.parent.parent)
+if _PARENT_DIR not in sys.path:
+    sys.path.insert(0, _PARENT_DIR)
+
+import code_check as gb50017  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mock CodeChecker providing _calc_item / _build_element_result
+# ---------------------------------------------------------------------------
+
+class MockCodeChecker:
+    """Minimal mock that replicates the CodeChecker interface used by check_element."""
+
+    def __init__(self, overrides: Dict[str, Dict[str, float]] | None = None):
+        self._overrides = overrides or {}
+
+    def _resolve_utilization(self, elem_id: str, item_name: str, context: Dict[str, Any]) -> float:
+        per_elem = self._overrides.get(elem_id, {})
+        raw = per_elem.get(item_name)
+        if isinstance(raw, (int, float)):
+            return max(0.0, float(raw))
+        # Read from context (our _ensure_utilization_overrides may have injected)
+        ctx_overrides = context.get('utilizationByElement', {})
+        if isinstance(ctx_overrides, dict):
+            ctx_elem = ctx_overrides.get(elem_id, {})
+            if isinstance(ctx_elem, dict):
+                val = ctx_elem.get(item_name)
+                if isinstance(val, (int, float)):
+                    return max(0.0, float(val))
+        # Deterministic fallback matching parent
+        seed = sum(ord(ch) for ch in f'{elem_id}:{item_name}')
+        return 0.55 + (seed % 40) / 100.0
+
+    def _calc_item(
+        self,
+        elem_id: str,
+        item_name: str,
+        context: Dict[str, Any],
+        clause: str,
+        formula: str,
+        limit: float,
+    ) -> Dict[str, Any]:
+        utilization = self._resolve_utilization(elem_id, item_name, context)
+        return {
+            'item': item_name,
+            'status': 'pass' if utilization <= 1.0 else 'fail',
+            'utilization': round(utilization, 4),
+            'clause': clause,
+            'formula': formula,
+            'inputs': {
+                'demand': round(utilization * limit, 4),
+                'capacity': round(limit, 4),
+                'limit': limit,
+            },
+        }
+
+    def _build_element_result(
+        self,
+        elem_id: str,
+        element_type: str,
+        checks: List[Dict[str, Any]],
+        code_version: str,
+    ) -> Dict[str, Any]:
+        all_items = [item for check in checks for item in check.get('items', [])]
+        controlling = max(all_items, key=lambda i: float(i.get('utilization', 0.0)), default={})
+        all_passed = all(i.get('status') == 'pass' for i in all_items)
+        return {
+            'elementId': elem_id,
+            'elementType': element_type,
+            'status': 'pass' if all_passed else 'fail',
+            'checks': checks,
+            'controlling': {
+                'item': controlling.get('item'),
+                'utilization': controlling.get('utilization', 0.0),
+                'clause': controlling.get('clause'),
+            },
+            'code': code_version,
+        }
+
+
+def _make_beam_element_data(**overrides) -> Dict[str, Any]:
+    """Create a default beam elementData entry."""
+    base = {
+        'type': 'beam',
+        'section': {'A': 5000.0, 'Wnx': 200000.0, 'Wx': 200000.0, 'i': 50.0},
+        'material': {'f': 215.0, 'fv': 125.0, 'fy': 235.0},
+        'forces': {'N': 50000.0, 'V': 30000.0, 'Mx': 30000000.0},
+        'length': 6000.0,
+        'phi': 0.85,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_column_element_data(**overrides) -> Dict[str, Any]:
+    base = {
+        'type': 'column',
+        'section': {'A': 8000.0, 'imin': 40.0, 'i': 40.0, 'b': 200.0, 't': 12.0},
+        'material': {'f': 215.0, 'fv': 125.0},
+        'forces': {'N': 800000.0, 'V': 10000.0},
+        'length': 4000.0,
+        'phi': 0.75,
+        'btLimit': 15.0,
+        'lambdaLimit': 150.0,
+    }
+    base.update(overrides)
+    return base
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+class TestGetRules:
+    def test_returns_correct_code_and_version(self):
+        rules = gb50017.get_rules()
+        assert rules['code'] == 'GB50017'
+        assert rules['version'] == 'v2-member-checks'
+
+    def test_rules_array_non_empty(self):
+        rules = gb50017.get_rules()
+        assert len(rules['rules']) >= 3
+
+    def test_contains_expected_check_categories(self):
+        rules = gb50017.get_rules()
+        names = [r['name'] for r in rules['rules']]
+        assert '强度验算' in names
+        assert '稳定验算' in names
+        assert '刚度验算' in names
+
+    def test_strength_checks_include_normal_shear_equivalent(self):
+        rules = gb50017.get_rules()
+        strength = next(r for r in rules['rules'] if r['name'] == '强度验算')
+        items = [c['item'] for c in strength['checks']]
+        assert '正应力' in items
+        assert '剪应力' in items
+        assert '折算应力' in items
+
+    def test_stability_checks_include_overall_local_axial(self):
+        rules = gb50017.get_rules()
+        stability = next(r for r in rules['rules'] if r['name'] == '稳定验算')
+        items = [c['item'] for c in stability['checks']]
+        assert '整体稳定' in items
+        assert '轴压稳定' in items
+        assert '局部稳定' in items
+
+    def test_stiffness_checks_include_slenderness_deflection(self):
+        rules = gb50017.get_rules()
+        stiffness = next(r for r in rules['rules'] if r['name'] == '刚度验算')
+        items = [c['item'] for c in stiffness['checks']]
+        assert '长细比' in items
+        assert '挠度' in items
+
+
+class TestResolveElementType:
+    def test_beam_from_context(self):
+        ctx = {'elementData': {'B1': {'type': 'beam'}}}
+        assert gb50017._resolve_element_type('B1', ctx) == 'beam'
+
+    def test_column_from_context(self):
+        ctx = {'elementData': {'C1': {'type': 'column'}}}
+        assert gb50017._resolve_element_type('C1', ctx) == 'column'
+
+    def test_brace_from_context(self):
+        ctx = {'elementData': {'X1': {'type': 'brace'}}}
+        assert gb50017._resolve_element_type('X1', ctx) == 'brace'
+
+    def test_column_from_naming_heuristic_col(self):
+        assert gb50017._resolve_element_type('C1-col', {}) == 'column'
+
+    def test_column_from_naming_heuristic_C_prefix(self):
+        # 'C' alone doesn't contain 'col', falls to default beam
+        assert gb50017._resolve_element_type('C-1', {}) == 'beam'
+        # But 'col' in name works
+        assert gb50017._resolve_element_type('C-col-1', {}) == 'column'
+
+    def test_brace_from_naming_heuristic_br_prefix(self):
+        assert gb50017._resolve_element_type('br-1', {}) == 'brace'
+
+    def test_brace_from_naming_heuristic_brace_in_name(self):
+        assert gb50017._resolve_element_type('X1-brace-1', {}) == 'brace'
+
+    def test_default_beam_when_no_data(self):
+        assert gb50017._resolve_element_type('B1', {}) == 'beam'
+
+    def test_default_beam_when_empty_element_data(self):
+        assert gb50017._resolve_element_type('B1', {'elementData': {}}) == 'beam'
+
+
+class TestEnsureUtilizationOverrides:
+    def test_computes_normal_stress(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {
+                'E1': _make_beam_element_data(),
+            },
+        }
+        gb50017._ensure_utilization_overrides('E1', ctx)
+        util = ctx['utilizationByElement']['E1']
+        # N=50000, A=5000 -> sigma=10, f=215 -> utilization=10/215≈0.0465
+        assert '正应力' in util
+        assert util['正应力'] == pytest.approx(50000.0 / 5000.0 / 215.0, abs=0.001)
+
+    def test_computes_shear_stress(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {
+                'E1': _make_beam_element_data(),
+            },
+        }
+        gb50017._ensure_utilization_overrides('E1', ctx)
+        util = ctx['utilizationByElement']['E1']
+        # V=30000, A=5000 -> tau=6, fv=125 -> utilization=6/125=0.048
+        assert '剪应力' in util
+        assert util['剪应力'] == pytest.approx(30000.0 / 5000.0 / 125.0, abs=0.001)
+
+    def test_computes_equivalent_stress(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {
+                'E1': _make_beam_element_data(),
+            },
+        }
+        gb50017._ensure_utilization_overrides('E1', ctx)
+        util = ctx['utilizationByElement']['E1']
+        assert '折算应力' in util
+        sigma = 50000.0 / 5000.0
+        tau = 30000.0 / 5000.0
+        expected = (sigma ** 2 + 3 * tau ** 2) ** 0.5 / 215.0
+        assert util['折算应力'] == pytest.approx(expected, abs=0.001)
+
+    def test_computes_overall_stability(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {
+                'E1': _make_beam_element_data(),
+            },
+        }
+        gb50017._ensure_utilization_overrides('E1', ctx)
+        util = ctx['utilizationByElement']['E1']
+        # Mx=3e7, phi=0.85, Wnx=2e5, f=215 -> 3e7/(0.85*2e5*215)≈0.819
+        assert '整体稳定' in util
+        assert util['整体稳定'] == pytest.approx(30000000.0 / (0.85 * 200000.0 * 215.0), abs=0.001)
+
+    def test_computes_axial_compression_stability(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {
+                'C1': _make_column_element_data(),
+            },
+        }
+        gb50017._ensure_utilization_overrides('C1', ctx)
+        util = ctx['utilizationByElement']['C1']
+        # N=8e5, phi=0.75, A=8000, f=215 -> 8e5/(0.75*8000*215)≈0.620
+        assert '轴压稳定' in util
+        assert util['轴压稳定'] == pytest.approx(800000.0 / (0.75 * 8000.0 * 215.0), abs=0.001)
+
+    def test_caller_override_not_overwritten(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {
+                'E1': _make_beam_element_data(),
+            },
+            'utilizationByElement': {
+                'E1': {'正应力': 0.73},
+            },
+        }
+        gb50017._ensure_utilization_overrides('E1', ctx)
+        # Caller override should remain
+        assert ctx['utilizationByElement']['E1']['正应力'] == 0.73
+
+    def test_no_computation_when_no_element_data(self):
+        ctx: Dict[str, Any] = {}
+        gb50017._ensure_utilization_overrides('E1', ctx)
+        # Should not crash, no utilizationByElement added if no data
+        assert 'utilizationByElement' not in ctx or 'E1' not in ctx.get('utilizationByElement', {})
+
+    def test_partial_data_computes_available_checks(self):
+        """Only N and A provided (no V) — should compute 正应力 but not 剪应力."""
+        ctx: Dict[str, Any] = {
+            'elementData': {
+                'E1': {
+                    'section': {'A': 5000.0},
+                    'material': {'f': 215.0},
+                    'forces': {'N': 50000.0},
+                },
+            },
+        }
+        gb50017._ensure_utilization_overrides('E1', ctx)
+        util = ctx['utilizationByElement']['E1']
+        assert '正应力' in util
+        assert '剪应力' not in util
+
+    def test_computes_slenderness(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {
+                'C1': _make_column_element_data(),
+            },
+        }
+        gb50017._ensure_utilization_overrides('C1', ctx)
+        util = ctx['utilizationByElement']['C1']
+        # l0=4000, i=40 -> lambda=100, limit=150 -> 100/150≈0.667
+        assert '长细比' in util
+        assert util['长细比'] == pytest.approx(4000.0 / 40.0 / 150.0, abs=0.001)
+
+    def test_computes_deflection(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {
+                'B1': {
+                    'section': {'A': 5000.0},
+                    'material': {'f': 215.0},
+                    'forces': {'N': 0, 'deflection': 12.0},
+                    'length': 6000.0,
+                    'deflectionLimitN': 250,
+                },
+            },
+        }
+        gb50017._ensure_utilization_overrides('B1', ctx)
+        util = ctx['utilizationByElement']['B1']
+        # f_max=12, L=6000, n=250 -> limit=24 -> 12/24=0.5
+        assert '挠度' in util
+        assert util['挠度'] == pytest.approx(12.0 / (6000.0 / 250.0), abs=0.001)
+
+    def test_computes_local_stability(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {
+                'C1': _make_column_element_data(),
+            },
+        }
+        gb50017._ensure_utilization_overrides('C1', ctx)
+        util = ctx['utilizationByElement']['C1']
+        # b=200, t=12, limit=15 -> 200/12=16.67, 16.67/15≈1.111
+        assert '局部稳定' in util
+        assert util['局部稳定'] == pytest.approx(200.0 / 12.0 / 15.0, abs=0.001)
+
+    def test_zero_area_does_not_crash(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {
+                'E1': {
+                    'section': {'A': 0.0},
+                    'material': {'f': 215.0},
+                    'forces': {'N': 50000.0, 'V': 30000.0},
+                },
+            },
+        }
+        gb50017._ensure_utilization_overrides('E1', ctx)
+        # Should not crash — values are silently skipped
+        util = ctx.get('utilizationByElement', {}).get('E1', {})
+        assert '正应力' not in util
+
+
+class TestCheckElementBeam:
+    def test_beam_has_strength_checks(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'B1': _make_beam_element_data()}}
+        result = gb50017.check_element(checker, 'B1', ctx)
+        strength = next(c for c in result['checks'] if c['name'] == '强度验算')
+        items = [i['item'] for i in strength['items']]
+        assert '正应力' in items
+        assert '剪应力' in items
+        assert '折算应力' in items
+
+    def test_beam_has_stability_checks(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'B1': _make_beam_element_data()}}
+        result = gb50017.check_element(checker, 'B1', ctx)
+        stability = next(c for c in result['checks'] if c['name'] == '稳定验算')
+        items = [i['item'] for i in stability['items']]
+        assert '整体稳定' in items
+        assert '局部稳定' in items
+
+    def test_beam_has_deflection_check(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'B1': _make_beam_element_data()}}
+        result = gb50017.check_element(checker, 'B1', ctx)
+        stiffness = next(c for c in result['checks'] if c['name'] == '刚度验算')
+        items = [i['item'] for i in stiffness['items']]
+        assert '挠度' in items
+
+    def test_beam_element_type_in_result(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'B1': _make_beam_element_data()}}
+        result = gb50017.check_element(checker, 'B1', ctx)
+        assert result['elementType'] == 'beam'
+        assert result['code'] == 'GB50017-2017'
+
+    def test_beam_computed_utilization_matches_element_data(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'B1': _make_beam_element_data()}}
+        result = gb50017.check_element(checker, 'B1', ctx)
+        strength = next(c for c in result['checks'] if c['name'] == '强度验算')
+        normal = next(i for i in strength['items'] if i['item'] == '正应力')
+        expected = 50000.0 / 5000.0 / 215.0
+        assert normal['utilization'] == pytest.approx(expected, abs=0.001)
+
+
+class TestCheckElementColumn:
+    def test_column_has_axial_compression_stability(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'C1': _make_column_element_data()}}
+        result = gb50017.check_element(checker, 'C1', ctx)
+        stability = next(c for c in result['checks'] if c['name'] == '稳定验算')
+        items = [i['item'] for i in stability['items']]
+        assert '轴压稳定' in items
+
+    def test_column_has_slenderness(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'C1': _make_column_element_data()}}
+        result = gb50017.check_element(checker, 'C1', ctx)
+        stiffness = next(c for c in result['checks'] if c['name'] == '刚度验算')
+        items = [i['item'] for i in stiffness['items']]
+        assert '长细比' in items
+
+    def test_column_element_type_in_result(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'C1': _make_column_element_data()}}
+        result = gb50017.check_element(checker, 'C1', ctx)
+        assert result['elementType'] == 'column'
+
+    def test_column_no_beam_overall_stability(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'C1': _make_column_element_data()}}
+        result = gb50017.check_element(checker, 'C1', ctx)
+        stability = next(c for c in result['checks'] if c['name'] == '稳定验算')
+        items = [i['item'] for i in stability['items']]
+        assert '整体稳定' not in items  # beam-only check
+
+
+class TestCheckElementBrace:
+    def test_brace_has_axial_strength(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'br1': {'type': 'brace', 'section': {'A': 3000.0}, 'material': {'f': 215.0}, 'forces': {'N': 200000.0}}}}
+        result = gb50017.check_element(checker, 'br1', ctx)
+        strength = next(c for c in result['checks'] if c['name'] == '强度验算')
+        assert strength['items'][0]['item'] == '正应力'
+
+    def test_brace_has_slenderness(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'br1': {'type': 'brace', 'section': {'A': 3000.0, 'i': 30.0}, 'material': {'f': 215.0}, 'forces': {'N': 200000.0}, 'length': 5000.0, 'lambdaLimit': 200.0}}}
+        result = gb50017.check_element(checker, 'br1', ctx)
+        stiffness = next(c for c in result['checks'] if c['name'] == '刚度验算')
+        items = [i['item'] for i in stiffness['items']]
+        assert '长细比' in items
+
+    def test_brace_element_type_in_result(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'br1': {'type': 'brace', 'section': {'A': 3000.0}, 'material': {'f': 215.0}, 'forces': {'N': 200000.0}}}}
+        result = gb50017.check_element(checker, 'br1', ctx)
+        assert result['elementType'] == 'brace'
+
+
+class TestBackwardCompatibility:
+    def test_traceability_contract(self):
+        """Replicates validate_code_check_traceability from analysis-runner.py."""
+        checker = MockCodeChecker(overrides={'E1': {'正应力': 0.73}})
+        ctx = {
+            'analysisSummary': {'analysisType': 'static', 'success': True},
+            'utilizationByElement': {'E1': {'正应力': 0.73}},
+        }
+        result = gb50017.check_element(checker, 'E1', ctx)
+
+        assert result['code'] == 'GB50017-2017'
+        item = result['checks'][0]['items'][0]
+        assert item['clause'] == 'GB50017-2017 7.1.1'
+        assert item['formula']
+        assert item['inputs']['demand'] >= 0
+        assert item['utilization'] >= 0
+
+    def test_fallback_when_no_element_data(self):
+        """Without elementData, deterministic seed fallback still works."""
+        checker = MockCodeChecker()
+        ctx = {'utilizationByElement': {}}
+        result = gb50017.check_element(checker, 'E1', ctx)
+
+        # Should produce results with deterministic fallback utilizations
+        assert result['elementId'] == 'E1'
+        assert result['status'] in ('pass', 'fail')
+        all_items = [i for c in result['checks'] for i in c.get('items', [])]
+        assert len(all_items) > 0
+        for item in all_items:
+            assert item['utilization'] >= 0
+
+    def test_caller_override_priority(self):
+        """When both elementData and utilizationByElement provide values, caller wins."""
+        checker = MockCodeChecker()
+        ctx = {
+            'elementData': {
+                'E1': _make_beam_element_data(),  # would compute 正应力 ≈ 0.047
+            },
+            'utilizationByElement': {
+                'E1': {'正应力': 0.90},  # caller override should win
+            },
+        }
+        result = gb50017.check_element(checker, 'E1', ctx)
+        strength = next(c for c in result['checks'] if c['name'] == '强度验算')
+        normal = next(i for i in strength['items'] if i['item'] == '正应力')
+        assert normal['utilization'] == pytest.approx(0.90, abs=0.01)
+
+    def test_first_check_is_strength_normal_stress(self):
+        """First check group is 强度验算, first item is 正应力 — matches existing contract."""
+        checker = MockCodeChecker()
+        result = gb50017.check_element(checker, 'E1', {})
+        assert result['checks'][0]['name'] == '强度验算'
+        assert result['checks'][0]['items'][0]['item'] == '正应力'
+        assert result['checks'][0]['items'][0]['clause'] == 'GB50017-2017 7.1.1'
+
+
+class TestClauseReferences:
+    def test_beam_clauses_reference_gb50017_2017(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'B1': _make_beam_element_data()}}
+        result = gb50017.check_element(checker, 'B1', ctx)
+        all_items = [i for c in result['checks'] for i in c.get('items', [])]
+        for item in all_items:
+            assert item['clause'].startswith('GB50017-2017'), f"Clause should start with GB50017-2017, got: {item['clause']}"
+
+    def test_beam_strength_clause_7_1_1(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'B1': _make_beam_element_data()}}
+        result = gb50017.check_element(checker, 'B1', ctx)
+        normal = result['checks'][0]['items'][0]
+        assert '7.1.1' in normal['clause']
+
+    def test_column_axial_stability_clause_8_1_1(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'C1': _make_column_element_data()}}
+        result = gb50017.check_element(checker, 'C1', ctx)
+        stability = next(c for c in result['checks'] if c['name'] == '稳定验算')
+        axial = next(i for i in stability['items'] if i['item'] == '轴压稳定')
+        assert '8.1.1' in axial['clause']
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/backend/src/agent-skills/code-check/gb50017/__tests__/test_code_check.py
+++ b/backend/src/agent-skills/code-check/gb50017/__tests__/test_code_check.py
@@ -16,11 +16,6 @@ _SKILL_DIR = str(Path(__file__).resolve().parent.parent)
 if _SKILL_DIR not in sys.path:
     sys.path.insert(0, _SKILL_DIR)
 
-# Parent code_check.py dir for CodeChecker (append, not insert, to avoid shadowing)
-_PARENT_DIR = str(Path(__file__).resolve().parent.parent.parent)
-if _PARENT_DIR not in sys.path:
-    sys.path.append(_PARENT_DIR)
-
 import code_check as gb50017  # noqa: E402
 
 

--- a/backend/src/agent-skills/code-check/gb50017/__tests__/test_code_check.py
+++ b/backend/src/agent-skills/code-check/gb50017/__tests__/test_code_check.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from typing import Any, Dict, List
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -40,7 +39,6 @@ class MockCodeChecker:
         raw = per_elem.get(item_name)
         if isinstance(raw, (int, float)):
             return max(0.0, float(raw))
-        # Read from context (our _ensure_utilization_overrides may have injected)
         ctx_overrides = context.get('utilizationByElement', {})
         if isinstance(ctx_overrides, dict):
             ctx_elem = ctx_overrides.get(elem_id, {})
@@ -48,7 +46,7 @@ class MockCodeChecker:
                 val = ctx_elem.get(item_name)
                 if isinstance(val, (int, float)):
                     return max(0.0, float(val))
-        # Deterministic fallback matching parent
+        # Deterministic fallback matching parent CodeChecker
         seed = sum(ord(ch) for ch in f'{elem_id}:{item_name}')
         return 0.55 + (seed % 40) / 100.0
 
@@ -101,31 +99,34 @@ class MockCodeChecker:
 
 def _make_beam_element_data(**overrides) -> Dict[str, Any]:
     """Create a default beam elementData entry."""
-    base = {
-        'type': 'beam',
-        'section': {'A': 5000.0, 'Wnx': 200000.0, 'Wx': 200000.0, 'i': 50.0},
-        'material': {'f': 215.0, 'fv': 125.0, 'fy': 235.0},
-        'forces': {'N': 50000.0, 'V': 30000.0, 'Mx': 30000000.0},
-        'length': 6000.0,
-        'phi': 0.85,
+    return {
+        **{
+            'type': 'beam',
+            'section': {'A': 5000.0, 'Wnx': 200000.0, 'Wx': 200000.0, 'i': 50.0,
+                        'I': 1e7, 'S': 100000.0, 'tw': 8.0, 'As': 2000.0},
+            'material': {'f': 215.0, 'fv': 125.0, 'fy': 235.0},
+            'forces': {'N': 50000.0, 'V': 30000.0, 'Mx': 30000000.0},
+            'length': 6000.0,
+            'phi': 0.85,
+        },
+        **overrides,
     }
-    base.update(overrides)
-    return base
 
 
 def _make_column_element_data(**overrides) -> Dict[str, Any]:
-    base = {
-        'type': 'column',
-        'section': {'A': 8000.0, 'imin': 40.0, 'i': 40.0, 'b': 200.0, 't': 12.0},
-        'material': {'f': 215.0, 'fv': 125.0},
-        'forces': {'N': 800000.0, 'V': 10000.0},
-        'length': 4000.0,
-        'phi': 0.75,
-        'btLimit': 15.0,
-        'lambdaLimit': 150.0,
+    return {
+        **{
+            'type': 'column',
+            'section': {'A': 8000.0, 'imin': 40.0, 'i': 40.0, 'b': 200.0, 't': 12.0},
+            'material': {'f': 215.0, 'fv': 125.0},
+            'forces': {'N': 800000.0, 'V': 10000.0},
+            'length': 4000.0,
+            'phi': 0.75,
+            'btLimit': 15.0,
+            'lambdaLimit': 150.0,
+        },
+        **overrides,
     }
-    base.update(overrides)
-    return base
 
 
 # ===========================================================================
@@ -196,11 +197,12 @@ class TestResolveElementType:
         # But 'col' in name works
         assert gb50017._resolve_element_type('C-col-1', {}) == 'column'
 
-    def test_brace_from_naming_heuristic_br_prefix(self):
-        assert gb50017._resolve_element_type('br-1', {}) == 'brace'
-
     def test_brace_from_naming_heuristic_brace_in_name(self):
         assert gb50017._resolve_element_type('X1-brace-1', {}) == 'brace'
+
+    def test_brace_from_naming_heuristic_br_prefix(self):
+        # 'br-1' does not contain 'brace', falls to beam
+        assert gb50017._resolve_element_type('br-1', {}) == 'beam'
 
     def test_default_beam_when_no_data(self):
         assert gb50017._resolve_element_type('B1', {}) == 'beam'
@@ -209,160 +211,176 @@ class TestResolveElementType:
         assert gb50017._resolve_element_type('B1', {'elementData': {}}) == 'beam'
 
 
-class TestEnsureUtilizationOverrides:
-    def test_computes_normal_stress(self):
-        ctx: Dict[str, Any] = {
-            'elementData': {
-                'E1': _make_beam_element_data(),
-            },
-        }
-        gb50017._ensure_utilization_overrides('E1', ctx)
-        util = ctx['utilizationByElement']['E1']
-        # N=50000, A=5000 -> sigma=10, f=215 -> utilization=10/215≈0.0465
-        assert '正应力' in util
-        assert util['正应力'] == pytest.approx(50000.0 / 5000.0 / 215.0, abs=0.001)
+class TestComputeUtilizationOverrides:
+    """Tests for _compute_utilization_overrides (returns new dict, no mutation)."""
 
-    def test_computes_shear_stress(self):
+    def test_computes_normal_stress_with_bending(self):
         ctx: Dict[str, Any] = {
-            'elementData': {
-                'E1': _make_beam_element_data(),
-            },
+            'elementData': {'E1': _make_beam_element_data()},
         }
-        gb50017._ensure_utilization_overrides('E1', ctx)
-        util = ctx['utilizationByElement']['E1']
-        # V=30000, A=5000 -> tau=6, fv=125 -> utilization=6/125=0.048
-        assert '剪应力' in util
-        assert util['剪应力'] == pytest.approx(30000.0 / 5000.0 / 125.0, abs=0.001)
+        result = gb50017._compute_utilization_overrides('E1', ctx)
+        # N=50000, A=5000 -> sigma_axial=10, Mx=3e7, Wnx=2e5 -> sigma_bending=150
+        # utilization = (10 + 150) / 215 ≈ 0.744
+        assert '正应力' in result
+        expected = (50000.0 / 5000.0 + 30000000.0 / 200000.0) / 215.0
+        assert result['正应力'] == pytest.approx(expected, abs=0.001)
 
-    def test_computes_equivalent_stress(self):
+    def test_computes_normal_stress_axial_only(self):
         ctx: Dict[str, Any] = {
-            'elementData': {
-                'E1': _make_beam_element_data(),
-            },
+            'elementData': {'E1': {
+                'section': {'A': 5000.0},
+                'material': {'f': 215.0},
+                'forces': {'N': 50000.0},
+            }},
         }
-        gb50017._ensure_utilization_overrides('E1', ctx)
-        util = ctx['utilizationByElement']['E1']
-        assert '折算应力' in util
-        sigma = 50000.0 / 5000.0
-        tau = 30000.0 / 5000.0
-        expected = (sigma ** 2 + 3 * tau ** 2) ** 0.5 / 215.0
-        assert util['折算应力'] == pytest.approx(expected, abs=0.001)
+        result = gb50017._compute_utilization_overrides('E1', ctx)
+        assert result['正应力'] == pytest.approx(50000.0 / 5000.0 / 215.0, abs=0.001)
+
+    def test_computes_shear_stress_with_S_I_tw(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {'E1': _make_beam_element_data()},
+        }
+        result = gb50017._compute_utilization_overrides('E1', ctx)
+        # V=30000, S=100000, I=1e7, tw=8 -> tau = 30000*100000/(1e7*8) = 37.5
+        # fv=125 -> 37.5/125 = 0.3
+        assert '剪应力' in result
+        expected = 30000.0 * 100000.0 / (1e7 * 8.0) / 125.0
+        assert result['剪应力'] == pytest.approx(expected, abs=0.001)
+
+    def test_computes_shear_stress_with_As_fallback(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {'E1': {
+                'section': {'A': 5000.0, 'As': 2000.0},
+                'material': {'fv': 125.0},
+                'forces': {'V': 30000.0, 'N': 50000.0},
+            }},
+        }
+        result = gb50017._compute_utilization_overrides('E1', ctx)
+        assert '剪应力' in result
+        expected = 30000.0 / 2000.0 / 125.0
+        assert result['剪应力'] == pytest.approx(expected, abs=0.001)
+
+    def test_computes_equivalent_stress_includes_bending(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {'E1': _make_beam_element_data()},
+        }
+        result = gb50017._compute_utilization_overrides('E1', ctx)
+        assert '折算应力' in result
+        sigma_axial = 50000.0 / 5000.0  # 10
+        sigma_bending = 30000000.0 / 200000.0  # 150
+        tau = 30000.0 * 100000.0 / (1e7 * 8.0)  # 37.5
+        expected = (sigma_axial ** 2 + sigma_bending ** 2
+                    - sigma_axial * sigma_bending + 3 * tau ** 2) ** 0.5 / 215.0
+        assert result['折算应力'] == pytest.approx(expected, abs=0.001)
 
     def test_computes_overall_stability(self):
         ctx: Dict[str, Any] = {
-            'elementData': {
-                'E1': _make_beam_element_data(),
-            },
+            'elementData': {'E1': _make_beam_element_data()},
         }
-        gb50017._ensure_utilization_overrides('E1', ctx)
-        util = ctx['utilizationByElement']['E1']
-        # Mx=3e7, phi=0.85, Wnx=2e5, f=215 -> 3e7/(0.85*2e5*215)≈0.819
-        assert '整体稳定' in util
-        assert util['整体稳定'] == pytest.approx(30000000.0 / (0.85 * 200000.0 * 215.0), abs=0.001)
+        result = gb50017._compute_utilization_overrides('E1', ctx)
+        assert '整体稳定' in result
+        assert result['整体稳定'] == pytest.approx(
+            30000000.0 / (0.85 * 200000.0 * 215.0), abs=0.001
+        )
 
     def test_computes_axial_compression_stability(self):
         ctx: Dict[str, Any] = {
-            'elementData': {
-                'C1': _make_column_element_data(),
-            },
+            'elementData': {'C1': _make_column_element_data()},
         }
-        gb50017._ensure_utilization_overrides('C1', ctx)
-        util = ctx['utilizationByElement']['C1']
-        # N=8e5, phi=0.75, A=8000, f=215 -> 8e5/(0.75*8000*215)≈0.620
-        assert '轴压稳定' in util
-        assert util['轴压稳定'] == pytest.approx(800000.0 / (0.75 * 8000.0 * 215.0), abs=0.001)
+        result = gb50017._compute_utilization_overrides('C1', ctx)
+        assert '轴压稳定' in result
+        assert result['轴压稳定'] == pytest.approx(
+            800000.0 / (0.75 * 8000.0 * 215.0), abs=0.001
+        )
 
     def test_caller_override_not_overwritten(self):
         ctx: Dict[str, Any] = {
-            'elementData': {
-                'E1': _make_beam_element_data(),
-            },
-            'utilizationByElement': {
-                'E1': {'正应力': 0.73},
-            },
+            'elementData': {'E1': _make_beam_element_data()},
+            'utilizationByElement': {'E1': {'正应力': 0.73}},
         }
-        gb50017._ensure_utilization_overrides('E1', ctx)
-        # Caller override should remain
-        assert ctx['utilizationByElement']['E1']['正应力'] == 0.73
+        result = gb50017._compute_utilization_overrides('E1', ctx)
+        # Function returns computed values only; caller override is in ctx, not in result
+        assert '正应力' not in result  # skipped because already in per_elem
 
     def test_no_computation_when_no_element_data(self):
         ctx: Dict[str, Any] = {}
-        gb50017._ensure_utilization_overrides('E1', ctx)
-        # Should not crash, no utilizationByElement added if no data
-        assert 'utilizationByElement' not in ctx or 'E1' not in ctx.get('utilizationByElement', {})
+        result = gb50017._compute_utilization_overrides('E1', ctx)
+        assert result == {}
 
     def test_partial_data_computes_available_checks(self):
-        """Only N and A provided (no V) — should compute 正应力 but not 剪应力."""
         ctx: Dict[str, Any] = {
-            'elementData': {
-                'E1': {
-                    'section': {'A': 5000.0},
-                    'material': {'f': 215.0},
-                    'forces': {'N': 50000.0},
-                },
-            },
+            'elementData': {'E1': {
+                'section': {'A': 5000.0},
+                'material': {'f': 215.0},
+                'forces': {'N': 50000.0},
+            }},
         }
-        gb50017._ensure_utilization_overrides('E1', ctx)
-        util = ctx['utilizationByElement']['E1']
-        assert '正应力' in util
-        assert '剪应力' not in util
+        result = gb50017._compute_utilization_overrides('E1', ctx)
+        assert '正应力' in result
+        assert '剪应力' not in result
 
     def test_computes_slenderness(self):
         ctx: Dict[str, Any] = {
-            'elementData': {
-                'C1': _make_column_element_data(),
-            },
+            'elementData': {'C1': _make_column_element_data()},
         }
-        gb50017._ensure_utilization_overrides('C1', ctx)
-        util = ctx['utilizationByElement']['C1']
-        # l0=4000, i=40 -> lambda=100, limit=150 -> 100/150≈0.667
-        assert '长细比' in util
-        assert util['长细比'] == pytest.approx(4000.0 / 40.0 / 150.0, abs=0.001)
+        result = gb50017._compute_utilization_overrides('C1', ctx)
+        assert '长细比' in result
+        assert result['长细比'] == pytest.approx(4000.0 / 40.0 / 150.0, abs=0.001)
 
-    def test_computes_deflection(self):
+    def test_computes_deflection_only_when_limit_provided(self):
         ctx: Dict[str, Any] = {
-            'elementData': {
-                'B1': {
-                    'section': {'A': 5000.0},
-                    'material': {'f': 215.0},
-                    'forces': {'N': 0, 'deflection': 12.0},
-                    'length': 6000.0,
-                    'deflectionLimitN': 250,
-                },
-            },
+            'elementData': {'B1': {
+                'section': {'A': 5000.0},
+                'material': {'f': 215.0},
+                'forces': {'N': 0, 'deflection': 12.0},
+                'length': 6000.0,
+                'deflectionLimitN': 250,
+            }},
         }
-        gb50017._ensure_utilization_overrides('B1', ctx)
-        util = ctx['utilizationByElement']['B1']
-        # f_max=12, L=6000, n=250 -> limit=24 -> 12/24=0.5
-        assert '挠度' in util
-        assert util['挠度'] == pytest.approx(12.0 / (6000.0 / 250.0), abs=0.001)
+        result = gb50017._compute_utilization_overrides('B1', ctx)
+        assert '挠度' in result
+        assert result['挠度'] == pytest.approx(12.0 / (6000.0 / 250.0), abs=0.001)
+
+    def test_no_deflection_without_explicit_limit(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {'B1': {
+                'section': {'A': 5000.0},
+                'material': {'f': 215.0},
+                'forces': {'N': 0, 'deflection': 12.0},
+                'length': 6000.0,
+                # no deflectionLimitN
+            }},
+        }
+        result = gb50017._compute_utilization_overrides('B1', ctx)
+        assert '挠度' not in result
 
     def test_computes_local_stability(self):
         ctx: Dict[str, Any] = {
-            'elementData': {
-                'C1': _make_column_element_data(),
-            },
+            'elementData': {'C1': _make_column_element_data()},
         }
-        gb50017._ensure_utilization_overrides('C1', ctx)
-        util = ctx['utilizationByElement']['C1']
-        # b=200, t=12, limit=15 -> 200/12=16.67, 16.67/15≈1.111
-        assert '局部稳定' in util
-        assert util['局部稳定'] == pytest.approx(200.0 / 12.0 / 15.0, abs=0.001)
+        result = gb50017._compute_utilization_overrides('C1', ctx)
+        assert '局部稳定' in result
+        assert result['局部稳定'] == pytest.approx(200.0 / 12.0 / 15.0, abs=0.001)
 
     def test_zero_area_does_not_crash(self):
         ctx: Dict[str, Any] = {
-            'elementData': {
-                'E1': {
-                    'section': {'A': 0.0},
-                    'material': {'f': 215.0},
-                    'forces': {'N': 50000.0, 'V': 30000.0},
-                },
-            },
+            'elementData': {'E1': {
+                'section': {'A': 0.0},
+                'material': {'f': 215.0},
+                'forces': {'N': 50000.0, 'V': 30000.0},
+            }},
         }
-        gb50017._ensure_utilization_overrides('E1', ctx)
-        # Should not crash — values are silently skipped
-        util = ctx.get('utilizationByElement', {}).get('E1', {})
-        assert '正应力' not in util
+        result = gb50017._compute_utilization_overrides('E1', ctx)
+        assert '正应力' not in result
+
+    def test_does_not_mutate_context(self):
+        ctx: Dict[str, Any] = {
+            'elementData': {'E1': _make_beam_element_data()},
+        }
+        original_keys = set(ctx.keys())
+        gb50017._compute_utilization_overrides('E1', ctx)
+        assert set(ctx.keys()) == original_keys
+        assert 'utilizationByElement' not in ctx
 
 
 class TestCheckElementBeam:
@@ -400,13 +418,13 @@ class TestCheckElementBeam:
         assert result['elementType'] == 'beam'
         assert result['code'] == 'GB50017-2017'
 
-    def test_beam_computed_utilization_matches_element_data(self):
+    def test_beam_computed_utilization_includes_bending(self):
         checker = MockCodeChecker()
         ctx = {'elementData': {'B1': _make_beam_element_data()}}
         result = gb50017.check_element(checker, 'B1', ctx)
         strength = next(c for c in result['checks'] if c['name'] == '强度验算')
         normal = next(i for i in strength['items'] if i['item'] == '正应力')
-        expected = 50000.0 / 5000.0 / 215.0
+        expected = (50000.0 / 5000.0 + 30000000.0 / 200000.0) / 215.0
         assert normal['utilization'] == pytest.approx(expected, abs=0.001)
 
 
@@ -445,23 +463,23 @@ class TestCheckElementColumn:
 class TestCheckElementBrace:
     def test_brace_has_axial_strength(self):
         checker = MockCodeChecker()
-        ctx = {'elementData': {'br1': {'type': 'brace', 'section': {'A': 3000.0}, 'material': {'f': 215.0}, 'forces': {'N': 200000.0}}}}
-        result = gb50017.check_element(checker, 'br1', ctx)
+        ctx = {'elementData': {'X1-brace-1': {'type': 'brace', 'section': {'A': 3000.0}, 'material': {'f': 215.0}, 'forces': {'N': 200000.0}}}}
+        result = gb50017.check_element(checker, 'X1-brace-1', ctx)
         strength = next(c for c in result['checks'] if c['name'] == '强度验算')
         assert strength['items'][0]['item'] == '正应力'
 
     def test_brace_has_slenderness(self):
         checker = MockCodeChecker()
-        ctx = {'elementData': {'br1': {'type': 'brace', 'section': {'A': 3000.0, 'i': 30.0}, 'material': {'f': 215.0}, 'forces': {'N': 200000.0}, 'length': 5000.0, 'lambdaLimit': 200.0}}}
-        result = gb50017.check_element(checker, 'br1', ctx)
+        ctx = {'elementData': {'X1-brace-1': {'type': 'brace', 'section': {'A': 3000.0, 'i': 30.0}, 'material': {'f': 215.0}, 'forces': {'N': 200000.0}, 'length': 5000.0, 'lambdaLimit': 200.0}}}
+        result = gb50017.check_element(checker, 'X1-brace-1', ctx)
         stiffness = next(c for c in result['checks'] if c['name'] == '刚度验算')
         items = [i['item'] for i in stiffness['items']]
         assert '长细比' in items
 
     def test_brace_element_type_in_result(self):
         checker = MockCodeChecker()
-        ctx = {'elementData': {'br1': {'type': 'brace', 'section': {'A': 3000.0}, 'material': {'f': 215.0}, 'forces': {'N': 200000.0}}}}
-        result = gb50017.check_element(checker, 'br1', ctx)
+        ctx = {'elementData': {'X1-brace-1': {'type': 'brace', 'section': {'A': 3000.0}, 'material': {'f': 215.0}, 'forces': {'N': 200000.0}}}}
+        result = gb50017.check_element(checker, 'X1-brace-1', ctx)
         assert result['elementType'] == 'brace'
 
 
@@ -488,7 +506,6 @@ class TestBackwardCompatibility:
         ctx = {'utilizationByElement': {}}
         result = gb50017.check_element(checker, 'E1', ctx)
 
-        # Should produce results with deterministic fallback utilizations
         assert result['elementId'] == 'E1'
         assert result['status'] in ('pass', 'fail')
         all_items = [i for c in result['checks'] for i in c.get('items', [])]
@@ -500,12 +517,8 @@ class TestBackwardCompatibility:
         """When both elementData and utilizationByElement provide values, caller wins."""
         checker = MockCodeChecker()
         ctx = {
-            'elementData': {
-                'E1': _make_beam_element_data(),  # would compute 正应力 ≈ 0.047
-            },
-            'utilizationByElement': {
-                'E1': {'正应力': 0.90},  # caller override should win
-            },
+            'elementData': {'E1': _make_beam_element_data()},
+            'utilizationByElement': {'E1': {'正应力': 0.90}},
         }
         result = gb50017.check_element(checker, 'E1', ctx)
         strength = next(c for c in result['checks'] if c['name'] == '强度验算')
@@ -520,6 +533,16 @@ class TestBackwardCompatibility:
         assert result['checks'][0]['items'][0]['item'] == '正应力'
         assert result['checks'][0]['items'][0]['clause'] == 'GB50017-2017 7.1.1'
 
+    def test_context_not_mutated_by_check_element(self):
+        """check_element should not mutate the original context."""
+        checker = MockCodeChecker()
+        ctx: Dict[str, Any] = {
+            'elementData': {'E1': _make_beam_element_data()},
+        }
+        original_ctx = dict(ctx)
+        gb50017.check_element(checker, 'E1', ctx)
+        assert ctx == original_ctx
+
 
 class TestClauseReferences:
     def test_beam_clauses_reference_gb50017_2017(self):
@@ -528,7 +551,7 @@ class TestClauseReferences:
         result = gb50017.check_element(checker, 'B1', ctx)
         all_items = [i for c in result['checks'] for i in c.get('items', [])]
         for item in all_items:
-            assert item['clause'].startswith('GB50017-2017'), f"Clause should start with GB50017-2017, got: {item['clause']}"
+            assert item['clause'].startswith('GB50017-2017')
 
     def test_beam_strength_clause_7_1_1(self):
         checker = MockCodeChecker()
@@ -544,6 +567,14 @@ class TestClauseReferences:
         stability = next(c for c in result['checks'] if c['name'] == '稳定验算')
         axial = next(i for i in stability['items'] if i['item'] == '轴压稳定')
         assert '8.1.1' in axial['clause']
+
+    def test_column_slenderness_clause_10_1_1(self):
+        checker = MockCodeChecker()
+        ctx = {'elementData': {'C1': _make_column_element_data()}}
+        result = gb50017.check_element(checker, 'C1', ctx)
+        stiffness = next(c for c in result['checks'] if c['name'] == '刚度验算')
+        slenderness = next(i for i in stiffness['items'] if i['item'] == '长细比')
+        assert '10.1.1' in slenderness['clause']
 
 
 if __name__ == '__main__':

--- a/backend/src/agent-skills/code-check/gb50017/__tests__/test_code_check.py
+++ b/backend/src/agent-skills/code-check/gb50017/__tests__/test_code_check.py
@@ -16,10 +16,10 @@ _SKILL_DIR = str(Path(__file__).resolve().parent.parent)
 if _SKILL_DIR not in sys.path:
     sys.path.insert(0, _SKILL_DIR)
 
-# Parent code_check.py dir for CodeChecker
+# Parent code_check.py dir for CodeChecker (append, not insert, to avoid shadowing)
 _PARENT_DIR = str(Path(__file__).resolve().parent.parent.parent)
 if _PARENT_DIR not in sys.path:
-    sys.path.insert(0, _PARENT_DIR)
+    sys.path.append(_PARENT_DIR)
 
 import code_check as gb50017  # noqa: E402
 

--- a/backend/src/agent-skills/code-check/gb50017/code_check.py
+++ b/backend/src/agent-skills/code-check/gb50017/code_check.py
@@ -5,7 +5,7 @@
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 
 RULE_VERSION = 'v2-member-checks'
@@ -454,12 +454,18 @@ def check_element(checker: Any, elem_id: str, context: Dict[str, Any]) -> Dict[s
     # Compute utilization overrides immutably — merge into a copy of context
     computed = _compute_utilization_overrides(elem_id, context)
     if computed:
+        existing_ube = context.get('utilizationByElement')
+        if not isinstance(existing_ube, dict):
+            existing_ube = {}
+        existing_elem = existing_ube.get(elem_id)
+        if not isinstance(existing_elem, dict):
+            existing_elem = {}
         merged_ctx = {
             **context,
             'utilizationByElement': {
-                **context.get('utilizationByElement', {}),
+                **existing_ube,
                 elem_id: {
-                    **context.get('utilizationByElement', {}).get(elem_id, {}),
+                    **existing_elem,
                     **computed,
                 },
             },

--- a/backend/src/agent-skills/code-check/gb50017/code_check.py
+++ b/backend/src/agent-skills/code-check/gb50017/code_check.py
@@ -255,13 +255,14 @@ def _compute_utilization_overrides(
                 - sigma_axial * sigma_bending
                 + 3 * tau ** 2
             ) ** 0.5
-            computed['折算应力'] = eq / float(f)
+            beta1 = elem.get('beta1', 1.0)
+            computed['折算应力'] = eq / (float(beta1) * float(f))
         except (ZeroDivisionError, ValueError, TypeError):
             pass
 
-    # Overall beam stability: |Mx| / (phi * Wnx * f)
+    # Overall beam stability: |Mx| / (phi_b * Wnx * f)
     if '整体稳定' not in per_elem:
-        phi = elem.get('phi')
+        phi = elem.get('phi_b') or elem.get('phi')
         if phi is not None and Wnx is not None and f is not None and Mx is not None:
             try:
                 computed['整体稳定'] = abs(float(Mx)) / (
@@ -270,9 +271,9 @@ def _compute_utilization_overrides(
             except (ZeroDivisionError, ValueError, TypeError):
                 pass
 
-    # Axial compression stability: |N| / (phi * A * f)
+    # Axial compression stability: |N| / (phi_axial * A * f)
     if '轴压稳定' not in per_elem:
-        phi = elem.get('phi')
+        phi = elem.get('phi_axial') or elem.get('phi')
         if phi is not None and A is not None and f is not None and N is not None:
             try:
                 computed['轴压稳定'] = abs(float(N)) / (float(phi) * float(A) * float(f))
@@ -303,7 +304,9 @@ def _compute_utilization_overrides(
 
     # Deflection: f_max / (L / n)  — only when deflectionLimitN explicitly provided
     if '挠度' not in per_elem:
-        f_max = forces.get('deflection') or elem.get('deflection')
+        f_max = forces.get('deflection')
+        if f_max is None:
+            f_max = elem.get('deflection')
         L = elem.get('length')
         n_limit = elem.get('deflectionLimitN')
         if f_max is not None and L is not None and n_limit is not None:
@@ -342,6 +345,7 @@ def _check_beam(checker: Any, elem_id: str, context: Dict[str, Any]) -> List[Dic
             'chapter': '第10章 正常使用极限状态',
             'name': '刚度验算',
             'items': [
+                checker._calc_item(elem_id, '长细比', context, 'GB50017-2017 10.1.1', 'λ = l₀/i ≤ [λ]', 1.0),
                 checker._calc_item(elem_id, '挠度', context, 'GB50017-2017 10.2.1', 'f_max ≤ L/n', 1.0),
             ],
         },
@@ -464,12 +468,13 @@ def check_element(checker: Any, elem_id: str, context: Dict[str, Any]) -> Dict[s
         merged_ctx = context
 
     builder = _BUILDERS.get(element_type, _check_beam)
+    normalized_type = element_type if element_type in _BUILDERS else 'beam'
     checks = builder(checker, elem_id, merged_ctx)
-    result = checker._build_element_result(elem_id, element_type, checks, CODE_VERSION)
+    result = checker._build_element_result(elem_id, normalized_type, checks, CODE_VERSION)
     result['chapters'] = _build_chapter_summaries(checks)
     result['chapterCount'] = len(result['chapters'])
     result['elementContext'] = {
-        'type': element_type,
+        'type': normalized_type,
         'section': element_context.get('section'),
         'material': element_context.get('material'),
     }

--- a/backend/src/agent-skills/code-check/gb50017/code_check.py
+++ b/backend/src/agent-skills/code-check/gb50017/code_check.py
@@ -5,7 +5,7 @@
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 RULE_VERSION = 'v2-member-checks'
@@ -44,23 +44,23 @@ def get_rules() -> Dict[str, Any]:
                     {
                         'item': '正应力',
                         'clause': '7.1.1',
-                        'formula': 'σ = N/Aₙ ≤ f',
+                        'formula': 'σ = N/Aₙ ± Mₓ/(γₓWₙₓ) ≤ f',
                         'limit': 1.0,
-                        'params': ['N', 'A', 'f'],
+                        'params': ['N', 'Mx', 'A', 'Wnx', 'f'],
                     },
                     {
                         'item': '剪应力',
                         'clause': '7.1.2',
-                        'formula': 'τ = V/(Aₙ·t) ≤ f_v',
+                        'formula': 'τ = V·S/(I·tw) ≤ f_v',
                         'limit': 1.0,
-                        'params': ['V', 'A', 'fv'],
+                        'params': ['V', 'S', 'I', 'tw', 'fv'],
                     },
                     {
                         'item': '折算应力',
                         'clause': '7.1.4',
-                        'formula': '√(σ² + 3τ²) ≤ β₁·f',
+                        'formula': '√(σₓ² + σ_b² - σₓ·σ_b + 3τ²) ≤ β₁·f',
                         'limit': 1.0,
-                        'params': ['sigma', 'tau', 'f'],
+                        'params': ['sigma_axial', 'sigma_bending', 'tau', 'f'],
                     },
                 ],
             },
@@ -99,7 +99,7 @@ def get_rules() -> Dict[str, Any]:
                 'checks': [
                     {
                         'item': '长细比',
-                        'clause': '8.3.1',
+                        'clause': '10.1.1',
                         'formula': 'λ = l₀/i ≤ [λ]',
                         'limit': 1.0,
                         'params': ['l0', 'i', 'lambdaLimit'],
@@ -156,7 +156,7 @@ def _resolve_element_type(elem_id: str, context: Dict[str, Any]) -> str:
     lower = elem_id.lower()
     if 'col' in lower:
         return 'column'
-    if 'brace' in lower or lower.startswith('br'):
+    if 'brace' in lower:
         return 'brace'
     return 'beam'
 
@@ -165,26 +165,38 @@ def _resolve_element_type(elem_id: str, context: Dict[str, Any]) -> str:
 # Utilization computation from elementData
 # ---------------------------------------------------------------------------
 
-def _ensure_utilization_overrides(elem_id: str, context: Dict[str, Any]) -> None:
-    """Pre-populate utilizationByElement from elementData where possible.
+def _compute_utilization_overrides(
+    elem_id: str, context: Dict[str, Any],
+) -> Dict[str, float]:
+    """Compute utilization ratios from elementData.
 
-    Only adds values that are not already present — caller overrides win.
+    Returns a new dict of computed overrides. Does NOT mutate context.
+    Caller overrides (already in utilizationByElement) are respected —
+    this function only computes values that are NOT already present.
     """
     element_data = context.get('elementData', {})
     if not isinstance(element_data, dict):
-        return
+        return {}
     elem = element_data.get(elem_id)
     if not isinstance(elem, dict):
-        return
+        return {}
 
     section = elem.get('section', {})
     material = elem.get('material', {})
     forces = elem.get('forces', {})
     if not isinstance(section, dict) or not isinstance(material, dict) or not isinstance(forces, dict):
-        return
+        return {}
 
-    overrides = context.setdefault('utilizationByElement', {})
-    per_elem = overrides.setdefault(elem_id, {})
+    # Existing caller overrides — these take priority
+    existing = context.get('utilizationByElement', {})
+    if isinstance(existing, dict):
+        per_elem = existing.get(elem_id, {})
+        if not isinstance(per_elem, dict):
+            per_elem = {}
+    else:
+        per_elem = {}
+
+    computed: Dict[str, float] = {}
 
     A = section.get('A')
     f = material.get('f')
@@ -192,37 +204,69 @@ def _ensure_utilization_overrides(elem_id: str, context: Dict[str, Any]) -> None
     N = forces.get('N')
     V = forces.get('V')
     Mx = forces.get('Mx')
+    I = section.get('I') or section.get('Iy') or section.get('Ix')
+    S = section.get('S')  # area moment above neutral axis
+    tw = section.get('tw')  # web thickness
+    Wnx = section.get('Wnx') or section.get('Wx')
 
-    # Normal stress: |N| / A / f
+    # Normal stress: (|N|/A + |Mx|/Wnx) / f  (GB50017-2017 7.1.1)
     if '正应力' not in per_elem and A is not None and f is not None and N is not None:
         try:
-            per_elem['正应力'] = abs(float(N)) / float(A) / float(f)
+            sigma_axial = abs(float(N)) / float(A)
+            sigma_bending = 0.0
+            if Mx is not None and Wnx is not None and float(Wnx) != 0:
+                sigma_bending = abs(float(Mx)) / float(Wnx)
+            computed['正应力'] = (sigma_axial + sigma_bending) / float(f)
         except (ZeroDivisionError, ValueError, TypeError):
             pass
 
-    # Shear stress: |V| / A / fv
-    if '剪应力' not in per_elem and A is not None and fv is not None and V is not None:
+    # Shear stress: |V|*S/(I*tw) / fv  (GB50017-2017 7.1.2)
+    #   Falls back to |V|/As/fv when S/I/tw not available but As is
+    if '剪应力' not in per_elem and fv is not None and V is not None:
         try:
-            per_elem['剪应力'] = abs(float(V)) / float(A) / float(fv)
+            As = section.get('As')  # explicit shear area
+            if S is not None and I is not None and tw is not None:
+                tau = abs(float(V)) * float(S) / (float(I) * float(tw))
+                computed['剪应力'] = tau / float(fv)
+            elif As is not None and float(As) != 0:
+                computed['剪应力'] = abs(float(V)) / float(As) / float(fv)
         except (ZeroDivisionError, ValueError, TypeError):
             pass
 
-    # Equivalent stress: sqrt(sigma^2 + 3*tau^2) / f
+    # Equivalent stress: sqrt(sigma_axial^2 + sigma_bending^2
+    #   - sigma_axial*sigma_bending + 3*tau^2) / f  (GB50017-2017 7.1.4)
     if '折算应力' not in per_elem and A is not None and f is not None and N is not None and V is not None:
         try:
-            sigma = abs(float(N)) / float(A)
-            tau = abs(float(V)) / float(A)
-            per_elem['折算应力'] = (sigma ** 2 + 3 * tau ** 2) ** 0.5 / float(f)
+            sigma_axial = abs(float(N)) / float(A)
+            sigma_bending = 0.0
+            if Mx is not None and Wnx is not None and float(Wnx) != 0:
+                sigma_bending = abs(float(Mx)) / float(Wnx)
+            # tau from shear formula or simplified
+            tau = 0.0
+            if S is not None and I is not None and tw is not None:
+                tau = abs(float(V)) * float(S) / (float(I) * float(tw))
+            else:
+                As = section.get('As', A)
+                if As is not None and float(As) != 0:
+                    tau = abs(float(V)) / float(As)
+            eq = (
+                sigma_axial ** 2
+                + sigma_bending ** 2
+                - sigma_axial * sigma_bending
+                + 3 * tau ** 2
+            ) ** 0.5
+            computed['折算应力'] = eq / float(f)
         except (ZeroDivisionError, ValueError, TypeError):
             pass
 
     # Overall beam stability: |Mx| / (phi * Wnx * f)
     if '整体稳定' not in per_elem:
         phi = elem.get('phi')
-        Wnx = section.get('Wnx') or section.get('Wx')
         if phi is not None and Wnx is not None and f is not None and Mx is not None:
             try:
-                per_elem['整体稳定'] = abs(float(Mx)) / (float(phi) * float(Wnx) * float(f))
+                computed['整体稳定'] = abs(float(Mx)) / (
+                    float(phi) * float(Wnx) * float(f)
+                )
             except (ZeroDivisionError, ValueError, TypeError):
                 pass
 
@@ -231,7 +275,7 @@ def _ensure_utilization_overrides(elem_id: str, context: Dict[str, Any]) -> None
         phi = elem.get('phi')
         if phi is not None and A is not None and f is not None and N is not None:
             try:
-                per_elem['轴压稳定'] = abs(float(N)) / (float(phi) * float(A) * float(f))
+                computed['轴压稳定'] = abs(float(N)) / (float(phi) * float(A) * float(f))
             except (ZeroDivisionError, ValueError, TypeError):
                 pass
 
@@ -242,7 +286,7 @@ def _ensure_utilization_overrides(elem_id: str, context: Dict[str, Any]) -> None
         bt_limit = elem.get('btLimit')
         if b is not None and t is not None and bt_limit is not None:
             try:
-                per_elem['局部稳定'] = (float(b) / float(t)) / float(bt_limit)
+                computed['局部稳定'] = (float(b) / float(t)) / float(bt_limit)
             except (ZeroDivisionError, ValueError, TypeError):
                 pass
 
@@ -253,20 +297,22 @@ def _ensure_utilization_overrides(elem_id: str, context: Dict[str, Any]) -> None
         lambda_limit = elem.get('lambdaLimit')
         if l0 is not None and i_min is not None and lambda_limit is not None:
             try:
-                per_elem['长细比'] = float(l0) / float(i_min) / float(lambda_limit)
+                computed['长细比'] = float(l0) / float(i_min) / float(lambda_limit)
             except (ZeroDivisionError, ValueError, TypeError):
                 pass
 
-    # Deflection: f_max / (L / n)
+    # Deflection: f_max / (L / n)  — only when deflectionLimitN explicitly provided
     if '挠度' not in per_elem:
         f_max = forces.get('deflection') or elem.get('deflection')
         L = elem.get('length')
-        n_limit = elem.get('deflectionLimitN', 250)
-        if f_max is not None and L is not None:
+        n_limit = elem.get('deflectionLimitN')
+        if f_max is not None and L is not None and n_limit is not None:
             try:
-                per_elem['挠度'] = abs(float(f_max)) / (float(L) / float(n_limit))
+                computed['挠度'] = abs(float(f_max)) / (float(L) / float(n_limit))
             except (ZeroDivisionError, ValueError, TypeError):
                 pass
+
+    return computed
 
 
 # ---------------------------------------------------------------------------
@@ -279,9 +325,9 @@ def _check_beam(checker: Any, elem_id: str, context: Dict[str, Any]) -> List[Dic
             'chapter': '第7章 强度验算',
             'name': '强度验算',
             'items': [
-                checker._calc_item(elem_id, '正应力', context, 'GB50017-2017 7.1.1', 'σ = N/Aₙ ≤ f', 1.0),
-                checker._calc_item(elem_id, '剪应力', context, 'GB50017-2017 7.1.2', 'τ = V/(Aₙ·t) ≤ f_v', 1.0),
-                checker._calc_item(elem_id, '折算应力', context, 'GB50017-2017 7.1.4', '√(σ² + 3τ²) ≤ β₁·f', 1.0),
+                checker._calc_item(elem_id, '正应力', context, 'GB50017-2017 7.1.1', 'σ = N/Aₙ ± Mₓ/(γₓWₙₓ) ≤ f', 1.0),
+                checker._calc_item(elem_id, '剪应力', context, 'GB50017-2017 7.1.2', 'τ = V·S/(I·tw) ≤ f_v', 1.0),
+                checker._calc_item(elem_id, '折算应力', context, 'GB50017-2017 7.1.4', '√(σₓ²+σ_b²-σₓ·σ_b+3τ²) ≤ β₁·f', 1.0),
             ],
         },
         {
@@ -323,7 +369,7 @@ def _check_column(checker: Any, elem_id: str, context: Dict[str, Any]) -> List[D
             'chapter': '第10章 正常使用极限状态',
             'name': '刚度验算',
             'items': [
-                checker._calc_item(elem_id, '长细比', context, 'GB50017-2017 8.3.1', 'λ = l₀/i ≤ [λ]', 1.0),
+                checker._calc_item(elem_id, '长细比', context, 'GB50017-2017 10.1.1', 'λ = l₀/i ≤ [λ]', 1.0),
             ],
         },
     ]
@@ -350,7 +396,7 @@ def _check_brace(checker: Any, elem_id: str, context: Dict[str, Any]) -> List[Di
             'chapter': '第10章 正常使用极限状态',
             'name': '刚度验算',
             'items': [
-                checker._calc_item(elem_id, '长细比', context, 'GB50017-2017 8.3.1', 'λ = l₀/i ≤ [λ]', 1.0),
+                checker._calc_item(elem_id, '长细比', context, 'GB50017-2017 10.1.1', 'λ = l₀/i ≤ [λ]', 1.0),
             ],
         },
     ]
@@ -400,9 +446,25 @@ def check_element(checker: Any, elem_id: str, context: Dict[str, Any]) -> Dict[s
     """GB50017-2017 构件校核入口。"""
     element_context = _resolve_element_context(elem_id, context)
     element_type = _resolve_element_type(elem_id, context)
-    _ensure_utilization_overrides(elem_id, context)
+
+    # Compute utilization overrides immutably — merge into a copy of context
+    computed = _compute_utilization_overrides(elem_id, context)
+    if computed:
+        merged_ctx = {
+            **context,
+            'utilizationByElement': {
+                **context.get('utilizationByElement', {}),
+                elem_id: {
+                    **context.get('utilizationByElement', {}).get(elem_id, {}),
+                    **computed,
+                },
+            },
+        }
+    else:
+        merged_ctx = context
+
     builder = _BUILDERS.get(element_type, _check_beam)
-    checks = builder(checker, elem_id, context)
+    checks = builder(checker, elem_id, merged_ctx)
     result = checker._build_element_result(elem_id, element_type, checks, CODE_VERSION)
     result['chapters'] = _build_chapter_summaries(checks)
     result['chapterCount'] = len(result['chapters'])

--- a/backend/src/agent-skills/code-check/gb50017/code_check.py
+++ b/backend/src/agent-skills/code-check/gb50017/code_check.py
@@ -44,7 +44,7 @@ def get_rules() -> Dict[str, Any]:
                     {
                         'item': '正应力',
                         'clause': '7.1.1',
-                        'formula': 'σ = N/Aₙ ± Mₓ/(γₓWₙₓ) ≤ f',
+                        'formula': '(|N|/A + |Mₓ|/Wₙₓ) / f ≤ 1.0',
                         'limit': 1.0,
                         'params': ['N', 'Mx', 'A', 'Wnx', 'f'],
                     },
@@ -60,7 +60,7 @@ def get_rules() -> Dict[str, Any]:
                         'clause': '7.1.4',
                         'formula': '√(σₓ² + σ_b² - σₓ·σ_b + 3τ²) ≤ β₁·f',
                         'limit': 1.0,
-                        'params': ['sigma_axial', 'sigma_bending', 'tau', 'f'],
+                        'params': ['sigma_axial', 'sigma_bending', 'tau', 'beta1', 'f'],
                     },
                 ],
             },
@@ -333,7 +333,7 @@ def _check_beam(checker: Any, elem_id: str, context: Dict[str, Any]) -> List[Dic
             'chapter': '第7章 强度验算',
             'name': '强度验算',
             'items': [
-                checker._calc_item(elem_id, '正应力', context, 'GB50017-2017 7.1.1', 'σ = N/Aₙ ± Mₓ/(γₓWₙₓ) ≤ f', 1.0),
+                checker._calc_item(elem_id, '正应力', context, 'GB50017-2017 7.1.1', '(|N|/A + |Mₓ|/Wₙₓ) / f ≤ 1.0', 1.0),
                 checker._calc_item(elem_id, '剪应力', context, 'GB50017-2017 7.1.2', 'τ = V·S/(I·tw) ≤ f_v', 1.0),
                 checker._calc_item(elem_id, '折算应力', context, 'GB50017-2017 7.1.4', '√(σₓ²+σ_b²-σₓ·σ_b+3τ²) ≤ β₁·f', 1.0),
             ],

--- a/backend/src/agent-skills/code-check/gb50017/code_check.py
+++ b/backend/src/agent-skills/code-check/gb50017/code_check.py
@@ -1,9 +1,14 @@
+"""GB50017-2017 钢结构设计标准 — 构件校核实现。
+
+覆盖第 7 章（强度）、第 8 章（稳定）、第 10 章（刚度）中梁、柱、支撑的
+构件级验算。连接校核（第 9 章）不在本迭代范围内。
+"""
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 
-RULE_VERSION = 'gb50017-chaptered-v1'
+RULE_VERSION = 'v2-member-checks'
 CODE_VERSION = 'GB50017-2017'
 
 CHAPTERS = [
@@ -15,7 +20,7 @@ CHAPTERS = [
     {
         'id': 'chapter-8-stability',
         'title': '第8章 稳定验算',
-        'checks': ['整体稳定', '局部稳定', '长细比'],
+        'checks': ['整体稳定', '轴压稳定', '局部稳定', '长细比'],
     },
     {
         'id': 'chapter-10-serviceability',
@@ -30,25 +35,94 @@ def get_rules() -> Dict[str, Any]:
         'code': 'GB50017',
         'version': RULE_VERSION,
         'chapters': CHAPTERS,
+        'rules': [
+            {
+                'name': '强度验算',
+                'clause': 'GB50017-2017 Chapter 7',
+                'elementType': ['beam', 'column', 'brace'],
+                'checks': [
+                    {
+                        'item': '正应力',
+                        'clause': '7.1.1',
+                        'formula': 'σ = N/Aₙ ≤ f',
+                        'limit': 1.0,
+                        'params': ['N', 'A', 'f'],
+                    },
+                    {
+                        'item': '剪应力',
+                        'clause': '7.1.2',
+                        'formula': 'τ = V/(Aₙ·t) ≤ f_v',
+                        'limit': 1.0,
+                        'params': ['V', 'A', 'fv'],
+                    },
+                    {
+                        'item': '折算应力',
+                        'clause': '7.1.4',
+                        'formula': '√(σ² + 3τ²) ≤ β₁·f',
+                        'limit': 1.0,
+                        'params': ['sigma', 'tau', 'f'],
+                    },
+                ],
+            },
+            {
+                'name': '稳定验算',
+                'clause': 'GB50017-2017 Chapter 8',
+                'elementType': ['beam', 'column', 'brace'],
+                'checks': [
+                    {
+                        'item': '整体稳定',
+                        'clause': '8.2.1',
+                        'formula': 'M/(φb·Wₓ·f) ≤ 1.0',
+                        'limit': 1.0,
+                        'params': ['Mx', 'phi', 'Wnx', 'f'],
+                    },
+                    {
+                        'item': '轴压稳定',
+                        'clause': '8.1.1',
+                        'formula': 'N/(φ·A·f) ≤ 1.0',
+                        'limit': 1.0,
+                        'params': ['N', 'phi', 'A', 'f'],
+                    },
+                    {
+                        'item': '局部稳定',
+                        'clause': '8.4.1',
+                        'formula': 'b/t ≤ [b/t]',
+                        'limit': 1.0,
+                        'params': ['b', 't', 'btLimit'],
+                    },
+                ],
+            },
+            {
+                'name': '刚度验算',
+                'clause': 'GB50017-2017 Chapter 10',
+                'elementType': ['beam', 'column', 'brace'],
+                'checks': [
+                    {
+                        'item': '长细比',
+                        'clause': '8.3.1',
+                        'formula': 'λ = l₀/i ≤ [λ]',
+                        'limit': 1.0,
+                        'params': ['l0', 'i', 'lambdaLimit'],
+                    },
+                    {
+                        'item': '挠度',
+                        'clause': '10.2.1',
+                        'formula': 'f_max ≤ L/n',
+                        'limit': 1.0,
+                        'params': ['deflection', 'L', 'deflectionLimitN'],
+                    },
+                ],
+            },
+        ],
     }
 
 
-def check_element(checker: Any, elem_id: str, context: Dict[str, Any]) -> Dict[str, Any]:
-    element_context = _resolve_element_context(elem_id, context)
-    element_type = _resolve_element_type(element_context)
-    checks = _build_checks(checker, elem_id, context, element_type)
-    result = checker._build_element_result(elem_id, element_type, checks, CODE_VERSION)
-    result['chapters'] = _build_chapter_summaries(checks)
-    result['chapterCount'] = len(result['chapters'])
-    result['elementContext'] = {
-        'type': element_type,
-        'section': element_context.get('section'),
-        'material': element_context.get('material'),
-    }
-    return result
-
+# ---------------------------------------------------------------------------
+# Element type resolution
+# ---------------------------------------------------------------------------
 
 def _resolve_element_context(elem_id: str, context: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve element context from elementContextById (upstream PR #134)."""
     mapping = context.get('elementContextById', {})
     if isinstance(mapping, dict):
         value = mapping.get(elem_id)
@@ -57,66 +131,236 @@ def _resolve_element_context(elem_id: str, context: Dict[str, Any]) -> Dict[str,
     return {}
 
 
-def _resolve_element_type(element_context: Dict[str, Any]) -> str:
+def _resolve_element_type(elem_id: str, context: Dict[str, Any]) -> str:
+    """Determine element type from context or naming heuristics."""
+    # Prefer elementContextById (upstream)
+    element_context = _resolve_element_context(elem_id, context)
     raw_type = element_context.get('type')
-    normalized = str(raw_type or '').strip().lower()
-    if normalized in {'column', 'brace', 'beam'}:
-        return normalized
-    if 'column' in normalized:
+    if raw_type:
+        normalized = str(raw_type).strip().lower()
+        if normalized in {'column', 'brace', 'beam'}:
+            return normalized
+        if 'column' in normalized:
+            return 'column'
+        if 'brace' in normalized:
+            return 'brace'
+
+    # Fallback: elementData
+    element_data = context.get('elementData', {})
+    if isinstance(element_data, dict):
+        elem = element_data.get(elem_id, {})
+        if isinstance(elem, dict) and 'type' in elem:
+            return str(elem['type']).lower()
+
+    # Fallback: naming heuristics
+    lower = elem_id.lower()
+    if 'col' in lower:
         return 'column'
-    if 'brace' in normalized:
+    if 'brace' in lower or lower.startswith('br'):
         return 'brace'
     return 'beam'
 
 
-def _build_checks(checker: Any, elem_id: str, context: Dict[str, Any], element_type: str):
-    checks = []
-    checks.extend(_build_strength_checks(checker, elem_id, context, element_type))
-    checks.extend(_build_stability_checks(checker, elem_id, context, element_type))
-    checks.extend(_build_serviceability_checks(checker, elem_id, context, element_type))
-    return checks
+# ---------------------------------------------------------------------------
+# Utilization computation from elementData
+# ---------------------------------------------------------------------------
+
+def _ensure_utilization_overrides(elem_id: str, context: Dict[str, Any]) -> None:
+    """Pre-populate utilizationByElement from elementData where possible.
+
+    Only adds values that are not already present — caller overrides win.
+    """
+    element_data = context.get('elementData', {})
+    if not isinstance(element_data, dict):
+        return
+    elem = element_data.get(elem_id)
+    if not isinstance(elem, dict):
+        return
+
+    section = elem.get('section', {})
+    material = elem.get('material', {})
+    forces = elem.get('forces', {})
+    if not isinstance(section, dict) or not isinstance(material, dict) or not isinstance(forces, dict):
+        return
+
+    overrides = context.setdefault('utilizationByElement', {})
+    per_elem = overrides.setdefault(elem_id, {})
+
+    A = section.get('A')
+    f = material.get('f')
+    fv = material.get('fv')
+    N = forces.get('N')
+    V = forces.get('V')
+    Mx = forces.get('Mx')
+
+    # Normal stress: |N| / A / f
+    if '正应力' not in per_elem and A is not None and f is not None and N is not None:
+        try:
+            per_elem['正应力'] = abs(float(N)) / float(A) / float(f)
+        except (ZeroDivisionError, ValueError, TypeError):
+            pass
+
+    # Shear stress: |V| / A / fv
+    if '剪应力' not in per_elem and A is not None and fv is not None and V is not None:
+        try:
+            per_elem['剪应力'] = abs(float(V)) / float(A) / float(fv)
+        except (ZeroDivisionError, ValueError, TypeError):
+            pass
+
+    # Equivalent stress: sqrt(sigma^2 + 3*tau^2) / f
+    if '折算应力' not in per_elem and A is not None and f is not None and N is not None and V is not None:
+        try:
+            sigma = abs(float(N)) / float(A)
+            tau = abs(float(V)) / float(A)
+            per_elem['折算应力'] = (sigma ** 2 + 3 * tau ** 2) ** 0.5 / float(f)
+        except (ZeroDivisionError, ValueError, TypeError):
+            pass
+
+    # Overall beam stability: |Mx| / (phi * Wnx * f)
+    if '整体稳定' not in per_elem:
+        phi = elem.get('phi')
+        Wnx = section.get('Wnx') or section.get('Wx')
+        if phi is not None and Wnx is not None and f is not None and Mx is not None:
+            try:
+                per_elem['整体稳定'] = abs(float(Mx)) / (float(phi) * float(Wnx) * float(f))
+            except (ZeroDivisionError, ValueError, TypeError):
+                pass
+
+    # Axial compression stability: |N| / (phi * A * f)
+    if '轴压稳定' not in per_elem:
+        phi = elem.get('phi')
+        if phi is not None and A is not None and f is not None and N is not None:
+            try:
+                per_elem['轴压稳定'] = abs(float(N)) / (float(phi) * float(A) * float(f))
+            except (ZeroDivisionError, ValueError, TypeError):
+                pass
+
+    # Local plate stability: (b/t) / bt_limit
+    if '局部稳定' not in per_elem:
+        b = section.get('flangeWidth') or section.get('b')
+        t = section.get('flangeThickness') or section.get('t')
+        bt_limit = elem.get('btLimit')
+        if b is not None and t is not None and bt_limit is not None:
+            try:
+                per_elem['局部稳定'] = (float(b) / float(t)) / float(bt_limit)
+            except (ZeroDivisionError, ValueError, TypeError):
+                pass
+
+    # Slenderness ratio: (l0 / i) / lambda_limit
+    if '长细比' not in per_elem:
+        l0 = elem.get('length') or elem.get('l0')
+        i_min = section.get('imin') or section.get('i')
+        lambda_limit = elem.get('lambdaLimit')
+        if l0 is not None and i_min is not None and lambda_limit is not None:
+            try:
+                per_elem['长细比'] = float(l0) / float(i_min) / float(lambda_limit)
+            except (ZeroDivisionError, ValueError, TypeError):
+                pass
+
+    # Deflection: f_max / (L / n)
+    if '挠度' not in per_elem:
+        f_max = forces.get('deflection') or elem.get('deflection')
+        L = elem.get('length')
+        n_limit = elem.get('deflectionLimitN', 250)
+        if f_max is not None and L is not None:
+            try:
+                per_elem['挠度'] = abs(float(f_max)) / (float(L) / float(n_limit))
+            except (ZeroDivisionError, ValueError, TypeError):
+                pass
 
 
-def _build_strength_checks(checker: Any, elem_id: str, context: Dict[str, Any], element_type: str):
-    items = []
-    if element_type in {'beam', 'column'}:
-        items.append(checker._calc_item(elem_id, '正应力', context, 'GB50017-2017 7.1.1', 'σ = N/A <= f', 0.95))
-    if element_type in {'beam', 'brace'}:
-        items.append(checker._calc_item(elem_id, '剪应力', context, 'GB50017-2017 7.1.2', 'τ = V/Aw <= f_v', 0.95))
-    items.append(checker._calc_item(elem_id, '折算应力', context, 'GB50017-2017 7.1.4', 'sqrt(σ^2 + 3τ^2) <= f', 0.95))
-    return [{
-        'chapter': '第7章 强度验算',
-        'name': '强度验算',
-        'items': items,
-    }]
+# ---------------------------------------------------------------------------
+# Element-type-specific check builders
+# ---------------------------------------------------------------------------
 
-
-def _build_stability_checks(checker: Any, elem_id: str, context: Dict[str, Any], element_type: str):
-    items = [
-        checker._calc_item(elem_id, '整体稳定', context, 'GB50017-2017 8.2.1', 'N/(φ*A*f) <= 1.0', 1.0),
-        checker._calc_item(elem_id, '局部稳定', context, 'GB50017-2017 8.4.1', 'b/t <= λ_lim', 1.0),
+def _check_beam(checker: Any, elem_id: str, context: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return [
+        {
+            'chapter': '第7章 强度验算',
+            'name': '强度验算',
+            'items': [
+                checker._calc_item(elem_id, '正应力', context, 'GB50017-2017 7.1.1', 'σ = N/Aₙ ≤ f', 1.0),
+                checker._calc_item(elem_id, '剪应力', context, 'GB50017-2017 7.1.2', 'τ = V/(Aₙ·t) ≤ f_v', 1.0),
+                checker._calc_item(elem_id, '折算应力', context, 'GB50017-2017 7.1.4', '√(σ² + 3τ²) ≤ β₁·f', 1.0),
+            ],
+        },
+        {
+            'chapter': '第8章 稳定验算',
+            'name': '稳定验算',
+            'items': [
+                checker._calc_item(elem_id, '整体稳定', context, 'GB50017-2017 8.2.1', 'M/(φb·Wₓ·f) ≤ 1.0', 1.0),
+                checker._calc_item(elem_id, '局部稳定', context, 'GB50017-2017 8.4.1', 'b/t ≤ [b/t]', 1.0),
+            ],
+        },
+        {
+            'chapter': '第10章 正常使用极限状态',
+            'name': '刚度验算',
+            'items': [
+                checker._calc_item(elem_id, '挠度', context, 'GB50017-2017 10.2.1', 'f_max ≤ L/n', 1.0),
+            ],
+        },
     ]
-    if element_type != 'beam':
-        items.append(checker._calc_item(elem_id, '长细比', context, 'GB50017-2017 8.3.1', 'λ = l0/i <= λ_lim', 1.0))
-    return [{
-        'chapter': '第8章 稳定验算',
-        'name': '稳定验算',
-        'items': items,
-    }]
 
 
-def _build_serviceability_checks(checker: Any, elem_id: str, context: Dict[str, Any], element_type: str):
-    limit = 1.0 if element_type == 'beam' else 0.95
-    return [{
-        'chapter': '第10章 正常使用极限状态',
-        'name': '刚度验算',
-        'items': [
-            checker._calc_item(elem_id, '挠度', context, 'GB50017-2017 10.2.1', 'f <= l/250', limit),
-        ],
-    }]
+def _check_column(checker: Any, elem_id: str, context: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return [
+        {
+            'chapter': '第7章 强度验算',
+            'name': '强度验算',
+            'items': [
+                checker._calc_item(elem_id, '正应力', context, 'GB50017-2017 7.1.1', 'σ = N/Aₙ ≤ f', 1.0),
+            ],
+        },
+        {
+            'chapter': '第8章 稳定验算',
+            'name': '稳定验算',
+            'items': [
+                checker._calc_item(elem_id, '轴压稳定', context, 'GB50017-2017 8.1.1', 'N/(φ·A·f) ≤ 1.0', 1.0),
+                checker._calc_item(elem_id, '局部稳定', context, 'GB50017-2017 8.4.1', 'b/t ≤ [b/t]', 1.0),
+            ],
+        },
+        {
+            'chapter': '第10章 正常使用极限状态',
+            'name': '刚度验算',
+            'items': [
+                checker._calc_item(elem_id, '长细比', context, 'GB50017-2017 8.3.1', 'λ = l₀/i ≤ [λ]', 1.0),
+            ],
+        },
+    ]
 
 
-def _build_chapter_summaries(checks):
+def _check_brace(checker: Any, elem_id: str, context: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return [
+        {
+            'chapter': '第7章 强度验算',
+            'name': '强度验算',
+            'items': [
+                checker._calc_item(elem_id, '正应力', context, 'GB50017-2017 7.1.1', 'σ = N/Aₙ ≤ f', 1.0),
+            ],
+        },
+        {
+            'chapter': '第8章 稳定验算',
+            'name': '稳定验算',
+            'items': [
+                checker._calc_item(elem_id, '轴压稳定', context, 'GB50017-2017 8.1.1', 'N/(φ·A·f) ≤ 1.0', 1.0),
+                checker._calc_item(elem_id, '局部稳定', context, 'GB50017-2017 8.4.1', 'b/t ≤ [b/t]', 1.0),
+            ],
+        },
+        {
+            'chapter': '第10章 正常使用极限状态',
+            'name': '刚度验算',
+            'items': [
+                checker._calc_item(elem_id, '长细比', context, 'GB50017-2017 8.3.1', 'λ = l₀/i ≤ [λ]', 1.0),
+            ],
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Chapter summaries (from upstream PR #134)
+# ---------------------------------------------------------------------------
+
+def _build_chapter_summaries(checks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     chapters = []
     for check in checks:
         chapter_name = check.get('chapter') or check.get('name')
@@ -139,3 +383,32 @@ def _build_chapter_summaries(checks):
             'controllingClause': controlling_clause,
         })
     return chapters
+
+
+# ---------------------------------------------------------------------------
+# Main dispatcher
+# ---------------------------------------------------------------------------
+
+_BUILDERS = {
+    'beam': _check_beam,
+    'column': _check_column,
+    'brace': _check_brace,
+}
+
+
+def check_element(checker: Any, elem_id: str, context: Dict[str, Any]) -> Dict[str, Any]:
+    """GB50017-2017 构件校核入口。"""
+    element_context = _resolve_element_context(elem_id, context)
+    element_type = _resolve_element_type(elem_id, context)
+    _ensure_utilization_overrides(elem_id, context)
+    builder = _BUILDERS.get(element_type, _check_beam)
+    checks = builder(checker, elem_id, context)
+    result = checker._build_element_result(elem_id, element_type, checks, CODE_VERSION)
+    result['chapters'] = _build_chapter_summaries(checks)
+    result['chapterCount'] = len(result['chapters'])
+    result['elementContext'] = {
+        'type': element_type,
+        'section': element_context.get('section'),
+        'material': element_context.get('material'),
+    }
+    return result

--- a/backend/src/agent-skills/code-check/gb50017/code_check.py
+++ b/backend/src/agent-skills/code-check/gb50017/code_check.py
@@ -198,6 +198,11 @@ def _compute_utilization_overrides(
 
     computed: Dict[str, float] = {}
 
+    def _has_override(key: str) -> bool:
+        """Check if caller provided a numeric override for this check item."""
+        val = per_elem.get(key)
+        return isinstance(val, (int, float))
+
     A = section.get('A')
     f = material.get('f')
     fv = material.get('fv')
@@ -210,7 +215,7 @@ def _compute_utilization_overrides(
     Wnx = section.get('Wnx') or section.get('Wx')
 
     # Normal stress: (|N|/A + |Mx|/Wnx) / f  (GB50017-2017 7.1.1)
-    if '正应力' not in per_elem and A is not None and f is not None and N is not None:
+    if not _has_override('正应力') and A is not None and f is not None and N is not None:
         try:
             sigma_axial = abs(float(N)) / float(A)
             sigma_bending = 0.0
@@ -222,7 +227,7 @@ def _compute_utilization_overrides(
 
     # Shear stress: |V|*S/(I*tw) / fv  (GB50017-2017 7.1.2)
     #   Falls back to |V|/As/fv when S/I/tw not available but As is
-    if '剪应力' not in per_elem and fv is not None and V is not None:
+    if not _has_override('剪应力') and fv is not None and V is not None:
         try:
             As = section.get('As')  # explicit shear area
             if S is not None and I is not None and tw is not None:
@@ -235,7 +240,7 @@ def _compute_utilization_overrides(
 
     # Equivalent stress: sqrt(sigma_axial^2 + sigma_bending^2
     #   - sigma_axial*sigma_bending + 3*tau^2) / f  (GB50017-2017 7.1.4)
-    if '折算应力' not in per_elem and A is not None and f is not None and N is not None and V is not None:
+    if not _has_override('折算应力') and A is not None and f is not None and N is not None and V is not None:
         try:
             sigma_axial = abs(float(N)) / float(A)
             sigma_bending = 0.0
@@ -261,7 +266,7 @@ def _compute_utilization_overrides(
             pass
 
     # Overall beam stability: |Mx| / (phi_b * Wnx * f)
-    if '整体稳定' not in per_elem:
+    if not _has_override('整体稳定'):
         phi = elem.get('phi_b') or elem.get('phi')
         if phi is not None and Wnx is not None and f is not None and Mx is not None:
             try:
@@ -272,7 +277,7 @@ def _compute_utilization_overrides(
                 pass
 
     # Axial compression stability: |N| / (phi_axial * A * f)
-    if '轴压稳定' not in per_elem:
+    if not _has_override('轴压稳定'):
         phi = elem.get('phi_axial') or elem.get('phi')
         if phi is not None and A is not None and f is not None and N is not None:
             try:
@@ -281,7 +286,7 @@ def _compute_utilization_overrides(
                 pass
 
     # Local plate stability: (b/t) / bt_limit
-    if '局部稳定' not in per_elem:
+    if not _has_override('局部稳定'):
         b = section.get('flangeWidth') or section.get('b')
         t = section.get('flangeThickness') or section.get('t')
         bt_limit = elem.get('btLimit')
@@ -292,7 +297,7 @@ def _compute_utilization_overrides(
                 pass
 
     # Slenderness ratio: (l0 / i) / lambda_limit
-    if '长细比' not in per_elem:
+    if not _has_override('长细比'):
         l0 = elem.get('length') or elem.get('l0')
         i_min = section.get('imin') or section.get('i')
         lambda_limit = elem.get('lambdaLimit')
@@ -303,7 +308,7 @@ def _compute_utilization_overrides(
                 pass
 
     # Deflection: f_max / (L / n)  — only when deflectionLimitN explicitly provided
-    if '挠度' not in per_elem:
+    if not _has_override('挠度'):
         f_max = forces.get('deflection')
         if f_max is None:
             f_max = elem.get('deflection')


### PR DESCRIPTION
## Summary

- Replace stub `gb50017/code_check.py` with proper implementation that computes real utilization ratios from elementData (section/material/forces)
- Support beam, column, and brace element types with appropriate GB50017-2017 checks
- Add 46 pytest unit tests covering all check types, edge cases, and backward compatibility

## Impacted areas

- `backend` (agent-skills/code-check/gb50017/)

## What changed

**`code_check.py`** — replaced stub with:
- `get_rules()`: structured rule definitions with version `v2-member-checks`
- `_resolve_element_type()`: determine beam/column/brace from context or naming heuristics
- `_ensure_utilization_overrides()`: compute utilization ratios from elementData and inject into context
- `_check_beam()`: strength (7.1.1/7.1.2/7.1.4) + stability (8.2.1/8.4.1) + deflection (10.2.1)
- `_check_column()`: strength (7.1.1) + axial stability (8.1.1/8.4.1) + slenderness (8.3.1)
- `_check_brace()`: same as column with axial-dominant checks
- Graceful fallback to deterministic mechanism when data is incomplete

**`__tests__/test_code_check.py`** — new file with 46 tests:
- Rule structure validation
- Element type resolution (context + heuristics + defaults)
- Utilization computation for all 8 check types
- Caller override priority, partial data, zero-division safety
- Backward compatibility with existing traceability contract
- Clause reference correctness

## Test plan

- [x] 46 pytest unit tests pass
- [x] `validate_code_check_traceability` regression test passes
- [x] Backend TypeScript build succeeds
- [ ] `npm run lint --prefix backend` (CI will verify)
- [ ] Full backend regression suite (`node tests/runner.mjs check backend-regression`)