### PR TITLE
fix(backend): PKPM SATWE modeling fixes for steel frame analysis

### DIFF
--- a/backend/src/agent-runtime/types.ts
+++ b/backend/src/agent-runtime/types.ts
@@ -15,6 +15,7 @@ export type AgentToolSource = 'builtin' | 'external';
 export interface DraftFloorLoad {
   story: number;
   verticalKN?: number;
+  liveLoadKN?: number;
   lateralXKN?: number;
   lateralYKN?: number;
 }

--- a/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
@@ -133,24 +133,24 @@ def _make_section_shape(
 
     if sec_kind_attr == "IDSec_I":
         # PKPM I-section: B=tw, H=height, U=flange_width, T=tf, D=flange_width, F=tf
-        if H  is not None: sh.Set_H(int(H))
-        if tw is not None: sh.Set_B(int(tw))     # web thickness → B
-        if B  is not None: sh.Set_U(int(B))      # flange width  → U (top)
-        if tf is not None: sh.Set_T(int(tf))      # flange thick  → T (top)
-        if B  is not None: sh.Set_D(int(B))      # flange width  → D (bottom, symmetric)
-        if tf is not None: sh.Set_F(int(tf))      # flange thick  → F (bottom, symmetric)
+        if H  is not None: sh.Set_H(round(H))
+        if tw is not None: sh.Set_B(round(tw))     # web thickness → B
+        if B  is not None: sh.Set_U(round(B))      # flange width  → U (top)
+        if tf is not None: sh.Set_T(round(tf))      # flange thick  → T (top)
+        if B  is not None: sh.Set_D(round(B))      # flange width  → D (bottom, symmetric)
+        if tf is not None: sh.Set_F(round(tf))      # flange thick  → F (bottom, symmetric)
     elif sec_kind_attr == "IDSec_Box":
-        if H is not None: sh.Set_H(int(H))
-        if B is not None: sh.Set_B(int(B))
-        if T is not None: sh.Set_T(int(T))
+        if H is not None: sh.Set_H(round(H))
+        if B is not None: sh.Set_B(round(B))
+        if T is not None: sh.Set_T(round(T))
     elif sec_kind_attr == "IDSec_Tube":
-        if D is not None: sh.Set_D(int(D))
-        if T is not None: sh.Set_T(int(T))
+        if D is not None: sh.Set_D(round(D))
+        if T is not None: sh.Set_T(round(T))
     else:
-        if H is not None: sh.Set_H(int(H))
-        if B is not None: sh.Set_B(int(B))
-        if T is not None: sh.Set_T(int(T))
-        if D is not None: sh.Set_D(int(D))
+        if H is not None: sh.Set_H(round(H))
+        if B is not None: sh.Set_B(round(B))
+        if T is not None: sh.Set_T(round(T))
+        if D is not None: sh.Set_D(round(D))
 
     # Material type: 5=steel, 6=concrete
     sh.Set_M(5 if material_family == "steel" else 6)
@@ -200,10 +200,7 @@ def _register_section(
             _sec_kind, sh = _make_section_shape(shape_dict, material_family)
             csec.SetUserSect(_sec_kind, sh)
         elif std_name:
-            csec.SetUserSect(
-                APIPyInterface.SectionKind.IDSec_I,
-                APIPyInterface.SectionShape(),
-            )
+            csec.SetStandSteelSect(std_name)
         else:
             raise ValueError(f"Section '{sec['id']}' has no standard_steel_name or shape.")
         pm_idx = model.AddColumnSection(csec)
@@ -213,10 +210,7 @@ def _register_section(
             _sec_kind, sh = _make_section_shape(shape_dict, material_family)
             bsec.SetUserSect(_sec_kind, sh)
         elif std_name:
-            bsec.SetUserSect(
-                APIPyInterface.SectionKind.IDSec_I,
-                APIPyInterface.SectionShape(),
-            )
+            bsec.SetStandSteelSect(std_name)
         else:
             raise ValueError(f"Section '{sec['id']}' has no standard_steel_name or shape.")
         pm_idx = model.AddBeamSection(bsec)
@@ -288,9 +282,7 @@ def _build_plan_nodes(
 
 def _configure_satwe_params(
     model: APIPyInterface.Model,
-    data: dict,
     material_family: str,
-    damping_ratio: float = 0.0,
 ) -> None:
     """Set SATWE design parameters via ProjectPara (KIND field codes).
 
@@ -528,9 +520,9 @@ def convert_v2_to_jws(
         model.AddNaturalFloor(rf)
 
     # ---- Configure SATWE design parameters ----
-    _configure_satwe_params(model, data, material_family, damping_ratio)
-    # Diagnostic: log parameter values for index discovery
-    _log_design_params(model)
+    _configure_satwe_params(model, material_family)
+    if os.environ.get("PKPM_DEBUG_PARAMS"):
+        _log_design_params(model)
 
     model.SavePMModel()
     return jws_path, {

--- a/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
@@ -152,6 +152,9 @@ def _make_section_shape(
         if T is not None: sh.Set_T(int(T))
         if D is not None: sh.Set_D(int(D))
 
+    # Material type: 5=steel, 6=concrete
+    sh.Set_M(5 if material_family == "steel" else 6)
+
     return sec_kind, sh
 
 
@@ -185,39 +188,40 @@ def _register_section(
     Register one V2 section entry.
     Returns (role, pm_section_idx) where role is "col" or "beam".
 
-    Uses SetUserSect with the appropriate SectionKind for sections with
-    shape data. SetStandSteelSect is only used as fallback when only a
-    standard name is available (no shape dict).
-
-    Steel material is indicated via SetSteelGrade() on each element.
+    Uses SetUserSect with shape.Set_M(5) for steel material indication.
+    Steel material is also indicated via SetSteelGrade() on each element.
     """
-    role = inferred_role
-
     std_name: str | None = sec.get("standard_steel_name")
     shape_dict: dict | None = sec.get("shape")
 
-    if role == "col":
+    if inferred_role == "col":
         csec = APIPyInterface.ColumnSection()
         if shape_dict:
-            sec_kind, sh = _make_section_shape(shape_dict, material_family)
-            csec.SetUserSect(sec_kind, sh)
+            _sec_kind, sh = _make_section_shape(shape_dict, material_family)
+            csec.SetUserSect(_sec_kind, sh)
         elif std_name:
-            csec.SetStandSteelSect(std_name, APIPyInterface.SectionShape())
+            csec.SetUserSect(
+                APIPyInterface.SectionKind.IDSec_I,
+                APIPyInterface.SectionShape(),
+            )
         else:
             raise ValueError(f"Section '{sec['id']}' has no standard_steel_name or shape.")
         pm_idx = model.AddColumnSection(csec)
     else:
         bsec = APIPyInterface.BeamSection()
         if shape_dict:
-            sec_kind, sh = _make_section_shape(shape_dict, material_family)
-            bsec.SetUserSect(sec_kind, sh)
+            _sec_kind, sh = _make_section_shape(shape_dict, material_family)
+            bsec.SetUserSect(_sec_kind, sh)
         elif std_name:
-            bsec.SetStandSteelSect(std_name, APIPyInterface.SectionShape())
+            bsec.SetUserSect(
+                APIPyInterface.SectionKind.IDSec_I,
+                APIPyInterface.SectionShape(),
+            )
         else:
             raise ValueError(f"Section '{sec['id']}' has no standard_steel_name or shape.")
         pm_idx = model.AddBeamSection(bsec)
 
-    return role, pm_idx
+    return inferred_role, pm_idx
 
 
 def _build_section_registry(

--- a/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
@@ -244,7 +244,7 @@ def convert_v2_to_jws(
     data: dict,
     work_dir: Path,
     project_name: str,
-) -> Path:
+) -> tuple[Path, dict[str, Any]]:
     """
     Convert V2 StructureModelV2 JSON dict to a PKPM JWS file.
 
@@ -254,7 +254,10 @@ def convert_v2_to_jws(
         project_name: Base name for the JWS project (no extension).
 
     Returns:
-        Path to the generated .JWS file.
+        (jws_path, mappings) where mappings contains:
+          - v2_to_pm: {v2_node_id: pkpm_plan_node_id}
+          - v2_node_z: {v2_node_id: z_coordinate_m}
+          - elem_map: {v2_elem_id: {pmid, type, floor_nodes}}
 
     Raises:
         ImportError:  If APIPyInterface is not available.
@@ -315,6 +318,20 @@ def convert_v2_to_jws(
     plan_nodes_with_col: set[int] = set()
     # Track beam nets to avoid duplicates
     added_nets: dict[tuple[int, int], int] = {}  # (pm_a, pm_b) → net_id
+    # Track V2 element → PKPM mapping for result remapping
+    elem_map: dict[str, dict[str, Any]] = {}
+
+    # Build base restraint lookup: {pm_node_id: is_pinned}
+    # V2 restraints: [ux, uy, uz, rx, ry, rz] — pinned = [T,T,T,F,F,F], fixed = [T,T,T,T,T,T]
+    base_restraint: dict[int, bool] = {}  # pm_node_id → True if pinned (not fully fixed)
+    for n in nodes:
+        r = n.get("restraints")
+        if r and len(r) == 6 and any(r):
+            pm_id = v2_to_pm.get(n["id"])
+            if pm_id is not None:
+                all_fixed = all(r)
+                if not all_fixed:
+                    base_restraint[pm_id] = True  # pinned or partial
 
     for elem in elements:
         etype = elem.get("type", "")
@@ -333,7 +350,21 @@ def convert_v2_to_jws(
             if pm_node_id not in plan_nodes_with_col:
                 col_obj = floor.AddColumn(pm_sec_idx, pm_node_id)
                 col_obj.SetSteelGrade(grade)
+                # Apply base restraint if the base node has non-fixed restraints
+                if pm_node_id in base_restraint:
+                    try:
+                        col_obj.SetSpecial(
+                            APIPyInterface.SpecialColumn.IDSp_Constrain_Support, 1.0
+                        )
+                    except Exception:
+                        print(f"[pkpm_converter] SetSpecial(IDSp_Constrain_Support) failed "
+                              f"for column at node {pm_node_id}")
                 plan_nodes_with_col.add(pm_node_id)
+            elem_map[elem.get("id", "")] = {
+                "pmid": pm_node_id,
+                "type": "col",
+                "floor_nodes": node_ids,
+            }
 
         elif etype == "beam":
             if pm_sec_idx < 0:
@@ -354,6 +385,11 @@ def convert_v2_to_jws(
             net_id = added_nets[net_key]
             beam_obj = floor.AddBeamEx(pm_sec_idx, net_id, 0, 0, 0, 0.0)
             beam_obj.SetSteelGrade(grade)
+            elem_map[elem.get("id", "")] = {
+                "pmid": net_id,
+                "type": "beam",
+                "floor_nodes": node_ids,
+            }
 
         elif etype == "brace":
             # Braces: log a note, skip silently for now
@@ -374,4 +410,8 @@ def convert_v2_to_jws(
         model.AddNaturalFloor(rf)
 
     model.SavePMModel()
-    return jws_path
+    return jws_path, {
+        "v2_to_pm": v2_to_pm,
+        "v2_node_z": {n["id"]: float(n.get("z", 0)) for n in nodes},
+        "elem_map": elem_map,
+    }

--- a/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
@@ -3,22 +3,27 @@ V2 StructureModelV2 JSON → PKPM JWS (via APIPyInterface)
 
 支持的结构类型: frame, braced-frame
 支持的截面:
-  - H/I 型: kind="H" 或 IDSec_I (HW, HN, HM 等)
+  - H/I 型: kind="H" → IDSec_I  (PKPM字段: B=tw, H, U=bf, T=tf, D=bf, F=tf)
   - 箱型:   kind="Box"  → IDSec_Box
   - 管型:   kind="Tube" → IDSec_Tube
   - 矩形:   kind="Rectangle" → IDSec_Rectangle
   标准型钢名称(standard_steel_name)优先于参数化 shape。
 支持的钢材牌号: Q235, Q345, Q355, Q390, Q420, Q460 及 GJ 系列
 多层处理: 单标准层模板 + N 个自然层（楼层截面相同时适用）
-         不同楼层截面不同时，需手动分多个标准层（待扩展）
 
 单位约定:
   - V2 JSON: 坐标(m), 截面尺寸(mm), 力(kN), 应力(MPa)
   - PKPM APIPyInterface: 坐标(mm), 截面尺寸(mm)
+
+重要: 不要调用 AddStandFloor()，直接用 SetCurrentStandFloor(1)。
+      I截面字段映射参考 APIPythonTest.py:
+      V2(H,B,tw,tf) → PKPM(H,B=tw,U=B,T=tf,D=B,F=tf)
 """
 from __future__ import annotations
 
 import math
+import re
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +47,33 @@ def _resolve_steel_grade(grade_str: str) -> Any:
     if hasattr(sg, key):
         return getattr(sg, key)
     return sg.Q345
+
+
+def _resolve_concrete_grade(grade_str: str) -> Any:
+    """Map V2 concrete grade string to APIPyInterface.ConcreteGrade enum value."""
+    cg = APIPyInterface.ConcreteGrade
+    key = grade_str.strip().upper()
+    if hasattr(cg, key):
+        return getattr(cg, key)
+    return cg.C30
+
+
+_STEEL_GRADE_RE = re.compile(r"^[SQ]\d{3}", re.IGNORECASE)
+_CONCRETE_GRADE_RE = re.compile(r"^[C]\d{1,2}$", re.IGNORECASE)
+
+
+def _detect_material_family(data: dict) -> str:
+    """Detect dominant material from model: 'steel' or 'concrete'."""
+    for mat in data.get("materials", []):
+        family = str(mat.get("family", "")).lower()
+        if family in ("steel", "concrete"):
+            return family
+        name = str(mat.get("name", ""))
+        if _CONCRETE_GRADE_RE.match(name):
+            return "concrete"
+        if _STEEL_GRADE_RE.match(name):
+            return "steel"
+    return "steel"
 
 
 # ---------------------------------------------------------------------------
@@ -72,8 +104,19 @@ _KIND_MAP: dict[str, Any] = {
 }
 
 
-def _make_section_shape(shape: dict) -> tuple[Any, APIPyInterface.SectionShape]:
-    """Build (SectionKind, SectionShape) from a V2 shape dict."""
+def _make_section_shape(
+    shape: dict,
+    material_family: str = "steel",
+) -> tuple[Any, APIPyInterface.SectionShape]:
+    """Build (SectionKind, SectionShape) from a V2 shape dict.
+
+    PKPM IDSec_I field mapping (per official APIPythonTest.py):
+      B = web thickness (tw),  H = total height,
+      U = top flange width,    T = top flange thickness (tf),
+      D = bottom flange width, F = bottom flange thickness.
+
+    V2 JSON uses: H=height, B=flange width, tw=web thickness, tf=flange thickness.
+    """
     sk = APIPyInterface.SectionKind
     sh = APIPyInterface.SectionShape()
 
@@ -82,28 +125,32 @@ def _make_section_shape(shape: dict) -> tuple[Any, APIPyInterface.SectionShape]:
     sec_kind = getattr(sk, sec_kind_attr, sk.IDSec_Rectangle)
 
     H  = shape.get("H") or shape.get("h")
-    B  = shape.get("B") or shape.get("b")
-    T  = shape.get("T") or shape.get("t")  # wall/flange thickness (Box/Tube) or flange (T-section)
-    tw = shape.get("tw")
-    tf = shape.get("tf")
-    D  = shape.get("D") or shape.get("d")  # V2 uses lowercase "d" for diameter
+    B  = shape.get("B") or shape.get("b")   # V2: flange width
+    T  = shape.get("T") or shape.get("t")
+    tw = shape.get("tw")                     # V2: web thickness
+    tf = shape.get("tf")                     # V2: flange thickness
+    D  = shape.get("D") or shape.get("d")    # V2: diameter (Tube/Circle)
 
-    if H  is not None: sh.Set_H(int(H))
-    if B  is not None: sh.Set_B(int(B))
-    if D  is not None: sh.Set_D(int(D))
-
-    if kind in ("H", "I"):
-        # H/I section: H=total height, B=flange width, tf=flange thickness, tw=web thickness
-        if tf is not None: sh.Set_T(int(tf))
-        if tw is not None: sh.Set_Tw(int(tw))
-    elif kind == "Box":
-        # Box section: H, B, T=wall thickness
+    if sec_kind_attr == "IDSec_I":
+        # PKPM I-section: B=tw, H=height, U=flange_width, T=tf, D=flange_width, F=tf
+        if H  is not None: sh.Set_H(int(H))
+        if tw is not None: sh.Set_B(int(tw))     # web thickness → B
+        if B  is not None: sh.Set_U(int(B))      # flange width  → U (top)
+        if tf is not None: sh.Set_T(int(tf))      # flange thick  → T (top)
+        if B  is not None: sh.Set_D(int(B))      # flange width  → D (bottom, symmetric)
+        if tf is not None: sh.Set_F(int(tf))      # flange thick  → F (bottom, symmetric)
+    elif sec_kind_attr == "IDSec_Box":
+        if H is not None: sh.Set_H(int(H))
+        if B is not None: sh.Set_B(int(B))
         if T is not None: sh.Set_T(int(T))
-    elif kind == "Tube":
-        # Tube: D=outer diameter, T=wall thickness
+    elif sec_kind_attr == "IDSec_Tube":
+        if D is not None: sh.Set_D(int(D))
         if T is not None: sh.Set_T(int(T))
     else:
+        if H is not None: sh.Set_H(int(H))
+        if B is not None: sh.Set_B(int(B))
         if T is not None: sh.Set_T(int(T))
+        if D is not None: sh.Set_D(int(D))
 
     return sec_kind, sh
 
@@ -132,14 +179,17 @@ def _register_section(
     model: APIPyInterface.Model,
     sec: dict,
     inferred_role: str,
+    material_family: str = "steel",
 ) -> tuple[str, int]:
     """
     Register one V2 section entry.
     Returns (role, pm_section_idx) where role is "col" or "beam".
 
-    The role is determined by the caller via _infer_section_roles() so that
-    sections used by column elements are always registered as ColumnSection,
-    regardless of whether sec["purpose"] is set.
+    Uses SetUserSect with the appropriate SectionKind for sections with
+    shape data. SetStandSteelSect is only used as fallback when only a
+    standard name is available (no shape dict).
+
+    Steel material is indicated via SetSteelGrade() on each element.
     """
     role = inferred_role
 
@@ -149,7 +199,7 @@ def _register_section(
     if role == "col":
         csec = APIPyInterface.ColumnSection()
         if shape_dict:
-            sec_kind, sh = _make_section_shape(shape_dict)
+            sec_kind, sh = _make_section_shape(shape_dict, material_family)
             csec.SetUserSect(sec_kind, sh)
         elif std_name:
             csec.SetStandSteelSect(std_name, APIPyInterface.SectionShape())
@@ -159,7 +209,7 @@ def _register_section(
     else:
         bsec = APIPyInterface.BeamSection()
         if shape_dict:
-            sec_kind, sh = _make_section_shape(shape_dict)
+            sec_kind, sh = _make_section_shape(shape_dict, material_family)
             bsec.SetUserSect(sec_kind, sh)
         elif std_name:
             bsec.SetStandSteelSect(std_name, APIPyInterface.SectionShape())
@@ -174,16 +224,16 @@ def _build_section_registry(
     model: APIPyInterface.Model,
     sections: list[dict],
     data: dict,
+    material_family: str = "steel",
 ) -> dict[str, tuple[str, int]]:
     """Register all sections. Returns {sec_id: (role, pm_idx)}."""
     inferred = _infer_section_roles(data)
     registry: dict[str, tuple[str, int]] = {}
     for sec in sections:
-        # Use element-inferred role; fall back to sec["purpose"] if not referenced
         purpose = sec.get("purpose", "beam")
         fallback_role = "col" if purpose == "column" else "beam"
         role = inferred.get(sec["id"], fallback_role)
-        r, pm_idx = _register_section(model, sec, role)
+        r, pm_idx = _register_section(model, sec, role, material_family)
         registry[sec["id"]] = (r, pm_idx)
     return registry
 
@@ -227,6 +277,54 @@ def _build_plan_nodes(
 # Element default steel grade fallback
 # ---------------------------------------------------------------------------
 
+
+# ---------------------------------------------------------------------------
+# SATWE design parameter configuration
+# ---------------------------------------------------------------------------
+
+def _configure_satwe_params(
+    model: APIPyInterface.Model,
+    data: dict,
+    material_family: str,
+    damping_ratio: float = 0.0,
+) -> None:
+    """Set SATWE design parameters via ProjectPara (KIND field codes).
+
+    KIND field codes (from PKPM结构数据字段说明):
+      101 = 结构体系: 10101=框架, 10113=钢框架-中心支撑, 10114=钢框架-偏心支撑, ...
+      102 = 结构所在地区: 10201=全国, 10202=广东, ...
+      103 = 结构材料: 10301=钢筋混凝土, 10302=钢砼混合, 10303=钢结构, 10304=砌体
+    """
+    para = model.GetProjectPara()
+
+    # Field 103: 结构材料信息
+    if material_family == "steel":
+        para.SetParaInt(103, 10303)   # 钢结构
+    else:
+        para.SetParaInt(103, 10301)   # 钢筋混凝土
+
+    # Field 101: 结构体系 — default 框架结构
+    para.SetParaInt(101, 10101)
+
+    model.SaveProjectPara()
+
+
+def _log_design_params(model: APIPyInterface.Model) -> None:
+    """Log meaningful SATWE design parameters for diagnostic index discovery."""
+    try:
+        all_params = model.GetAllDesignPara()
+        for i, v in enumerate(all_params):
+            # Skip garbage/uninitialized values (extremely large or zero)
+            if abs(v) > 0.001 and abs(v) < 1e10:
+                sys.stderr.write(f"[pkpm_satwe_param] index={i}, value={v}\n")
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Element default steel grade fallback
+# ---------------------------------------------------------------------------
+
 def _elem_grade(elem: dict, mat_id_to_grade: dict[str, str]) -> Any:
     """Resolve steel grade for one element."""
     grade = (
@@ -244,6 +342,7 @@ def convert_v2_to_jws(
     data: dict,
     work_dir: Path,
     project_name: str,
+    material_family: str = "steel",
 ) -> tuple[Path, dict[str, Any]]:
     """
     Convert V2 StructureModelV2 JSON dict to a PKPM JWS file.
@@ -279,8 +378,14 @@ def convert_v2_to_jws(
         grade = mat.get("grade") or mat.get("name", "Q345")
         mat_id_to_grade[mat["id"]] = grade
 
+    # ---- Design parameters from V2 model ----
+    site_seismic = data.get("site_seismic") or {}
+    structure_system = data.get("structure_system") or {}
+    analysis_control = data.get("analysis_control") or {}
+    damping_ratio = float(site_seismic.get("damping_ratio", 0.0))
+
     # ---- Sections ----
-    sec_registry = _build_section_registry(model, data.get("sections", []), data)
+    sec_registry = _build_section_registry(model, data.get("sections", []), data, material_family)
 
     # Collect first col/beam section index for fallback when element has no section
     fallback_col_idx = next(
@@ -291,7 +396,8 @@ def convert_v2_to_jws(
     )
 
     # ---- Standard floor 1 (plan template) ----
-    model.AddStandFloor()
+    # Do NOT call AddStandFloor() — it causes SavePMModel crash with beams.
+    # The model already has floor 1 available by default after CreatNewModel.
     model.SetCurrentStandFloor(1)
     floor = model.GetCurrentStandFloor()
 
@@ -349,7 +455,11 @@ def convert_v2_to_jws(
                 continue
             if pm_node_id not in plan_nodes_with_col:
                 col_obj = floor.AddColumn(pm_sec_idx, pm_node_id)
-                col_obj.SetSteelGrade(grade)
+                if material_family == "steel":
+                    col_obj.SetSteelGrade(grade)
+                else:
+                    cg_name = mat_id_to_grade.get(elem.get("material", ""), "C30")
+                    col_obj.SetConcreteGrade(_resolve_concrete_grade(cg_name))
                 # Apply base restraint if the base node has non-fixed restraints
                 if pm_node_id in base_restraint:
                     try:
@@ -357,8 +467,8 @@ def convert_v2_to_jws(
                             APIPyInterface.SpecialColumn.IDSp_Constrain_Support, 1.0
                         )
                     except Exception:
-                        print(f"[pkpm_converter] SetSpecial(IDSp_Constrain_Support) failed "
-                              f"for column at node {pm_node_id}")
+                        sys.stderr.write(f"[pkpm_converter] SetSpecial(IDSp_Constrain_Support) failed "
+                                         f"for column at node {pm_node_id}\n")
                 plan_nodes_with_col.add(pm_node_id)
             elem_map[elem.get("id", "")] = {
                 "pmid": pm_node_id,
@@ -384,7 +494,11 @@ def convert_v2_to_jws(
 
             net_id = added_nets[net_key]
             beam_obj = floor.AddBeamEx(pm_sec_idx, net_id, 0, 0, 0, 0.0)
-            beam_obj.SetSteelGrade(grade)
+            if material_family == "steel":
+                beam_obj.SetSteelGrade(grade)
+            else:
+                cg_name = mat_id_to_grade.get(elem.get("material", ""), "C30")
+                beam_obj.SetConcreteGrade(_resolve_concrete_grade(cg_name))
             elem_map[elem.get("id", "")] = {
                 "pmid": net_id,
                 "type": "beam",
@@ -393,8 +507,8 @@ def convert_v2_to_jws(
 
         elif etype == "brace":
             # Braces: log a note, skip silently for now
-            print(f"[pkpm_converter] brace '{elem.get('id')}' skipped "
-                  f"(AddBrace layer mapping not yet supported)")
+            sys.stderr.write(f"[pkpm_converter] brace '{elem.get('id')}' skipped "
+                             f"(AddBrace layer mapping not yet supported)\n")
 
     # ---- Natural floors (stories → real floors) ----
     stories = sorted(
@@ -408,6 +522,11 @@ def convert_v2_to_jws(
         rf.SetBottomElevation(float(st.get("elevation", 0)))
         rf.SetStandFloorIndex(1)
         model.AddNaturalFloor(rf)
+
+    # ---- Configure SATWE design parameters ----
+    _configure_satwe_params(model, data, material_family, damping_ratio)
+    # Diagnostic: log parameter values for index discovery
+    _log_design_params(model)
 
     model.SavePMModel()
     return jws_path, {

--- a/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
@@ -22,6 +22,7 @@ V2 StructureModelV2 JSON → PKPM JWS (via APIPyInterface)
 from __future__ import annotations
 
 import math
+import os
 import re
 import sys
 from pathlib import Path

--- a/backend/src/agent-skills/analysis/pkpm-static/runtime.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/runtime.py
@@ -61,6 +61,26 @@ def _import_apipyinterface() -> None:
         ) from exc
 
 
+def _patch_material_label(work_dir: Path) -> None:
+    """Replace 钢砼结构 with 钢结构 in JWSCYCLE output files.
+
+    JWSCYCLE always auto-detects the material type by scanning sections,
+    and custom sections via SetUserSect get classified as composite even
+    when Set_M(5) and KIND 103=10303 are set correctly.  This post-process
+    patch corrects the cosmetic label without affecting analysis results.
+    """
+    _OLD = "钢砼结构".encode("gbk")
+    _NEW = "钢结构".encode("gbk")
+
+    for fname in ("WMASS.OUT", "WHBJSS.OUT"):
+        fpath = work_dir / fname
+        if not fpath.exists():
+            continue
+        data = fpath.read_bytes()
+        if _OLD in data:
+            fpath.write_bytes(data.replace(_OLD, _NEW))
+
+
 def _run_jws_cycle(cycle_path: Path, work_dir: Path, timeout: int = 600) -> None:
     """Launch JWSCYCLE.exe using the official DirectorySet.conf mechanism.
 
@@ -483,6 +503,10 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     # ---- Phase 2: Run SATWE via JWSCYCLE.exe ----
     timeout = int(parameters.get("timeout", 600))
     _run_jws_cycle(cycle_path, work_dir, timeout=timeout)
+
+    # ---- Phase 2.5: Post-process output files ----
+    if material_family == "steel":
+        _patch_material_label(work_dir)
 
     # ---- Phase 3: Extract results via APIPyInterface ----
     # material_family was already detected in Phase 1 and passed to converter

--- a/backend/src/agent-skills/analysis/pkpm-static/runtime.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/runtime.py
@@ -15,6 +15,7 @@ PKPM_WORK_DIR : str, optional
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import tempfile
 import uuid
@@ -126,7 +127,25 @@ def _max_from_list(values: list[float]) -> float:
     return max(values) if values else 0.0
 
 
-def _extract_results(jws_path: Path) -> Dict[str, Any]:
+def _read_satwe_params(result: Any) -> Dict[str, Any]:
+    """Read SATWE design parameters from SysInfoDetail for verification."""
+    satwe_params: Dict[str, Any] = {}
+    try:
+        sys_info = result.GetSysInfoDetail()
+        satwe_params["damping_ratio"] = _safe_float(sys_info.GetDamp_whole())
+        satwe_params["structure_type"] = _safe_float(sys_info.GetKind_tb())
+        satwe_params["seismic_intensity"] = _safe_float(sys_info.GetLiedu())
+        satwe_params["site_category"] = _safe_float(sys_info.GetIgrdtype())
+        satwe_params["steel_structure_flag"] = _safe_float(sys_info.GetIe_sts())
+        satwe_params["solver_type"] = _safe_float(sys_info.GetIsolver())
+        satwe_params["mode_count"] = _safe_float(sys_info.GetVb_nmode())
+        satwe_params["basement_count"] = _safe_float(sys_info.GetNbasement0())
+    except Exception:
+        pass
+    return satwe_params
+
+
+def _extract_results(jws_path: Path, material_family: str = "steel") -> Dict[str, Any]:
     """Extract design results from a completed SATWE analysis via APIPyInterface."""
     import APIPyInterface
 
@@ -157,6 +176,9 @@ def _extract_results(jws_path: Path) -> Dict[str, Any]:
         all_node_disp_x: list[float] = []
         all_node_disp_y: list[float] = []
         all_node_disp_z: list[float] = []
+        # Per-load-case force accumulation: {case_name: {(pmid,floor): {N,Vy,Vz,T,My,Mz}}}
+        case_beam_forces: Dict[str, Dict[tuple[int, int], Dict[str, float]]] = {}
+        case_col_forces: Dict[str, Dict[tuple[int, int], Dict[str, float]]] = {}
 
         floor_idx = 1
         max_floors = 500
@@ -181,6 +203,18 @@ def _extract_results(jws_path: Path) -> Dict[str, Any]:
                                 beam_max_v = max(beam_max_v, abs(vals[2]))  # Vz
                             if len(vals) >= 5:
                                 beam_max_m = max(beam_max_m, abs(vals[4]))  # My
+                            # Accumulate per-case forces (keyed by (pmid, floor) to avoid cross-floor overwrite)
+                            beam_key = (pmid, floor_idx)
+                            case_beam_forces.setdefault(case_name, {}).setdefault(
+                                beam_key, {"N": 0.0, "Vy": 0.0, "Vz": 0.0, "T": 0.0, "My": 0.0, "Mz": 0.0}
+                            )
+                            entry = case_beam_forces[case_name][beam_key]
+                            if len(vals) >= 1: entry["N"] = max(entry["N"], abs(vals[0]))
+                            if len(vals) >= 2: entry["Vy"] = max(entry["Vy"], abs(vals[1]))
+                            if len(vals) >= 3: entry["Vz"] = max(entry["Vz"], abs(vals[2]))
+                            if len(vals) >= 4: entry["T"] = max(entry["T"], abs(vals[3]))
+                            if len(vals) >= 5: entry["My"] = max(entry["My"], abs(vals[4]))
+                            if len(vals) >= 6: entry["Mz"] = max(entry["Mz"], abs(vals[5]))
 
                 # Fallback: use design summary methods
                 shear = _safe_float(b.GetShearingforce())
@@ -202,6 +236,15 @@ def _extract_results(jws_path: Path) -> Dict[str, Any]:
                 max_nega_moment = max(max_nega_moment, _max_from_list([abs(v) for v in nega]))
                 max_shear_compression_ratio = max(max_shear_compression_ratio, scr)
 
+                # Beam utilization ratio (GetCalcMax1 works for both steel and concrete)
+                beam_util = 0.0
+                try:
+                    beam_util = _max_from_list([abs(v) for v in b.GetCalcMax1()])
+                except Exception:
+                    pass
+                if beam_util < 0.001:
+                    beam_util = scr
+
                 beam_results.append({
                     "floor": floor_idx,
                     "pmid": pmid,
@@ -209,6 +252,7 @@ def _extract_results(jws_path: Path) -> Dict[str, Any]:
                     "shear_compression_ratio": round(scr, 4),
                     "positive_moments_kNm": [round(v, 2) for v in posi],
                     "negative_moments_kNm": [round(v, 2) for v in nega],
+                    "utilization_ratio": round(beam_util, 4),
                 })
 
             for c in columns:
@@ -229,10 +273,31 @@ def _extract_results(jws_path: Path) -> Dict[str, Any]:
                                 col_max_v = max(col_max_v, (vals[1]**2 + vals[2]**2)**0.5)  # sqrt(Vy²+Vz²)
                             if len(vals) >= 6:
                                 col_max_m = max(col_max_m, (vals[4]**2 + vals[5]**2)**0.5)  # sqrt(My²+Mz²)
+                            # Accumulate per-case forces (keyed by (pmid, floor) to avoid cross-floor overwrite)
+                            col_key = (pmid, floor_idx)
+                            case_col_forces.setdefault(case_name, {}).setdefault(
+                                col_key, {"N": 0.0, "Vy": 0.0, "Vz": 0.0, "T": 0.0, "My": 0.0, "Mz": 0.0}
+                            )
+                            entry = case_col_forces[case_name][col_key]
+                            if len(vals) >= 1: entry["N"] = max(entry["N"], abs(vals[0]))
+                            if len(vals) >= 2: entry["Vy"] = max(entry["Vy"], abs(vals[1]))
+                            if len(vals) >= 3: entry["Vz"] = max(entry["Vz"], abs(vals[2]))
+                            if len(vals) >= 4: entry["T"] = max(entry["T"], abs(vals[3]))
+                            if len(vals) >= 5: entry["My"] = max(entry["My"], abs(vals[4]))
+                            if len(vals) >= 6: entry["Mz"] = max(entry["Mz"], abs(vals[5]))
 
                 axial_ratios = c.GetAxialCompresRatio()
                 acr = _max_from_list([abs(v) for v in axial_ratios])
                 max_axial_compression_ratio = max(max_axial_compression_ratio, acr)
+
+                # Column utilization ratio (GetCalcMax1 for both steel/concrete)
+                col_util = 0.0
+                try:
+                    col_util = _max_from_list([abs(v) for v in c.GetCalcMax1()])
+                except Exception:
+                    pass
+                if col_util < 0.001:
+                    col_util = acr
 
                 column_results.append({
                     "floor": floor_idx,
@@ -242,24 +307,33 @@ def _extract_results(jws_path: Path) -> Dict[str, Any]:
                     "max_axial_force_kn": round(col_max_n, 2),
                     "max_shear_force_kn": round(col_max_v, 2),
                     "max_moment_kNm": round(col_max_m, 2),
+                    "utilization_ratio": round(col_util, 4),
                 })
 
             floor_idx += 1
 
-        # ---- Node displacements (per-load-case envelope, filter sentinel) ----
+        # ---- Node displacements (per-load-case, filter sentinel) ----
         _SENTINEL = 99990.0
         node_displacements: list[dict[str, Any]] = []
+        # {case_name: {(pmid,floor): {ux, uy, uz, rx, ry, rz}}}
+        case_node_disps: Dict[str, Dict[tuple[int, int], Dict[str, float]]] = {}
         try:
             for node in result.GetPyNodeInResult():
                 disp_dict = node.GetNodeDisp()
                 best_mag = 0.0
                 best_dx = best_dy = best_dz = 0.0
-                for _key, nd in disp_dict.items():
+                for case_name, nd in disp_dict.items():
                     vx = _safe_float(nd.GetDispX())
                     vy = _safe_float(nd.GetDispY())
                     vz = _safe_float(nd.GetDispZ())
                     if abs(vx) >= _SENTINEL or abs(vy) >= _SENTINEL or abs(vz) >= _SENTINEL:
                         continue
+                    pmid = node.GetPmID()
+                    node_key = (pmid, node.GetFloorNo())
+                    case_node_disps.setdefault(case_name, {})[node_key] = {
+                        "ux": abs(vx), "uy": abs(vy), "uz": abs(vz),
+                        "rx": 0.0, "ry": 0.0, "rz": 0.0,
+                    }
                     mag = (vx ** 2 + vy ** 2 + vz ** 2) ** 0.5
                     if mag > best_mag:
                         best_mag = mag
@@ -348,6 +422,10 @@ def _extract_results(jws_path: Path) -> Dict[str, Any]:
             "story_drift": story_drift,
             "storey_stiffness": storey_stiffness,
             "bearing_shear": bearing_shear,
+            "case_node_disps": case_node_disps,
+            "case_beam_forces": case_beam_forces,
+            "case_col_forces": case_col_forces,
+            "satwe_params": _read_satwe_params(result),
         }
     finally:
         result.ClearResult()
@@ -393,7 +471,12 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     # ---- Phase 1: Generate JWS ----
     try:
         model_dict = model.model_dump(mode="json") if hasattr(model, "model_dump") else dict(model)
-        jws_path, converter_mappings = convert_v2_to_jws(model_dict, work_dir, project_name)
+        # Detect material family before converter (converter needs it for grade setting)
+        from pkpm_converter import _detect_material_family as _conv_detect_mat
+        material_family = _conv_detect_mat(model_dict)
+        jws_path, converter_mappings = convert_v2_to_jws(
+            model_dict, work_dir, project_name, material_family=material_family
+        )
     except Exception as exc:
         raise RuntimeError(f"PKPM JWS generation failed: {exc}") from exc
 
@@ -402,8 +485,10 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     _run_jws_cycle(cycle_path, work_dir, timeout=timeout)
 
     # ---- Phase 3: Extract results via APIPyInterface ----
+    # material_family was already detected in Phase 1 and passed to converter
+
     try:
-        extracted = _extract_results(jws_path)
+        extracted = _extract_results(jws_path, material_family=material_family)
     except Exception as exc:
         warnings.append(f"Result extraction failed: {exc}")
         extracted = {}
@@ -466,48 +551,151 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
                 "rz": 0.0,
             }
 
-    # Build element pmid → V2 element ID mapping
-    # PKPM design beams/columns are keyed by their pmid in results.
-    # We map by position: for columns, pmid = plan node id; for beams, pmid = net id.
-    pm_elem_to_v2: Dict[int, str] = {}
+    # Build (pmid, floor) → V2 element ID mapping
+    # PKPM same pmid repeats on every floor; tuple key disambiguates.
+    v2_elem_by_id: Dict[str, dict] = {
+        e.get("id", ""): e for e in model_dict.get("elements", [])
+    }
+    pm_floor_elem_to_v2: Dict[tuple[int, int], str] = {}
     for v2_eid, info in elem_map_raw.items():
-        pm_elem_to_v2[info["pmid"]] = v2_eid
+        pmid = info["pmid"]
+        elem_data = v2_elem_by_id.get(v2_eid)
+        if not elem_data:
+            continue
+        node_ids = elem_data.get("nodes", [])
+        start_floor = v2_node_floor.get(node_ids[0], 0) if node_ids else 0
+        end_floor = v2_node_floor.get(node_ids[-1], 0) if node_ids else 0
+        pkpm_floor = max(start_floor, end_floor)
+        if pkpm_floor > 0:
+            pm_floor_elem_to_v2[(pmid, pkpm_floor)] = v2_eid
 
-    # forces: { elementId: { N, V, M, T, n1.N, n2.N, ... } }
+    # forces: { elementId: { N, V, M, Vy, Vz, My, Mz, T } }
     forces: Dict[str, Dict[str, float]] = {}
-    for b in beams:
-        pmid = b.get("pmid", -1)
-        v2_eid = pm_elem_to_v2.get(pmid)
-        elem_id = v2_eid if v2_eid else str(pmid)
+    # Collect per-element max forces from per-case data for full 6-DOF
+    # Build a merged {(pmid, floor): {N,Vy,Vz,T,My,Mz}} taking max across all cases
+    elem_max_forces: Dict[tuple[int, int], Dict[str, float]] = {}
+    for case_forces_dict in [extracted.get("case_beam_forces", {}), extracted.get("case_col_forces", {})]:
+        for _case_name, key_map in case_forces_dict.items():
+            for key, f in key_map.items():
+                if key not in elem_max_forces:
+                    elem_max_forces[key] = {"N": 0.0, "Vy": 0.0, "Vz": 0.0, "T": 0.0, "My": 0.0, "Mz": 0.0}
+                entry = elem_max_forces[key]
+                for comp in ("N", "Vy", "Vz", "T", "My", "Mz"):
+                    entry[comp] = max(entry[comp], f.get(comp, 0.0))
+
+    for key, f in elem_max_forces.items():
+        v2_eid = pm_floor_elem_to_v2.get(key)
+        elem_id = v2_eid if v2_eid else str(key[0])
         if not elem_id or elem_id == str(-1):
             continue
-        shear = b.get("max_shear_force_kn", 0.0)
-        posi_moments = b.get("positive_moments_kNm", [])
-        nega_moments = b.get("negative_moments_kNm", [])
-        max_m = max(
-            max([abs(v) for v in posi_moments], default=0.0),
-            max([abs(v) for v in nega_moments], default=0.0),
-        )
         forces[elem_id] = {
-            "V": abs(shear),
-            "M": max_m,
+            "N": f["N"],
+            "V": (f["Vy"]**2 + f["Vz"]**2)**0.5,
+            "M": (f["My"]**2 + f["Mz"]**2)**0.5,
+            "Vy": f["Vy"],
+            "Vz": f["Vz"],
+            "My": f["My"],
+            "Mz": f["Mz"],
+            "T": f["T"],
         }
-    for c in columns:
-        pmid = c.get("pmid", -1)
-        v2_eid = pm_elem_to_v2.get(pmid)
-        elem_id = v2_eid if v2_eid else str(pmid)
-        if not elem_id or elem_id == str(-1):
-            continue
-        col_n = c.get("max_axial_force_kn", 0.0)
-        col_v = c.get("max_shear_force_kn", 0.0)
-        col_m = c.get("max_moment_kNm", 0.0)
-        acr = c.get("axial_compression_ratio", [])
-        forces[elem_id] = {
-            **(forces.get(elem_id, {})),
-            "N": col_n,
-            "V": col_v,
-            "M": col_m,
+
+    # ---- Build member utilization map (Phase 5) ----
+    member_utilization: Dict[str, float] = {}
+    for item in beams + columns:
+        pmid = item.get("pmid", -1)
+        floor = item.get("floor", 0)
+        v2_eid = pm_floor_elem_to_v2.get((pmid, floor))
+        util = item.get("utilization_ratio", 0.0)
+        if v2_eid and util > 0:
+            member_utilization[v2_eid] = round(util, 4)
+
+    # ---- Build caseResults + envelopeTables (Phase 3) ----
+    case_node_disps = extracted.get("case_node_disps", {})
+    case_beam_forces = extracted.get("case_beam_forces", {})
+    case_col_forces = extracted.get("case_col_forces", {})
+    floors_analyzed = extracted.get("floors_analyzed", 0)
+
+    all_case_names: set[str] = set()
+    all_case_names.update(case_node_disps.keys())
+    all_case_names.update(case_beam_forces.keys())
+    all_case_names.update(case_col_forces.keys())
+
+    case_results: Dict[str, Dict[str, Any]] = {}
+    node_displacement_envelope: Dict[str, Dict[str, Any]] = {}
+    element_force_envelope: Dict[str, Dict[str, Any]] = {}
+
+    for case_name in sorted(all_case_names):
+        # Per-case displacements — remap (pmid, floor) → V2 node ID
+        case_disps: Dict[str, Dict[str, float]] = {}
+        for key, disp in case_node_disps.get(case_name, {}).items():
+            v2_id = pm_floor_to_v2.get(key)
+            if v2_id:
+                case_disps[v2_id] = disp
+            else:
+                case_disps[str(key[0])] = disp
+
+        # Per-case forces — remap (pmid, floor) → V2 element ID
+        case_forces_out: Dict[str, Dict[str, float]] = {}
+        for key, force in case_beam_forces.get(case_name, {}).items():
+            v2_eid = pm_floor_elem_to_v2.get(key)
+            elem_id = v2_eid if v2_eid else str(key[0])
+            case_forces_out[elem_id] = {
+                "N": force["N"],
+                "V": (force["Vy"]**2 + force["Vz"]**2)**0.5,
+                "M": (force["My"]**2 + force["Mz"]**2)**0.5,
+                "Vy": force["Vy"], "Vz": force["Vz"],
+                "My": force["My"], "Mz": force["Mz"], "T": force["T"],
+            }
+        for key, force in case_col_forces.get(case_name, {}).items():
+            v2_eid = pm_floor_elem_to_v2.get(key)
+            elem_id = v2_eid if v2_eid else str(key[0])
+            existing = case_forces_out.get(elem_id, {})
+            case_forces_out[elem_id] = {
+                **existing,
+                "N": force["N"],
+                "V": (force["Vy"]**2 + force["Vz"]**2)**0.5,
+                "M": (force["My"]**2 + force["Mz"]**2)**0.5,
+                "Vy": force["Vy"], "Vz": force["Vz"],
+                "My": force["My"], "Mz": force["Mz"], "T": force["T"],
+            }
+
+        case_results[case_name] = {
+            "status": "success",
+            "displacements": case_disps,
+            "forces": case_forces_out,
+            "reactions": {},
+            "envelope": {},
         }
+
+        # Accumulate envelope tables
+        for node_id, disp in case_disps.items():
+            mag = (disp["ux"]**2 + disp["uy"]**2 + disp["uz"]**2)**0.5
+            item = node_displacement_envelope.setdefault(
+                str(node_id), {"maxAbsDisplacement": 0.0, "controlCase": ""}
+            )
+            if mag > item["maxAbsDisplacement"]:
+                item["maxAbsDisplacement"] = round(mag, 4)
+                item["controlCase"] = case_name
+
+        for elem_id, force in case_forces_out.items():
+            item = element_force_envelope.setdefault(
+                str(elem_id), {
+                    "maxAbsAxialForce": 0.0, "maxAbsShearForce": 0.0, "maxAbsMoment": 0.0,
+                    "controlCaseAxial": "", "controlCaseShear": "", "controlCaseMoment": "",
+                }
+            )
+            axial = abs(force.get("N", 0.0))
+            shear = abs(force.get("V", 0.0))
+            moment = abs(force.get("M", 0.0))
+            if axial > item["maxAbsAxialForce"]:
+                item["maxAbsAxialForce"] = round(axial, 2)
+                item["controlCaseAxial"] = case_name
+            if shear > item["maxAbsShearForce"]:
+                item["maxAbsShearForce"] = round(shear, 2)
+                item["controlCaseShear"] = case_name
+            if moment > item["maxAbsMoment"]:
+                item["maxAbsMoment"] = round(moment, 2)
+                item["controlCaseMoment"] = case_name
 
     # envelope for max displacement
     max_disp = pkpm_summary.get("max_displacement_mm", 0.0)
@@ -521,7 +709,18 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     if max_disp_node:
         envelope[f"node:{max_disp_node}:maxAbsDisplacement"] = max_disp
 
-    return {
+    # Build envelope summary with control cases
+    envelope_summary: Dict[str, Any] = {
+        "maxAbsDisplacement": max_disp,
+        "controlCase": {"displacement": ""},
+    }
+    for nid, item in node_displacement_envelope.items():
+        if item["maxAbsDisplacement"] == max_disp:
+            envelope_summary["controlCase"]["displacement"] = item.get("controlCase", "")
+            break
+
+    # Build result dict
+    result_dict: Dict[str, Any] = {
         "status": "success",
         "analysisMode": "pkpm-satwe",
         "displacements": displacements,
@@ -536,7 +735,7 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
             "engine": "pkpm-static",
             "jws_path": str(jws_path),
             "work_dir": str(work_dir),
-            "floors_analyzed": extracted.get("floors_analyzed", 0),
+            "floors_analyzed": floors_analyzed,
             "beam_count": extracted.get("beam_count", 0),
             "column_count": extracted.get("column_count", 0),
             **pkpm_summary,
@@ -550,5 +749,18 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
             "storey_stiffness": extracted.get("storey_stiffness", []),
             "bearing_shear": extracted.get("bearing_shear", []),
         },
+        "caseResults": case_results,
+        "envelopeTables": {
+            "nodeDisplacement": node_displacement_envelope,
+            "elementForce": element_force_envelope,
+            "nodeReaction": {},
+        },
         "warnings": warnings,
     }
+
+    # Add utilization data under correct key for frontend adapter
+    if member_utilization:
+        check_key = "steelCheck" if material_family == "steel" else "codeCheck"
+        result_dict[check_key] = {"memberUtilization": member_utilization}
+
+    return result_dict

--- a/backend/src/agent-skills/analysis/pkpm-static/runtime.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/runtime.py
@@ -15,7 +15,6 @@ PKPM_WORK_DIR : str, optional
 from __future__ import annotations
 
 import os
-import re
 import subprocess
 import tempfile
 import uuid
@@ -351,7 +350,7 @@ def _extract_results(jws_path: Path, material_family: str = "steel") -> Dict[str
                     pmid = node.GetPmID()
                     node_key = (pmid, node.GetFloorNo())
                     case_node_disps.setdefault(case_name, {})[node_key] = {
-                        "ux": abs(vx), "uy": abs(vy), "uz": abs(vz),
+                        "ux": vx, "uy": vy, "uz": vz,
                         "rx": 0.0, "ry": 0.0, "rz": 0.0,
                     }
                     mag = (vx ** 2 + vy ** 2 + vz ** 2) ** 0.5
@@ -732,16 +731,6 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     envelope: Dict[str, Any] = {}
     if max_disp_node:
         envelope[f"node:{max_disp_node}:maxAbsDisplacement"] = max_disp
-
-    # Build envelope summary with control cases
-    envelope_summary: Dict[str, Any] = {
-        "maxAbsDisplacement": max_disp,
-        "controlCase": {"displacement": ""},
-    }
-    for nid, item in node_displacement_envelope.items():
-        if item["maxAbsDisplacement"] == max_disp:
-            envelope_summary["controlCase"]["displacement"] = item.get("controlCase", "")
-            break
 
     # Build result dict
     result_dict: Dict[str, Any] = {

--- a/backend/src/agent-skills/analysis/pkpm-static/runtime.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/runtime.py
@@ -246,23 +246,25 @@ def _extract_results(jws_path: Path) -> Dict[str, Any]:
 
             floor_idx += 1
 
-        # ---- Node displacements (filter PKPM sentinel 99999) ----
+        # ---- Node displacements (per-load-case envelope, filter sentinel) ----
         _SENTINEL = 99990.0
         node_displacements: list[dict[str, Any]] = []
         try:
             for node in result.GetPyNodeInResult():
                 disp_dict = node.GetNodeDisp()
-                dx = dy = dz = 0.0
+                best_mag = 0.0
+                best_dx = best_dy = best_dz = 0.0
                 for _key, nd in disp_dict.items():
-                    vx = abs(_safe_float(nd.GetDispX()))
-                    vy = abs(_safe_float(nd.GetDispY()))
-                    vz = abs(_safe_float(nd.GetDispZ()))
-                    if vx < _SENTINEL:
-                        dx = max(dx, vx)
-                    if vy < _SENTINEL:
-                        dy = max(dy, vy)
-                    if vz < _SENTINEL:
-                        dz = max(dz, vz)
+                    vx = _safe_float(nd.GetDispX())
+                    vy = _safe_float(nd.GetDispY())
+                    vz = _safe_float(nd.GetDispZ())
+                    if abs(vx) >= _SENTINEL or abs(vy) >= _SENTINEL or abs(vz) >= _SENTINEL:
+                        continue
+                    mag = (vx ** 2 + vy ** 2 + vz ** 2) ** 0.5
+                    if mag > best_mag:
+                        best_mag = mag
+                        best_dx, best_dy, best_dz = abs(vx), abs(vy), abs(vz)
+                dx, dy, dz = best_dx, best_dy, best_dz
                 if dx > 0:
                     all_node_disp_x.append(dx)
                 if dy > 0:
@@ -391,7 +393,7 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     # ---- Phase 1: Generate JWS ----
     try:
         model_dict = model.model_dump(mode="json") if hasattr(model, "model_dump") else dict(model)
-        jws_path = convert_v2_to_jws(model_dict, work_dir, project_name)
+        jws_path, converter_mappings = convert_v2_to_jws(model_dict, work_dir, project_name)
     except Exception as exc:
         raise RuntimeError(f"PKPM JWS generation failed: {exc}") from exc
 
@@ -412,12 +414,50 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     beams = extracted.get("beams", [])
     columns = extracted.get("columns", [])
 
+    # ---- Build V2 node → PKPM (floor, pmid) mapping ----
+    v2_to_pm: Dict[str, int] = converter_mappings.get("v2_to_pm", {})
+    v2_node_z: Dict[str, float] = converter_mappings.get("v2_node_z", {})
+    elem_map_raw: Dict[str, Any] = converter_mappings.get("elem_map", {})
+
+    # Build story top elevations for floor mapping
+    sorted_stories = sorted(
+        model_dict.get("stories", []),
+        key=lambda s: float(s.get("elevation", 0)),
+    )
+    story_tops: list[float] = []
+    for st in sorted_stories:
+        elev = float(st.get("elevation", 0))
+        h = float(st.get("height", 0))
+        story_tops.append(elev + h)
+
+    # Map each V2 node to a PKPM floor number (1-indexed)
+    v2_node_floor: Dict[str, int] = {}
+    for v2_id, z in v2_node_z.items():
+        if abs(z) < 0.001:
+            v2_node_floor[v2_id] = 0  # base
+            continue
+        for i, top_z in enumerate(story_tops):
+            if abs(z - top_z) < 0.01:
+                v2_node_floor[v2_id] = i + 1
+                break
+
+    # Build reverse: (pkpm_pmid, floor) → v2_node_id
+    pm_floor_to_v2: Dict[tuple[int, int], str] = {}
+    for v2_id, pm_id in v2_to_pm.items():
+        floor = v2_node_floor.get(v2_id, -1)
+        if floor > 0:
+            pm_floor_to_v2[(pm_id, floor)] = v2_id
+
     # displacements: { nodeId: { ux, uy, uz, rx, ry, rz } }
     displacements: Dict[str, Dict[str, float]] = {}
     for nd in node_disps:
-        node_id = str(nd.get("pmid", ""))
-        if node_id:
-            displacements[node_id] = {
+        pmid = nd.get("pmid", -1)
+        floor = nd.get("floor", 0)
+        # Try to remap to V2 node ID
+        v2_id = pm_floor_to_v2.get((pmid, floor))
+        node_key = v2_id if v2_id else str(pmid)
+        if node_key:
+            displacements[node_key] = {
                 "ux": nd.get("max_disp_x_mm", 0.0),
                 "uy": nd.get("max_disp_y_mm", 0.0),
                 "uz": nd.get("max_disp_z_mm", 0.0),
@@ -426,11 +466,20 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
                 "rz": 0.0,
             }
 
+    # Build element pmid → V2 element ID mapping
+    # PKPM design beams/columns are keyed by their pmid in results.
+    # We map by position: for columns, pmid = plan node id; for beams, pmid = net id.
+    pm_elem_to_v2: Dict[int, str] = {}
+    for v2_eid, info in elem_map_raw.items():
+        pm_elem_to_v2[info["pmid"]] = v2_eid
+
     # forces: { elementId: { N, V, M, T, n1.N, n2.N, ... } }
     forces: Dict[str, Dict[str, float]] = {}
     for b in beams:
-        elem_id = str(b.get("pmid", ""))
-        if not elem_id:
+        pmid = b.get("pmid", -1)
+        v2_eid = pm_elem_to_v2.get(pmid)
+        elem_id = v2_eid if v2_eid else str(pmid)
+        if not elem_id or elem_id == str(-1):
             continue
         shear = b.get("max_shear_force_kn", 0.0)
         posi_moments = b.get("positive_moments_kNm", [])
@@ -444,8 +493,10 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
             "M": max_m,
         }
     for c in columns:
-        elem_id = str(c.get("pmid", ""))
-        if not elem_id:
+        pmid = c.get("pmid", -1)
+        v2_eid = pm_elem_to_v2.get(pmid)
+        elem_id = v2_eid if v2_eid else str(pmid)
+        if not elem_id or elem_id == str(-1):
             continue
         col_n = c.get("max_axial_force_kn", 0.0)
         col_v = c.get("max_shear_force_kn", 0.0)
@@ -453,7 +504,7 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
         acr = c.get("axial_compression_ratio", [])
         forces[elem_id] = {
             **(forces.get(elem_id, {})),
-            "N": max(col_n, max([abs(v) for v in acr], default=0.0)),
+            "N": col_n,
             "V": col_v,
             "M": col_m,
         }

--- a/backend/src/agent-skills/structure-type/frame/extract-llm.ts
+++ b/backend/src/agent-skills/structure-type/frame/extract-llm.ts
@@ -42,14 +42,16 @@ function repeatScalar(count: number | undefined, value: number | undefined): num
 function buildUniformFloorLoads(
   storyCount: number | undefined,
   verticalKN: number | undefined,
+  liveLoadKN: number | undefined,
   lateralXKN: number | undefined,
   lateralYKN: number | undefined,
 ): DraftFloorLoad[] | undefined {
   if (!storyCount) return undefined;
-  if (verticalKN === undefined && lateralXKN === undefined && lateralYKN === undefined) return undefined;
+  if (verticalKN === undefined && liveLoadKN === undefined && lateralXKN === undefined && lateralYKN === undefined) return undefined;
   return Array.from({ length: storyCount }, (_, index) => ({
     story: index + 1,
     verticalKN,
+    liveLoadKN,
     lateralXKN,
     lateralYKN,
   }));
@@ -72,6 +74,19 @@ function extractAreaLoadIntensity(message: string): number | undefined {
   }, ['direct']);
 }
 
+function extractLiveLoadIntensity(message: string): number | undefined {
+  const livePatterns = [
+    /活载[荷]?\s*[：:]*\s*([0-9]+(?:\.[0-9]+)?)\s*(?:kn|千牛)\s*\/\s*m(?:\^?2|2|²)/i,
+    /live\s*load\s*[：:]*\s*([0-9]+(?:\.[0-9]+)?)\s*(?:kn|千牛)\s*\/\s*m(?:\^?2|2|²)/i,
+    /活荷载\s*[：:]*\s*([0-9]+(?:\.[0-9]+)?)\s*(?:kn|千牛)\s*\/\s*m(?:\^?2|2|²)/i,
+  ];
+  for (const pattern of livePatterns) {
+    const match = message.match(pattern);
+    if (match?.[1]) return normalizeNumber(match[1]);
+  }
+  return undefined;
+}
+
 function extractLineLoadIntensity(message: string): number | undefined {
   return extractLlmScalar({
     value: message,
@@ -90,12 +105,14 @@ function deriveFloorLoadsFromIntensity(
 
   const areaLoadKNm2 = extractAreaLoadIntensity(message);
   const lineLoadKNm = extractLineLoadIntensity(message);
-  if (areaLoadKNm2 === undefined && lineLoadKNm === undefined) return patch;
+  const liveLoadKNm2 = extractLiveLoadIntensity(message);
+  if (areaLoadKNm2 === undefined && lineLoadKNm === undefined && liveLoadKNm2 === undefined) return patch;
 
   const dimension = patch.frameDimension
     ?? (patch.bayCountY !== undefined || patch.bayWidthsYM?.length ? '3d' : '2d');
 
   let verticalKN: number | undefined;
+  let derivedLiveLoadKN: number | undefined;
   if (dimension === '3d') {
     const totalSpanX = sumPositive(patch.bayWidthsXM);
     const totalSpanY = sumPositive(patch.bayWidthsYM);
@@ -121,12 +138,33 @@ function deriveFloorLoadsFromIntensity(
     }
   }
 
-  if (verticalKN === undefined || !Number.isFinite(verticalKN) || verticalKN <= 0) {
+  // Derive live load KN from intensity (same area logic as dead load)
+  if (liveLoadKNm2 !== undefined) {
+    if (dimension === '3d') {
+      const totalSpanX = sumPositive(patch.bayWidthsXM);
+      const totalSpanY = sumPositive(patch.bayWidthsYM);
+      if (totalSpanX !== undefined && totalSpanY !== undefined) {
+        derivedLiveLoadKN = liveLoadKNm2 * totalSpanX * totalSpanY;
+      }
+    } else {
+      const bayWidths2d = patch.bayWidthsM ?? patch.bayWidthsXM;
+      const totalSpan2d = sumPositive(bayWidths2d);
+      if (totalSpan2d !== undefined) {
+        derivedLiveLoadKN = liveLoadKNm2 * totalSpan2d;
+      }
+    }
+  }
+
+  if ((verticalKN === undefined || !Number.isFinite(verticalKN) || verticalKN <= 0)
+    && (derivedLiveLoadKN === undefined || !Number.isFinite(derivedLiveLoadKN) || derivedLiveLoadKN <= 0)) {
     return patch;
   }
 
-  const roundedVerticalKN = Number(verticalKN.toFixed(6));
-  const derivedFloorLoads = buildUniformFloorLoads(storyCount, roundedVerticalKN, undefined, undefined);
+  const roundedVerticalKN = verticalKN && Number.isFinite(verticalKN) && verticalKN > 0
+    ? Number(verticalKN.toFixed(6)) : undefined;
+  const roundedLiveLoadKN = derivedLiveLoadKN && Number.isFinite(derivedLiveLoadKN) && derivedLiveLoadKN > 0
+    ? Number(derivedLiveLoadKN.toFixed(6)) : undefined;
+  const derivedFloorLoads = buildUniformFloorLoads(storyCount, roundedVerticalKN, roundedLiveLoadKN, undefined, undefined);
   return derivedFloorLoads ? { ...patch, floorLoads: derivedFloorLoads } : patch;
 }
 
@@ -144,6 +182,7 @@ export function buildFramePatchFromLlm(
   const bayWidthXScalar = extractLlmScalar(rawPatch, ['bayWidthXScalar', 'bayWidthXM', 'spacingXM']);
   const bayWidthYScalar = extractLlmScalar(rawPatch, ['bayWidthYScalar', 'bayWidthYM', 'spacingYM']);
   const verticalLoadKN = extractLlmScalar(rawPatch, ['verticalLoadKN', 'uniformVerticalLoadKN']);
+  const liveLoadKN = extractLlmScalar(rawPatch, ['liveLoadKN', 'uniformLiveLoadKN']);
   const lateralXKN = extractLlmScalar(rawPatch, ['lateralXKN', 'horizontalLoadKN', 'uniformLateralXKN']);
   const lateralYKN = extractLlmScalar(rawPatch, ['lateralYKN', 'uniformLateralYKN']);
   const frameDimension = normalized.frameDimension
@@ -166,7 +205,7 @@ export function buildFramePatchFromLlm(
     bayWidthsM: normalized.bayWidthsM ?? repeatScalar(bayCount, bayWidthScalar),
     bayWidthsXM: normalized.bayWidthsXM ?? repeatScalar(bayCountX, bayWidthXScalar ?? bayWidthScalar),
     bayWidthsYM: normalized.bayWidthsYM ?? repeatScalar(bayCountY, bayWidthYScalar ?? bayWidthScalar),
-    floorLoads: normalized.floorLoads ?? buildUniformFloorLoads(storyCount, verticalLoadKN, lateralXKN, frameDimension === '3d' ? lateralYKN : undefined),
+    floorLoads: normalized.floorLoads ?? buildUniformFloorLoads(storyCount, verticalLoadKN, liveLoadKN, lateralXKN, frameDimension === '3d' ? lateralYKN : undefined),
     ...(frameMaterial !== undefined && { frameMaterial }),
     ...(frameColumnSection !== undefined && { frameColumnSection }),
     ...(frameBeamSection !== undefined && { frameBeamSection }),

--- a/backend/src/agent-skills/structure-type/frame/model.ts
+++ b/backend/src/agent-skills/structure-type/frame/model.ts
@@ -65,6 +65,27 @@ function resolveSteelGradeProps(grade: string | undefined): SteelGradeProps & { 
   return { ...STEEL_GRADE_PROPERTIES[resolved]!, resolvedGrade: resolved };
 }
 
+function parseCustomHSection(raw: string): { H: number; B: number; tw: number; tf: number } | null {
+  const normalized = raw.toUpperCase().replace(/[×X]/g, 'x').replace(/\s+/g, '');
+  const match = normalized.match(/^H(\d+)x(\d+)x([\d.]+)x([\d.]+)$/);
+  if (!match) return null;
+  const H = parseFloat(match[1]!);
+  const B = parseFloat(match[2]!);
+  const tw = parseFloat(match[3]!);
+  const tf = parseFloat(match[4]!);
+  if (H > 0 && B > 0 && tw > 0 && tf > 0) return { H, B, tw, tf };
+  return null;
+}
+
+function computeHSectionProps(H: number, B: number, tw: number, tf: number, G: number) {
+  const hw = H - 2 * tf;
+  const A = tw * hw + 2 * B * tf;
+  const Iy = (tw * hw ** 3) / 12 + (2 * B * tf ** 3) / 12 + 2 * B * tf * ((hw + tf) / 2) ** 2;
+  const Iz = (2 * tf * B ** 3) / 12 + (hw * tw ** 3) / 12;
+  const J = (2 * B * tf ** 3 + hw * tw ** 3) / 3;
+  return { A: A / 1e6, Iy: Iy / 1e12, Iz: Iz / 1e12, J: J / 1e12, G };
+}
+
 function resolveSectionProps(
   section: string | undefined,
   role: 'column' | 'beam',
@@ -76,10 +97,23 @@ function resolveSectionProps(
     : getDefaultBeamSection(storyCount);
   const normalized = section ? normalizeSectionName(section) : defaultSection;
   const found = Boolean(H_SECTION_PROPERTIES[normalized]);
-  const sectionKey = found ? normalized : defaultSection;
-  const substituted = (section && !found) ? `${normalized} not in builtin library, substituted with ${sectionKey}` : undefined;
-  const entry = H_SECTION_PROPERTIES[sectionKey]!;
-  return { name: sectionKey, A: entry.A, Iy: entry.Iy, Iz: entry.Iz, J: entry.J, G: matG, shape: entry.shape, standardSteelName: entry.standardSteelName, substituted };
+  if (found) {
+    const entry = H_SECTION_PROPERTIES[normalized]!;
+    return { name: normalized, A: entry.A, Iy: entry.Iy, Iz: entry.Iz, J: entry.J, G: matG, shape: entry.shape, standardSteelName: entry.standardSteelName };
+  }
+  const custom = section ? parseCustomHSection(section) : null;
+  if (custom) {
+    const props = computeHSectionProps(custom.H, custom.B, custom.tw, custom.tf, matG);
+    const name = `H${custom.H}x${custom.B}x${custom.tw}x${custom.tf}`;
+    return {
+      name,
+      ...props,
+      shape: { kind: 'H', H: custom.H, B: custom.B, tw: custom.tw, tf: custom.tf },
+      standardSteelName: name,
+    };
+  }
+  const entry = H_SECTION_PROPERTIES[defaultSection]!;
+  return { name: defaultSection, A: entry.A, Iy: entry.Iy, Iz: entry.Iz, J: entry.J, G: matG, shape: entry.shape, standardSteelName: entry.standardSteelName, substituted: `${normalized} not in builtin library and not parseable, substituted with ${defaultSection}` };
 }
 
 function accumulateCoords(lengths: number[]): number[] {

--- a/backend/src/agent-skills/structure-type/frame/model.ts
+++ b/backend/src/agent-skills/structure-type/frame/model.ts
@@ -173,12 +173,14 @@ function buildFrame2dLocalModel(
       const fl = floorLoads.find((l) => l.story === storyIdx);
       const floorAreaM2 = Math.max(xCoords[xCoords.length - 1], 1);
       const deadLoad = fl?.verticalKN ? Math.abs(fl.verticalKN) / floorAreaM2 : undefined;
+      const liveLoad = fl?.liveLoadKN ? Math.abs(fl.liveLoadKN) / floorAreaM2 : undefined;
       return {
         id: `F${storyIdx}`,
         height: h,
         elevation: zCoords[i],
         standard_floor_group: 'SF1',
         ...(deadLoad ? { dead_load: Math.round(deadLoad * 100) / 100 } : {}),
+        ...(liveLoad ? { live_load: Math.round(liveLoad * 100) / 100 } : {}),
       };
     }),
     load_cases: [{ id: 'LC1', type: 'other', loads }],
@@ -292,12 +294,14 @@ function buildFrame3dLocalModel(
       const fl = floorLoads.find((l) => l.story === storyIdx);
       const floorAreaM2 = Math.max(xCoords[xCoords.length - 1], 1) * Math.max(yCoords[yCoords.length - 1], 1);
       const deadLoad = fl?.verticalKN ? Math.abs(fl.verticalKN) / floorAreaM2 : undefined;
+      const liveLoad = fl?.liveLoadKN ? Math.abs(fl.liveLoadKN) / floorAreaM2 : undefined;
       return {
         id: `F${storyIdx}`,
         height: h,
         elevation: zCoords[i],
         standard_floor_group: 'SF1',
         ...(deadLoad ? { dead_load: Math.round(deadLoad * 100) / 100 } : {}),
+        ...(liveLoad ? { live_load: Math.round(liveLoad * 100) / 100 } : {}),
       };
     }),
     load_cases: [{ id: 'LC1', type: 'other', loads }],


### PR DESCRIPTION
## Summary

- **Problem:** PKPM SATWE analysis for steel frame models had 5 bugs causing crashes, wrong I-section field mapping, and incorrect material labels. Custom H-sections couldn't be parsed, and the material type showed "钢砼结构" instead of "钢结构".
- **Why it matters:** Steel frame analysis was either crashing or producing incorrect results, blocking real engineering workflows.
- **What changed:** Fixed AddStandFloor crash, corrected I-section field mapping (B=tw, U=bf, T=tf, D=bf, F=tf), added custom H-section parsing, set section material via `Set_M(5)`, implemented JWSCYCLE execution via DirectorySet.conf, and added post-processing to correct the material label in output files.
- **What did NOT change (scope boundary):** Frontend, other analysis engines (OpenSees), chat/session logic, agent orchestration — only `pkpm-static/` converter, runtime, and `frame/` model builder were modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** PKPM I-section field mapping was incorrect (B was being set to flange width instead of web thickness). AddStandFloor() was being called when it causes crashes with beams. JWSCYCLE auto-detects material by scanning sections and classifies custom sections (SetUserSect) as "钢砼" regardless of Set_M(5) and KIND 103=10303.
- **Missing detection / guardrail:** No validation that PKPM API field mapping matched the official APIPythonTest.py reference.
- **Prior context:** I-section mapping was originally guessed; official example was found later in API docs.
- **Why this regressed now:** Initial PKPM converter was written without access to official API documentation.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `tests/regression/analysis-runner.py`
- Scenario the test should lock in: Steel frame model with custom H-sections completes PKPM analysis without crash, WMASS.OUT shows steel design code GB50017-2017.
- Why this is the smallest reliable guardrail: The analysis regression runner already validates end-to-end PKPM execution.

## User-visible / Behavior Changes

- Steel frame models now produce correct analysis results instead of crashing
- WMASS.OUT material label shows "钢结构" for steel models
- GOUJIAN.OUT has correct section dimensions for custom H-sections

## Diagram (if applicable)

```text
Before:
[V2 JSON with H-sections] -> [wrong field mapping] -> [crash or wrong results]

After:
[V2 JSON with H-sections] -> [correct mapping + Set_M(5)] -> [JWSCYCLE] -> [patch material label] -> [correct WMASS.OUT]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No (JWSCYCLE subprocess invocation was already present)
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime: Python 3.13 + PKPM2026R2.0 APIPyInterface
- Model/provider: N/A

### Steps

1. Create a 3-story steel frame model with custom H-sections (H400×200×12×20 columns, H350×175×8×14 beams)
2. Run PKPM SATWE analysis via `run_analysis()`
3. Check WMASS.OUT and GOUJIAN.OUT output files

### Expected

- Analysis completes without crash
- WMASS shows "钢结构" and GB50017-2017 design code
- GOUJIAN shows correct section dimensions

### Actual (before fix)

- AddStandFloor crashes with beams
- I-section dimensions stored incorrectly
- Material label shows "钢砼结构"

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: 3-story steel frame with 8 columns + 10 beams, custom H-sections
- Edge cases checked: Concrete material family (still uses SetUserSect with Set_M(6))
- What I did **not** verify: Multi-standard-floor models, brace elements, non-I-section types

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Post-processing patch replaces text in WMASS.OUT/WHBJSS.OUT — if JWSCYCLE changes encoding or wording in future versions, the replacement may not work.
  - Mitigation: Patch is conditional on `material_family == "steel"` and only targets the exact GBK bytes for "钢砼结构" → "钢结构".