### PR TITLE
fix(ci): support minute-format durations in E2E test summary

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -150,7 +150,7 @@ jobs:
             echo "summary=Tests did not produce output." >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          SUMMARY=$(grep -E '^[[:space:]]*[0-9]+ passed.*\(([0-9]+m[[:space:]]+)?[0-9]+(\.[0-9]+)?s\)' test-output.txt || grep -E '^[[:space:]]*[0-9]+ failed' test-output.txt || echo "No summary found")
+          SUMMARY=$(grep -E '^[[:space:]]*[0-9]+ (passed|failed).*\(([0-9]+m[[:space:]]+)?[0-9]+(\.[0-9]+)?(m|s)\)' test-output.txt || grep -E '^[[:space:]]*[0-9]+ failed' test-output.txt || echo "No summary found")
           echo "summary<<EOF" >> "$GITHUB_OUTPUT"
           echo "$SUMMARY" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Fix regex in `Extract test summary` step to match Playwright's minute-format durations (`1.5m`), which are used when test runs exceed 60 seconds.

## Changes

The original regex required a `s` suffix, so durations like `(1.5m)` were never captured. Updated to match both `s` and `m` suffixes:

- `(5.2s)` — seconds
- `(1.5m)` — minutes (was missed)
- `(1m 30s)` — minutes + seconds

Also added `failed` as an alternative keyword alongside `passed` in the first grep, so failed test summaries with durations are captured directly instead of falling through to the second grep.

## Test plan

- [x] Verified regex matches all Playwright output formats: `5.2s`, `1.5m`, `1m 30s`, `12s`, `failed (2.1s)`, `failed (1.0m)`