### PR TITLE
fix(frontend): keep 3D visualization grid on floor when switching planes

### DIFF
--- a/frontend/src/components/visualization/structural-scene-utils.ts
+++ b/frontend/src/components/visualization/structural-scene-utils.ts
@@ -173,11 +173,16 @@ function planeGridFallback(plane: VisualizationPlane) {
 
 export function getAdaptiveGridConfig(snapshot: VisualizationSnapshot, plane: VisualizationPlane) {
   if (!snapshot.nodes.length) {
-    return planeGridFallback(plane)
+    return planeGridFallback(snapshot.dimension === 3 ? 'xy' : plane)
   }
 
+  // For 3D mode, always compute grid from raw positions (z-up canonical).
+  // The grid should always be the horizontal floor (XY plane) at minZ,
+  // regardless of which analysis plane the user selected.
+  const effectivePlane = snapshot.dimension === 3 ? 'xy' : plane
+
   const projected = snapshot.nodes.map((node) =>
-    projectPosition(new THREE.Vector3(node.position.x, node.position.y, node.position.z), plane, snapshot.dimension),
+    projectPosition(new THREE.Vector3(node.position.x, node.position.y, node.position.z), effectivePlane, snapshot.dimension),
   )
   const xs = projected.map((p) => p.x)
   const ys = projected.map((p) => p.y)
@@ -197,7 +202,7 @@ export function getAdaptiveGridConfig(snapshot: VisualizationSnapshot, plane: Vi
   )
   const offset = Math.max(offsetBase * 0.01, 0.001)
 
-  if (plane === 'xy') {
+  if (effectivePlane === 'xy') {
     const spanX = Math.max(maxX - minX, 1)
     const spanY = Math.max(maxY - minY, 1)
     const span = Math.max(spanX, spanY)
@@ -211,7 +216,7 @@ export function getAdaptiveGridConfig(snapshot: VisualizationSnapshot, plane: Vi
     }
   }
 
-  if (plane === 'yz') {
+  if (effectivePlane === 'yz') {
     const spanY = Math.max(maxY - minY, 1)
     const spanZ = Math.max(maxZ - minZ, 1)
     const span = Math.max(spanY, spanZ)

--- a/frontend/tests/components/visualization-structural-scene-utils.test.ts
+++ b/frontend/tests/components/visualization-structural-scene-utils.test.ts
@@ -39,6 +39,20 @@ describe('structural-scene-utils', () => {
     expect(config.position[2]).toBeLessThan(0)
   })
 
+  it('keeps the 3d grid on the xy floor regardless of selected plane', () => {
+    // Switching to xz or yz in 3D should NOT move the grid to a wall.
+    const xzConfig = getAdaptiveGridConfig(sample3dSnapshot, 'xz')
+    const yzConfig = getAdaptiveGridConfig(sample3dSnapshot, 'yz')
+
+    // Both should produce the same XY floor grid as the 'xy' selection.
+    const xyConfig = getAdaptiveGridConfig(sample3dSnapshot, 'xy')
+
+    expect(xzConfig.rotation).toEqual(xyConfig.rotation)
+    expect(xzConfig.position).toEqual(xyConfig.position)
+    expect(yzConfig.rotation).toEqual(xyConfig.rotation)
+    expect(yzConfig.position).toEqual(xyConfig.position)
+  })
+
   it('uses a top-down orthographic preset for xy plane views', () => {
     expect(getPlaneCameraPreset('xy')).toEqual({
       position: [0, 0, 10],


### PR DESCRIPTION
## Summary

- The global-z-up migration (7b30ddb) introduced per-plane grid positioning that caused the grid to become a vertical wall when XZ or YZ was selected in 3D mode. For 3D z-up scenes the floor is always the XY plane at minZ — the grid must stay horizontal regardless of which analysis plane is active.

## Changes

- `structural-scene-utils.ts`: introduce `effectivePlane` that forces `'xy'` for `dimension === 3`, ensuring the grid always sits at the bottom of the structure
- `visualization-structural-scene-utils.test.ts`: add test verifying XZ and YZ selections in 3D produce the same grid position/rotation as XY

## Test plan

- [x] `npx vitest run tests/components/visualization-structural-scene-utils.test.ts` — 5/5 passed
- [x] `npx vitest run` (full frontend suite) — 184/184 passed, 25 files