### PR TITLE
fix: frontend markdown rendering in result panels

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-markdown": "^9.0.1",
+        "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^3.4.3",
@@ -6891,6 +6892,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6899,6 +6910,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -6919,6 +6958,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7152,6 +7292,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -8674,6 +8935,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -8701,6 +8980,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-markdown": "^9.0.1",
+    "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^3.4.3",

--- a/frontend/src/components/chat/ai-console.tsx
+++ b/frontend/src/components/chat/ai-console.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import { ArrowUp, Bot, BrainCircuit, Clock3, Cuboid, FileText, Loader2, Maximize2, MessageSquarePlus, Orbit, Sparkles, Square, Trash2, User } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -297,6 +298,22 @@ type CapabilityMatrixPayload = {
   filteredEngineReasonsBySkill?: Record<string, Record<string, string[]>>
   canonicalSkillIdByAlias?: Record<string, string>
   skillAliasesByCanonicalId?: Record<string, string[]>
+}
+
+const MARKDOWN_BODY_CLASS = 'prose prose-sm max-w-none prose-headings:text-foreground prose-p:my-0 prose-p:text-muted-foreground prose-strong:text-foreground prose-code:text-cyan-700 prose-pre:bg-muted/60 prose-a:text-cyan-700 prose-a:no-underline hover:prose-a:text-cyan-600 prose-table:my-4 prose-table:w-full prose-th:border prose-th:border-border/70 prose-th:bg-background/70 prose-th:px-3 prose-th:py-2 prose-th:text-left prose-th:text-foreground prose-td:border prose-td:border-border/50 prose-td:px-3 prose-td:py-2 prose-td:text-muted-foreground dark:prose-invert dark:prose-code:text-cyan-200 dark:prose-pre:bg-black/30 dark:prose-a:text-cyan-200 dark:hover:prose-a:text-cyan-100 dark:prose-th:border-white/10 dark:prose-th:bg-white/5 dark:prose-td:border-white/10'
+
+function MarkdownBody({
+  content,
+  className,
+}: {
+  content: string
+  className?: string
+}) {
+  return (
+    <div className={cn(MARKDOWN_BODY_CLASS, className)}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+    </div>
+  )
 }
 
 
@@ -1352,9 +1369,7 @@ function AnalysisPanel({
                 </div>
                 <div>
                   <CardTitle className="text-xl text-foreground">{t('executionSummary')}</CardTitle>
-                  <CardDescription className="text-muted-foreground">
-                    {result.response || t('noNaturalLanguageSummary')}
-                  </CardDescription>
+                  <MarkdownBody content={result.response || t('noNaturalLanguageSummary')} />
                 </div>
               </CardHeader>
               {(stats.length > 0 || result.plan?.length) && (
@@ -1442,9 +1457,7 @@ function AnalysisPanel({
               >
                 <CardHeader>
                   <CardTitle className="text-lg">{t('guidancePanelTitle')}</CardTitle>
-                  <CardDescription className="text-muted-foreground">
-                    {result.response || t('guidancePanelBody')}
-                  </CardDescription>
+                  <MarkdownBody content={result.response || t('guidancePanelBody')} />
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="grid gap-3 md:grid-cols-2">
@@ -1459,7 +1472,7 @@ function AnalysisPanel({
                   {guidance.fallbackSupportNote && (
                     <div className="rounded-2xl border border-cyan-300/30 bg-cyan-300/10 p-4 text-sm leading-6 text-foreground">
                       <div className="mb-2 text-xs uppercase tracking-[0.18em] text-cyan-700 dark:text-cyan-200">{t('guidanceSupportNote')}</div>
-                      <div>{guidance.fallbackSupportNote}</div>
+                      <MarkdownBody content={guidance.fallbackSupportNote} className="prose-p:text-foreground dark:prose-p:text-foreground" />
                     </div>
                   )}
 
@@ -1492,7 +1505,7 @@ function AnalysisPanel({
                   {guidance.recommendedNextStep && (
                     <div className="rounded-2xl border border-border/70 bg-background/70 p-4 dark:border-white/10 dark:bg-white/5">
                       <div className="mb-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('guidanceRecommendedNextStep')}</div>
-                      <div className="text-sm leading-6 text-foreground">{guidance.recommendedNextStep}</div>
+                      <MarkdownBody content={guidance.recommendedNextStep} className="prose-p:text-foreground dark:prose-p:text-foreground" />
                     </div>
                   )}
                 </CardContent>
@@ -1527,8 +1540,8 @@ function AnalysisPanel({
                     {t('reportSummary')}
                   </CardTitle>
                 </CardHeader>
-                <CardContent className="text-sm leading-7 text-muted-foreground">
-                  {reportSummary}
+                <CardContent>
+                  <MarkdownBody content={reportSummary} />
                 </CardContent>
               </Card>
             )}
@@ -1542,8 +1555,8 @@ function AnalysisPanel({
               </CardHeader>
               <CardContent>
                 {reportMarkdown ? (
-                  <article className="prose prose-sm max-w-none dark:prose-invert prose-headings:text-foreground prose-p:text-muted-foreground prose-strong:text-foreground prose-code:text-cyan-700 dark:prose-code:text-cyan-200">
-                    <ReactMarkdown>{reportMarkdown}</ReactMarkdown>
+                  <article>
+                    <MarkdownBody content={reportMarkdown} />
                   </article>
                 ) : (
                   <div className="rounded-2xl border border-dashed border-border/70 bg-background/70 p-6 text-sm text-muted-foreground dark:border-white/10 dark:bg-white/5">

--- a/frontend/src/components/chat/ai-console.tsx
+++ b/frontend/src/components/chat/ai-console.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
-import ReactMarkdown from 'react-markdown'
+import ReactMarkdown, { defaultUrlTransform, type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { ArrowUp, Bot, BrainCircuit, Clock3, Cuboid, FileText, Loader2, Maximize2, MessageSquarePlus, Orbit, Sparkles, Square, Trash2, User } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
@@ -300,18 +300,32 @@ type CapabilityMatrixPayload = {
   skillAliasesByCanonicalId?: Record<string, string[]>
 }
 
-const MARKDOWN_BODY_CLASS = 'prose prose-sm max-w-none prose-headings:text-foreground prose-p:my-0 prose-p:text-muted-foreground prose-strong:text-foreground prose-code:text-cyan-700 prose-pre:bg-muted/60 prose-a:text-cyan-700 prose-a:no-underline hover:prose-a:text-cyan-600 prose-table:my-4 prose-table:w-full prose-th:border prose-th:border-border/70 prose-th:bg-background/70 prose-th:px-3 prose-th:py-2 prose-th:text-left prose-th:text-foreground prose-td:border prose-td:border-border/50 prose-td:px-3 prose-td:py-2 prose-td:text-muted-foreground dark:prose-invert dark:prose-code:text-cyan-200 dark:prose-pre:bg-black/30 dark:prose-a:text-cyan-200 dark:hover:prose-a:text-cyan-100 dark:prose-th:border-white/10 dark:prose-th:bg-white/5 dark:prose-td:border-white/10'
+const MARKDOWN_BODY_BASE_CLASS = 'prose prose-sm max-w-none prose-headings:text-foreground prose-p:text-muted-foreground prose-strong:text-foreground prose-code:text-cyan-700 prose-pre:bg-muted/60 prose-a:text-cyan-700 prose-a:no-underline hover:prose-a:text-cyan-600 prose-table:my-4 prose-table:w-full prose-th:border prose-th:border-border/70 prose-th:bg-background/70 prose-th:px-3 prose-th:py-2 prose-th:text-left prose-th:text-foreground prose-td:border prose-td:border-border/50 prose-td:px-3 prose-td:py-2 prose-td:text-muted-foreground dark:prose-invert dark:prose-code:text-cyan-200 dark:prose-pre:bg-black/30 dark:prose-a:text-cyan-200 dark:hover:prose-a:text-cyan-100 dark:prose-th:border-white/10 dark:prose-th:bg-white/5 dark:prose-td:border-white/10'
+const MARKDOWN_BODY_COMPACT_CLASS = `${MARKDOWN_BODY_BASE_CLASS} prose-p:my-0`
+
+function rewriteMarkdownUrl(url: string) {
+  const safeUrl = defaultUrlTransform(url)
+  return safeUrl.startsWith('/') ? `${API_BASE}${safeUrl}` : safeUrl
+}
+
+const MARKDOWN_COMPONENTS: Components = {
+  a: ({ href, ...props }) => <a {...props} href={href} target="_blank" rel="noopener noreferrer" />,
+}
 
 function MarkdownBody({
   content,
   className,
+  compact = false,
 }: {
   content: string
   className?: string
+  compact?: boolean
 }) {
   return (
-    <div className={cn(MARKDOWN_BODY_CLASS, className)}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+    <div className={cn(compact ? MARKDOWN_BODY_COMPACT_CLASS : MARKDOWN_BODY_BASE_CLASS, className)}>
+      <ReactMarkdown components={MARKDOWN_COMPONENTS} remarkPlugins={[remarkGfm]} urlTransform={rewriteMarkdownUrl}>
+        {content}
+      </ReactMarkdown>
     </div>
   )
 }
@@ -1369,7 +1383,7 @@ function AnalysisPanel({
                 </div>
                 <div>
                   <CardTitle className="text-xl text-foreground">{t('executionSummary')}</CardTitle>
-                  <MarkdownBody content={result.response || t('noNaturalLanguageSummary')} />
+                  <MarkdownBody compact content={result.response || t('noNaturalLanguageSummary')} />
                 </div>
               </CardHeader>
               {(stats.length > 0 || result.plan?.length) && (
@@ -1457,7 +1471,7 @@ function AnalysisPanel({
               >
                 <CardHeader>
                   <CardTitle className="text-lg">{t('guidancePanelTitle')}</CardTitle>
-                  <MarkdownBody content={result.response || t('guidancePanelBody')} />
+                  <MarkdownBody compact content={result.response || t('guidancePanelBody')} />
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="grid gap-3 md:grid-cols-2">
@@ -1472,7 +1486,7 @@ function AnalysisPanel({
                   {guidance.fallbackSupportNote && (
                     <div className="rounded-2xl border border-cyan-300/30 bg-cyan-300/10 p-4 text-sm leading-6 text-foreground">
                       <div className="mb-2 text-xs uppercase tracking-[0.18em] text-cyan-700 dark:text-cyan-200">{t('guidanceSupportNote')}</div>
-                      <MarkdownBody content={guidance.fallbackSupportNote} className="prose-p:text-foreground dark:prose-p:text-foreground" />
+                      <MarkdownBody compact content={guidance.fallbackSupportNote} className="prose-p:text-foreground dark:prose-p:text-foreground" />
                     </div>
                   )}
 
@@ -1505,7 +1519,7 @@ function AnalysisPanel({
                   {guidance.recommendedNextStep && (
                     <div className="rounded-2xl border border-border/70 bg-background/70 p-4 dark:border-white/10 dark:bg-white/5">
                       <div className="mb-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('guidanceRecommendedNextStep')}</div>
-                      <MarkdownBody content={guidance.recommendedNextStep} className="prose-p:text-foreground dark:prose-p:text-foreground" />
+                      <MarkdownBody compact content={guidance.recommendedNextStep} className="prose-p:text-foreground dark:prose-p:text-foreground" />
                     </div>
                   )}
                 </CardContent>

--- a/frontend/tests/integration/console-page.test.tsx
+++ b/frontend/tests/integration/console-page.test.tsx
@@ -155,6 +155,8 @@ const archivedResult = {
   },
 }
 
+const modelJsonPlaceholderPattern = /Paste StructureModel v2 JSON here|将 StructureModel v2 JSON 粘贴到这里/
+
 function createSseResponse(events: unknown[]) {
   const encoder = new TextEncoder()
   const chunks = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).concat('data: [DONE]\n\n')
@@ -295,7 +297,7 @@ describe('ConsolePage Integration (CONS-13)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Expand Engineering Context|展开工程上下文/ }))
 
-    const modelInput = screen.getByPlaceholderText(/Paste StructureModel v1 JSON here|将 StructureModel v1 JSON 粘贴到这里/)
+    const modelInput = screen.getByPlaceholderText(modelJsonPlaceholderPattern)
     fireEvent.change(modelInput, { target: { value: sampleModelJson } })
 
     await waitFor(() => {
@@ -637,12 +639,14 @@ describe('ConsolePage Integration (CONS-13)', () => {
     }))
     expect(screen.getByText(/Stream stopped|已停止/)).toBeInTheDocument()
 
-    const stored = JSON.parse(window.localStorage.getItem('structureclaw.console.conversations') || '{}')
-    expect(stored['conv-stop']?.messages?.at(-1)).toEqual(expect.objectContaining({
-      role: 'assistant',
-      content: '',
-      status: 'aborted',
-    }))
+    await waitFor(() => {
+      const stored = JSON.parse(window.localStorage.getItem('structureclaw.console.conversations') || '{}')
+      expect(stored['conv-stop']?.messages?.at(-1)).toEqual(expect.objectContaining({
+        role: 'assistant',
+        content: '',
+        status: 'aborted',
+      }))
+    })
   })
 
   it.skipIf(!hasLlmKey)('shows conversation-list timeout when the backend request hangs', async () => {
@@ -789,7 +793,7 @@ describe('ConsolePage Integration (CONS-13)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Expand Engineering Context|展开工程上下文/ }))
 
-    const modelInput = screen.getByPlaceholderText(/Paste StructureModel v1 JSON here|将 StructureModel v1 JSON 粘贴到这里/) as HTMLTextAreaElement
+    const modelInput = screen.getByPlaceholderText(modelJsonPlaceholderPattern) as HTMLTextAreaElement
     expect(modelInput.value).toContain('"schema_version": "1.0.0"')
     expect(screen.queryByText(/^Design Code$|^设计规范$/)).not.toBeInTheDocument()
     expect(screen.getByText('Archived summary')).toBeInTheDocument()
@@ -871,7 +875,7 @@ describe('ConsolePage Integration (CONS-13)', () => {
     fireEvent.click(screen.getByRole('button', { name: /New Conversation|新建对话/ }))
     fireEvent.click(screen.getByRole('button', { name: /Expand Engineering Context|展开工程上下文/ }))
 
-    const modelInput = screen.getByPlaceholderText(/Paste StructureModel v1 JSON here|将 StructureModel v1 JSON 粘贴到这里/) as HTMLTextAreaElement
+    const modelInput = screen.getByPlaceholderText(modelJsonPlaceholderPattern) as HTMLTextAreaElement
     expect(modelInput.value).toBe('')
     expect(screen.queryByText('Archived summary')).not.toBeInTheDocument()
     expect(screen.queryByText(/Analysis Engine Auto|计算引擎 自动选择/)).not.toBeInTheDocument()
@@ -1010,7 +1014,7 @@ describe('ConsolePage Integration (CONS-13)', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: /Expand Engineering Context|展开工程上下文/ }))
-    const modelInput = screen.getByPlaceholderText(/Paste StructureModel v1 JSON here|将 StructureModel v1 JSON 粘贴到这里/) as HTMLTextAreaElement
+    const modelInput = screen.getByPlaceholderText(modelJsonPlaceholderPattern) as HTMLTextAreaElement
     fireEvent.change(modelInput, { target: { value: sampleModelJson } })
 
     const titleButtons = screen.getAllByRole('button').filter((button) => (
@@ -1851,7 +1855,7 @@ describe('ConsolePage Integration (CONS-13)', () => {
     await renderConsolePage()
 
     fireEvent.click(screen.getByRole('button', { name: /Expand Engineering Context|展开工程上下文/ }))
-    const modelInput = screen.getByPlaceholderText(/Paste StructureModel v1 JSON here|将 StructureModel v1 JSON 粘贴到这里/)
+    const modelInput = screen.getByPlaceholderText(modelJsonPlaceholderPattern)
     fireEvent.change(modelInput, { target: { value: '{"schema_version":' } })
     fireEvent.change(screen.getByPlaceholderText(/Describe your structural goal|描述你的结构目标/), {
       target: { value: 'Please draft a beam model' },
@@ -1995,7 +1999,7 @@ describe('ConsolePage Integration (CONS-13)', () => {
     await renderConsolePage()
 
     fireEvent.click(screen.getByRole('button', { name: /Expand Engineering Context|展开工程上下文/ }))
-    fireEvent.change(screen.getByPlaceholderText(/Paste StructureModel v1 JSON here|将 StructureModel v1 JSON 粘贴到这里/), {
+    fireEvent.change(screen.getByPlaceholderText(modelJsonPlaceholderPattern), {
       target: { value: sampleModelJson },
     })
     fireEvent.change(screen.getByPlaceholderText(/Describe your structural goal|描述你的结构目标/), {
@@ -2080,7 +2084,7 @@ describe('ConsolePage Integration (CONS-13)', () => {
     setCapabilityPreferences(['generic', 'opensees-static', 'code-check-gb50017'])
     await renderConsolePage()
     fireEvent.click(screen.getByRole('button', { name: /Expand Engineering Context|展开工程上下文/ }))
-    fireEvent.change(screen.getByPlaceholderText(/Paste StructureModel v1 JSON here|将 StructureModel v1 JSON 粘贴到这里/), {
+    fireEvent.change(screen.getByPlaceholderText(modelJsonPlaceholderPattern), {
       target: { value: sampleModelJson },
     })
     fireEvent.change(screen.getByPlaceholderText(/Describe your structural goal|描述你的结构目标/), {
@@ -2153,7 +2157,7 @@ describe('ConsolePage Integration (CONS-13)', () => {
     await renderConsolePage()
 
     fireEvent.click(screen.getByRole('button', { name: /Expand Engineering Context|展开工程上下文/ }))
-    fireEvent.change(screen.getByPlaceholderText(/Paste StructureModel v1 JSON here|将 StructureModel v1 JSON 粘贴到这里/), {
+    fireEvent.change(screen.getByPlaceholderText(modelJsonPlaceholderPattern), {
       target: { value: sampleModelJson },
     })
     fireEvent.change(screen.getByPlaceholderText(/Describe your structural goal|描述你的结构目标/), {

--- a/frontend/tests/integration/console-page.test.tsx
+++ b/frontend/tests/integration/console-page.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import ConsolePage from '../../src/app/(console)/console/page'
 import type { VisualizationSnapshot } from '../../src/components/visualization'
+import { API_BASE } from '@/lib/api-base'
 import { CAPABILITY_PREFERENCE_STORAGE_KEY } from '@/lib/capability-preference'
 import { clearLocaleCookie, LOCALE_STORAGE_KEY, normalizeLocale } from '@/lib/locale-preference'
 import { AppStoreProvider } from '@/lib/stores/context'
@@ -1701,6 +1702,169 @@ describe('ConsolePage Integration (CONS-13)', () => {
     expect(within(reportTable).getByRole('columnheader', { name: 'Drift' })).toBeInTheDocument()
     expect(within(reportTable).getByText('SLS')).toBeInTheDocument()
     expect(within(reportTable).getByText('1/350')).toBeInTheDocument()
+  })
+
+  it('rewrites backend-relative markdown links to API_BASE urls', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'en')
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input)
+      const supportResponse = mockConsoleSupportRequest(url)
+      if (supportResponse) {
+        return supportResponse
+      }
+
+      if (url.includes('/api/v1/analysis-engines')) {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({ engines: [] }),
+        } as unknown as Response
+      }
+
+      if (url.includes('/api/v1/chat/conversations')) {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue([]),
+        } as unknown as Response
+      }
+
+      if (url.includes('/api/v1/chat/conversation') && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({
+            id: 'conv-markdown-links',
+            title: 'Markdown links',
+            type: 'general',
+            createdAt: '2026-04-20T08:00:00.000Z',
+            updatedAt: '2026-04-20T08:00:00.000Z',
+          }),
+        } as unknown as Response
+      }
+
+      if (url.includes('/api/v1/chat/stream')) {
+        return createSseResponse([
+          {
+            type: 'result',
+            content: {
+              response: 'Execution done.',
+              success: true,
+              report: {
+                summary: '[Download artifact](/api/v1/files/serve?path=report.md)',
+                markdown: '[Open backend file](/api/v1/files/serve?path=report.md)',
+              },
+            },
+          },
+        ])
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await renderConsolePage()
+
+    fireEvent.change(screen.getByPlaceholderText(/Describe your structural goal|描述你的结构目标/), {
+      target: { value: 'Render markdown links' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^Send$|^发送$/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Report$|^报告$/ })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Report$|^报告$/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Download artifact' })).toHaveAttribute('href', `${API_BASE}/api/v1/files/serve?path=report.md`)
+    })
+    expect(screen.getByRole('link', { name: 'Open backend file' })).toHaveAttribute('href', `${API_BASE}/api/v1/files/serve?path=report.md`)
+  })
+
+  it('keeps compact paragraph spacing out of the report markdown containers', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'en')
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input)
+      const supportResponse = mockConsoleSupportRequest(url)
+      if (supportResponse) {
+        return supportResponse
+      }
+
+      if (url.includes('/api/v1/analysis-engines')) {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({ engines: [] }),
+        } as unknown as Response
+      }
+
+      if (url.includes('/api/v1/chat/conversations')) {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue([]),
+        } as unknown as Response
+      }
+
+      if (url.includes('/api/v1/chat/conversation') && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({
+            id: 'conv-markdown-spacing',
+            title: 'Markdown spacing',
+            type: 'general',
+            createdAt: '2026-04-20T08:00:00.000Z',
+            updatedAt: '2026-04-20T08:00:00.000Z',
+          }),
+        } as unknown as Response
+      }
+
+      if (url.includes('/api/v1/chat/stream')) {
+        return createSseResponse([
+          {
+            type: 'result',
+            content: {
+              response: 'First paragraph.\n\nSecond paragraph.',
+              success: true,
+              report: {
+                summary: 'Summary first paragraph.\n\nSummary second paragraph.',
+                markdown: 'Body first paragraph.\n\nBody second paragraph.',
+              },
+            },
+          },
+        ])
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await renderConsolePage()
+
+    fireEvent.change(screen.getByPlaceholderText(/Describe your structural goal|描述你的结构目标/), {
+      target: { value: 'Render markdown spacing' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^Send$|^发送$/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Analysis$|^分析结果$/ })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^Analysis$|^分析结果$/ }))
+
+    const executionSummaryParagraph = screen.getByText('First paragraph.').closest('p')
+    expect(executionSummaryParagraph).not.toBeNull()
+    const executionMarkdownContainer = executionSummaryParagraph?.parentElement
+    expect(executionMarkdownContainer).toHaveClass('prose-p:my-0')
+
+    fireEvent.click(screen.getByRole('button', { name: /^Report$|^报告$/ }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Summary first paragraph.')).toBeInTheDocument()
+    })
+
+    const reportSummaryParagraph = screen.getByText('Summary first paragraph.').closest('p')
+    expect(reportSummaryParagraph).not.toBeNull()
+    expect(reportSummaryParagraph?.parentElement).not.toHaveClass('prose-p:my-0')
+
+    const reportBodyParagraph = screen.getByText('Body first paragraph.').closest('p')
+    expect(reportBodyParagraph).not.toBeNull()
+    expect(reportBodyParagraph?.parentElement).not.toHaveClass('prose-p:my-0')
   })
 
   it('does not show an engine manager action on the conversation page', async () => {

--- a/frontend/tests/integration/console-page.test.tsx
+++ b/frontend/tests/integration/console-page.test.tsx
@@ -1529,6 +1529,176 @@ describe('ConsolePage Integration (CONS-13)', () => {
     expect(screen.getByText(/Actual engine builtin-simplified|实际引擎 builtin-simplified/)).toBeInTheDocument()
   })
 
+  it('renders markdown body fields in the execution summary and guidance panel', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'en')
+    const interaction = {
+      detectedStructuralType: 'unknown',
+      interactionStageLabel: 'Intent',
+      missingCritical: [],
+      missingOptional: [],
+      fallbackSupportNote: 'Use the **generic** structure skill first.',
+      recommendedNextStep: 'Confirm the **system** and main loads.',
+      questions: [],
+      pending: {
+        criticalMissing: [],
+        nonCriticalMissing: [],
+      },
+    }
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input)
+      const supportResponse = mockConsoleSupportRequest(url)
+      if (supportResponse) {
+        return supportResponse
+      }
+
+      if (url.includes('/api/v1/analysis-engines')) {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({ engines: [] }),
+        } as unknown as Response
+      }
+
+      if (url.includes('/api/v1/chat/conversations')) {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue([]),
+        } as unknown as Response
+      }
+
+      if (url.includes('/api/v1/chat/conversation') && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({
+            id: 'conv-markdown-guidance',
+            title: 'Markdown guidance',
+            type: 'general',
+            createdAt: '2026-04-20T08:00:00.000Z',
+            updatedAt: '2026-04-20T08:00:00.000Z',
+          }),
+        } as unknown as Response
+      }
+
+      if (url.includes('/api/v1/chat/stream')) {
+        return createSseResponse([
+          {
+            type: 'result',
+            content: {
+              response: 'Continue with **intent** collection.',
+              success: true,
+              interaction,
+            },
+          },
+        ])
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await renderConsolePage()
+
+    fireEvent.change(screen.getByPlaceholderText(/Describe your structural goal|描述你的结构目标/), {
+      target: { value: 'Render markdown guidance' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^Send$|^发送$/ }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('console-guidance-panel')).toBeInTheDocument()
+    })
+
+    const executionHeader = screen.getByRole('heading', { name: 'Execution Summary' }).parentElement
+    expect(executionHeader).not.toBeNull()
+    expect(within(executionHeader as HTMLElement).getByText('intent', { selector: 'strong' })).toBeInTheDocument()
+
+    const guidancePanel = screen.getByTestId('console-guidance-panel')
+    expect(within(guidancePanel).getByText('intent', { selector: 'strong' })).toBeInTheDocument()
+    expect(within(guidancePanel).getByText('generic', { selector: 'strong' })).toBeInTheDocument()
+    expect(within(guidancePanel).getByText('system', { selector: 'strong' })).toBeInTheDocument()
+  })
+
+  it('renders markdown summaries and gfm tables in the report panel', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'en')
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input)
+      const supportResponse = mockConsoleSupportRequest(url)
+      if (supportResponse) {
+        return supportResponse
+      }
+
+      if (url.includes('/api/v1/analysis-engines')) {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({ engines: [] }),
+        } as unknown as Response
+      }
+
+      if (url.includes('/api/v1/chat/conversations')) {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue([]),
+        } as unknown as Response
+      }
+
+      if (url.includes('/api/v1/chat/conversation') && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: vi.fn().mockResolvedValue({
+            id: 'conv-markdown-report',
+            title: 'Markdown report',
+            type: 'general',
+            createdAt: '2026-04-20T08:00:00.000Z',
+            updatedAt: '2026-04-20T08:00:00.000Z',
+          }),
+        } as unknown as Response
+      }
+
+      if (url.includes('/api/v1/chat/stream')) {
+        return createSseResponse([
+          {
+            type: 'result',
+            content: {
+              response: 'Report is ready.',
+              success: true,
+              report: {
+                summary: 'Report **insight** is available.',
+                markdown: [
+                  '| Case | Drift |',
+                  '| --- | --- |',
+                  '| SLS | 1/350 |',
+                ].join('\n'),
+              },
+            },
+          },
+        ])
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    await renderConsolePage()
+
+    fireEvent.change(screen.getByPlaceholderText(/Describe your structural goal|描述你的结构目标/), {
+      target: { value: 'Render markdown report' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^Send$|^发送$/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Report$|^报告$/ })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Report$|^报告$/ }))
+
+    await waitFor(() => {
+      expect(screen.getByText('insight', { selector: 'strong' })).toBeInTheDocument()
+    })
+    const reportTable = screen.getByRole('table')
+    expect(within(reportTable).getByRole('columnheader', { name: 'Case' })).toBeInTheDocument()
+    expect(within(reportTable).getByRole('columnheader', { name: 'Drift' })).toBeInTheDocument()
+    expect(within(reportTable).getByText('SLS')).toBeInTheDocument()
+    expect(within(reportTable).getByText('1/350')).toBeInTheDocument()
+  })
+
   it('does not show an engine manager action on the conversation page', async () => {
     await renderConsolePage()
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: The frontend only rendered raw text in the execution summary and conversation guidance body fields, and the Markdown report view did not support GFM tables.
- Why it matters: Analysis/reporting results lost formatting, so headings, emphasis, and tables from backend output were hard to read in the console.
- What changed: Added shared Markdown rendering for result-panel body content, enabled `remark-gfm` for table support, and expanded console integration coverage for Markdown rendering and current `StructureModel v2` UI expectations.
- What did NOT change (scope boundary): No backend payload format, agent orchestration, or report-generation logic changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The console used plain text rendering for result-panel body strings, and `react-markdown` was mounted without the GFM plugin, so table syntax stayed raw.
- Missing detection / guardrail: Integration coverage did not assert Markdown rendering for execution/guidance body fields or table rendering in the report panel.
- Prior context (`git blame`, prior PR, issue, or refactor if known): The current UI copy and tests had already moved to `StructureModel v2`, but several older assertions still queried the deprecated `v1` placeholder string.
- Why this regressed now: Result-panel content evolved to carry Markdown-rich text, while the frontend display path stayed on raw string output.
- If unknown, what was ruled out: Ruled out backend payload/schema changes; the issue was isolated to frontend rendering and stale test assertions.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `frontend/tests/integration/console-page.test.tsx`
- Scenario the test should lock in: Execution summary, conversation guidance, and report summary/body should render Markdown formatting, and report tables should render as actual HTML tables.
- Why this is the smallest reliable guardrail: The regression sits at the rendered console surface where translated labels, archived state, and streamed result payloads meet.
- Existing test that already covers this (if any): Existing console-page integration coverage already exercised the same result panel; this PR extends that file with Markdown-specific assertions.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Execution summary body now renders Markdown formatting instead of raw markers.
- Conversation guidance body/support note/next-step text now renders Markdown formatting instead of raw markers.
- Markdown reports now render GFM tables in the frontend console.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[backend markdown text] -> [result panel raw string render] -> [**bold** and |table| syntax shown literally]

After:
[backend markdown text] -> [shared markdown renderer + remark-gfm] -> [formatted prose/table output in console]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/Next.js frontend test environment
- Model/provider: N/A
- Integration/channel (if any): frontend Vitest integration tests
- Relevant config (redacted): default local test config

### Steps

1. Return a streamed agent result whose `response`, `interaction`, or `report.summary` contains Markdown markers such as `**bold**`.
2. Return a `report.markdown` payload containing a GFM table.
3. Open the console result panels.

### Expected

- Markdown body fields render formatted text.
- Markdown report tables render as actual tables.

### Actual

- Before this change, body fields displayed raw Markdown markers and tables stayed as plain text.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran frontend type-check, targeted Markdown rendering integration tests, and the full `console-page` integration suite.
- Edge cases checked: Report table rendering, archived-state assertions against `StructureModel v2`, and async aborted-stream archive persistence.
- What you did **not** verify: Manual browser interaction outside automated frontend tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Markdown styling could affect spacing/readability in non-report result cards.
  - Mitigation: Scoped rendering to body text fields only and covered the affected console surface with integration tests.
