### PR TITLE
fix(backend): fix YJK multi-story assembly and fire-and-forget calculation

### DIFF
--- a/backend/src/agent-skills/analysis/yjk-static/intent.md
+++ b/backend/src/agent-skills/analysis/yjk-static/intent.md
@@ -1,5 +1,23 @@
+---
+id: yjk-static
+zhName: YJK 静力分析
+enName: YJK Static Analysis
+zhDescription: 使用 YJK (盈建科) 引擎自动建模并执行静力分析，提取节点位移、构件内力、楼层刚度等结构化结果（需安装 YJK 8.0 并配置 YJKS_ROOT 或 YJK_PATH）。
+enDescription: Automated modeling and static analysis using the YJK engine. Extracts node displacements, member forces, and floor statistics as structured results (requires YJK 8.0 and YJKS_ROOT or YJK_PATH).
+software: yjk
+analysisType: static
+engineId: builtin-yjk
+adapterKey: builtin-yjk
+priority: 125
+triggers: ["YJK 静力分析", "YJK 计算", "盈建科", "yjk static", "yjk analysis"]
+stages: ["analysis"]
+capabilities: ["analysis-policy", "analysis-execution"]
+supportedModelFamilies: ["frame", "generic"]
+autoLoadByDefault: false
+runtimeRelativePath: runtime.py
+---
 # YJK Static Analysis
 
-- `zh`: 当用户要求使用 YJK（盈建科）进行结构静力计算、设计验算时使用。自动将 V2 模型转换为 YJK 格式，启动盈建科软件执行建模、前处理、整体计算，并从 .OUT 文本文件提取分析结果。需要已安装 YJK 8.0 并配置 `YJKS_ROOT` 或 `YJK_PATH` 指向安装根目录（与官方 SDK 示例一致）。
-- `en`: Use when the request asks for YJK-based structural static analysis or design checks. Automatically converts V2 model to YJK format, launches YJK for modeling, preprocessing, and full calculation, then extracts results from .OUT text files. Requires YJK 8.0 and `YJKS_ROOT` or `YJK_PATH` pointing to the install root (same convention as the official YJK SDK samples).
+- `zh`: 当用户要求使用 YJK（盈建科）进行结构静力计算、设计验算时使用。自动将 V2 模型转换为 YJK 格式，启动盈建科软件执行建模、前处理，并自动触发整体计算。由于 YJK 计算时间不可预测，系统会在模型导入和预处理完成后立即返回成功，计算在 YJK 中后台继续进行。请提示用户在 YJK 软件中查看计算进度和结果。需要已安装 YJK 8.0 并配置 `YJKS_ROOT` 或 `YJK_PATH` 指向安装根目录。
+- `en`: Use when the request asks for YJK-based structural static analysis or design checks. Automatically converts V2 model to YJK format, launches YJK for modeling and preprocessing, then kicks off the full calculation. Since YJK calculation time is unpredictable, the system returns success immediately after model import and preprocessing. The calculation continues running in the YJK GUI. Prompt the user to check progress and results in the YJK application. Requires YJK 8.0 and `YJKS_ROOT` or `YJK_PATH` pointing to the install root.
 - Runtime: `analysis/yjk-static/runtime.py`

--- a/backend/src/agent-skills/analysis/yjk-static/yjk_converter.py
+++ b/backend/src/agent-skills/analysis/yjk-static/yjk_converter.py
@@ -302,10 +302,20 @@ def _extract_grid_spans(nodes: list[dict]) -> tuple[list[int], list[int]]:
     sorted_y = sorted(ys)
 
     if len(sorted_x) < 2 or len(sorted_y) < 2:
-        raise ValueError(
-            f"Need at least 2 unique X and 2 unique Y coordinates, "
-            f"got {len(sorted_x)} X and {len(sorted_y)} Y"
-        )
+        # 2D frame models may have only 1 unique coordinate on one axis
+        # after V1→V2 remap (XZ plane → Y=0, YZ plane → X=0).
+        # Synthesize a nominal span so YJK can proceed.
+        if len(sorted_x) >= 2 and len(sorted_y) < 2:
+            nominal_y = sorted_y[0] if sorted_y else 0
+            sorted_y = [nominal_y, nominal_y + 1000]
+        elif len(sorted_y) >= 2 and len(sorted_x) < 2:
+            nominal_x = sorted_x[0] if sorted_x else 0
+            sorted_x = [nominal_x, nominal_x + 1000]
+        else:
+            raise ValueError(
+                f"Need at least 2 unique coordinates in at least one plan direction (X or Y) "
+                f"to form a grid. Got {len(sorted_x)} X and {len(sorted_y)} Y."
+            )
 
     xspans = [int(sorted_x[0])]
     for i in range(1, len(sorted_x)):

--- a/backend/src/agent-skills/analysis/yjk-static/yjk_converter.py
+++ b/backend/src/agent-skills/analysis/yjk-static/yjk_converter.py
@@ -302,22 +302,10 @@ def _extract_grid_spans(nodes: list[dict]) -> tuple[list[int], list[int]]:
     sorted_y = sorted(ys)
 
     if len(sorted_x) < 2 or len(sorted_y) < 2:
-        # 2D frame models may have only 1 unique coordinate on one axis
-        # after V1→V2 remap (XZ plane → Y=0, YZ plane → X=0).
-        # Synthesize a nominal span so YJK can proceed.
-        if len(sorted_x) >= 2 and len(sorted_y) < 2:
-            nominal_y = sorted_y[0] if sorted_y else 0
-            # Use 1000 as a default span for 2D models; can be optimized later
-            sorted_y = [nominal_y, nominal_y + 1000]
-        elif len(sorted_y) >= 2 and len(sorted_x) < 2:
-            nominal_x = sorted_x[0] if sorted_x else 0
-            # Use 1000 as a default span for 2D models; can be optimized later
-            sorted_x = [nominal_x, nominal_x + 1000]
-        else:
-            raise ValueError(
-                f"Need at least 2 unique coordinates in at least one plan direction (X or Y) "
-                f"to form a grid. Got {len(sorted_x)} X and {len(sorted_y)} Y."
-            )
+        raise ValueError(
+            f"Need at least 2 unique X and 2 unique Y coordinates, "
+            f"got {len(sorted_x)} X and {len(sorted_y)} Y"
+        )
 
     xspans = [int(sorted_x[0])]
     for i in range(1, len(sorted_x)):
@@ -443,23 +431,54 @@ def convert_v2_to_ydb(
         _log(f"ERROR: beam arrangement failed: {exc}")
         raise
 
-    # Assemble floors story by story to support varying story heights.
-    # Each story gets its own StdFlr with the correct height and loads.
-    # If all stories share the same height the loop degenerates to a single call.
-    for i, story in enumerate(stories):
-        s_height_mm = int(round(float(story.get("height", first_story["height"])) * M_TO_MM))
-        if s_height_mm <= 0:
-            s_height_mm = height_mm
-        s_dead, s_live = _get_floor_loads(story)
-        s_flr = data_func.StdFlr_Generate(s_height_mm, s_dead, s_live) if (
-            s_height_mm != height_mm or s_dead != dead or s_live != live
+    # Assemble floors story by story.
+    #
+    # Floors_Assemb signature: (H_start_mm, std_flr, num_floors, floor_height_mm)
+    #   H_start_mm  — cumulative elevation (mm) where this batch of floors begins
+    #   std_flr     — standard floor definition from StdFlr_Generate
+    #   num_floors  — how many consecutive floors to create with this definition
+    #   floor_height_mm — storey height for these floors (mm)
+    #
+    # Group consecutive stories that share the same height and loads so we can
+    # batch them into a single Floors_Assemb call (matching the SDK pattern).
+    # For varying heights we issue multiple calls with the correct H_start.
+    cumulative_h = 0
+    group_start = 0
+    while group_start < len(stories):
+        ref = stories[group_start]
+        ref_h = int(round(float(ref.get("height", first_story["height"])) * M_TO_MM))
+        if ref_h <= 0:
+            ref_h = height_mm
+        ref_dead, ref_live = _get_floor_loads(ref)
+
+        # Count how many consecutive stories share the same height & loads
+        group_count = 1
+        for j in range(group_start + 1, len(stories)):
+            s = stories[j]
+            s_h = int(round(float(s.get("height", first_story["height"])) * M_TO_MM))
+            if s_h <= 0:
+                s_h = height_mm
+            s_dead, s_live = _get_floor_loads(s)
+            if s_h == ref_h and s_dead == ref_dead and s_live == ref_live:
+                group_count += 1
+            else:
+                break
+
+        s_flr = data_func.StdFlr_Generate(ref_h, ref_dead, ref_live) if (
+            ref_h != height_mm or ref_dead != dead or ref_live != live
         ) else std_flr
-        _log(f"Assembling floor {i + 1}/{len(stories)}: height={s_height_mm}mm, dead={s_dead}, live={s_live}")
+
+        _log(f"Floors_Assemb(H_start={cumulative_h}, flr, count={group_count}, h={ref_h}) "
+             f"[stories {group_start + 1}-{group_start + group_count}]")
         try:
-            data_func.Floors_Assemb(i, s_flr, 1, s_height_mm)
+            data_func.Floors_Assemb(cumulative_h, s_flr, group_count, ref_h)
         except Exception as exc:
-            _log(f"ERROR: Floors_Assemb failed for story {i + 1}: {exc}")
+            _log(f"ERROR: Floors_Assemb failed for stories {group_start + 1}-{group_start + group_count}: {exc}")
             raise
+
+        cumulative_h += ref_h * group_count
+        group_start += group_count
+
     _log("Floors_Assemb completed")
 
     _log("Assigning model to database...")

--- a/backend/src/agent-skills/analysis/yjk-static/yjk_driver.py
+++ b/backend/src/agent-skills/analysis/yjk-static/yjk_driver.py
@@ -244,8 +244,13 @@ def _run(model_path: str, work_dir: str, yjks_root: str) -> int:
         _error("YJK crashed during layer support setup")
         return 1
 
-    # -- Phase 5: Preprocessing + full analysis -------------------------
-    print("[yjk_driver] Phase 5: preprocessing + calculation", file=sys.stderr, flush=True)
+    # -- Phase 5: Preprocessing + kick off analysis ----------------------
+    # Preprocessing steps (genmodrel, transload) are fast and must finish
+    # before the model is usable.  The heavy design calculation
+    # (yjkdesign_dsncalculating_all) can take an unpredictable amount of
+    # time, so we launch it in a background thread and return immediately.
+    # The user can monitor progress and view results directly in the YJK GUI.
+    print("[yjk_driver] Phase 5: preprocessing", file=sys.stderr, flush=True)
     if not _run_cmd("yjkspre_genmodrel"):
         _error("YJK crashed during model relation generation")
         return 1
@@ -258,22 +263,31 @@ def _run(model_path: str, work_dir: str, yjks_root: str) -> int:
     if not _run_cmd("SetCurrentLabel", "IDSPRE_ROOT"):
         _error("YJK crashed during label switch")
         return 1
-    if not _run_cmd("yjkdesign_dsncalculating_all"):
-        _error("YJK crashed during design calculation - this often happens when the model has no valid structural data or missing sections")
-        return 1
-    if not _run_cmd("SetCurrentLabel", "IDDSN_DSP"):
-        _error("YJK crashed during final label switch")
-        return 1
 
-    print("[yjk_driver] Phase 5 complete: analysis finished", file=sys.stderr, flush=True)
+    print("[yjk_driver] Phase 5: preprocessing done, launching calculation in background", file=sys.stderr, flush=True)
 
-    # -- Phase 6: Skip result extraction for now -------------------------
-    # TODO: implement structured result extraction via yjks_pyload
-    print("[yjk_driver] Phase 6: result extraction skipped (not yet implemented)", file=sys.stderr, flush=True)
+    # Fire-and-forget: start the heavy calculation in a daemon thread so
+    # the driver can return immediately.  The YJK GUI stays open and the
+    # user can observe progress there.
+    import threading
 
-    # -- Phase 7: Build final output ------------------------------------
+    def _background_calc() -> None:
+        try:
+            _run_cmd("yjkdesign_dsncalculating_all")
+            _run_cmd("SetCurrentLabel", "IDDSN_DSP")
+            print("[yjk_driver] background calculation finished", file=sys.stderr, flush=True)
+        except Exception as exc:
+            print(f"[yjk_driver] background calculation error: {exc}", file=sys.stderr, flush=True)
+
+    calc_thread = threading.Thread(target=_background_calc, daemon=True)
+    calc_thread.start()
+    # Give the thread a moment to issue the RunCmd call to YJK before we exit.
+    # The YJK GUI process is independent — once the command is dispatched,
+    # calculation continues even after this driver process exits.
+    calc_thread.join(timeout=5)
+
+    # -- Build final output (return immediately) ------------------------
     warnings: list[str] = []
-    warnings.append("Structured result extraction not yet implemented; returning .OUT files as fallback")
 
     output: dict = {
         "status": "success",
@@ -284,12 +298,17 @@ def _run(model_path: str, work_dir: str, yjks_root: str) -> int:
             "work_dir": work_dir,
         },
         "data": {},
-        "detailed": {"raw_output": _collect_out_files(work_dir)},
+        "detailed": {
+            "message": "模型已导入YJK并启动计算，请在YJK中查看计算进度和结果。"
+                       " / Model imported into YJK and calculation started. "
+                       "Please check progress and results in the YJK application.",
+            "yjk_project": yjk_project,
+        },
         "warnings": warnings,
     }
 
     _emit_json(output)
-    print("[yjk_driver] done", file=sys.stderr, flush=True)
+    print("[yjk_driver] done — calculation running in YJK", file=sys.stderr, flush=True)
     return 0
 
 

--- a/backend/src/agent-skills/analysis/yjk-static/yjk_driver.py
+++ b/backend/src/agent-skills/analysis/yjk-static/yjk_driver.py
@@ -266,25 +266,35 @@ def _run(model_path: str, work_dir: str, yjks_root: str) -> int:
 
     print("[yjk_driver] Phase 5: preprocessing done, launching calculation in background", file=sys.stderr, flush=True)
 
-    # Fire-and-forget: start the heavy calculation in a daemon thread so
-    # the driver can return immediately.  The YJK GUI stays open and the
-    # user can observe progress there.
+    # Fire-and-forget: dispatch the heavy calculation command to YJK, then
+    # return immediately.  RunCmd is synchronous (blocks until YJK finishes),
+    # but the YJK GUI is an independent process — once the command is
+    # dispatched via the YJKAPI COM/IPC channel, the calculation continues
+    # even after this driver process exits.
+    #
+    # We use a non-daemon thread so Python won't kill it during shutdown.
+    # The thread calls RunCmd which blocks inside the YJKAPI DLL; once the
+    # IPC message is sent to YJK, the actual computation runs in yjks.exe.
+    # We join with a generous timeout to ensure the IPC dispatch completes,
+    # then emit our result and exit.  The thread may still be alive (blocked
+    # waiting for YJK to finish), but os._exit() will terminate cleanly.
     import threading
+
+    dispatch_ok = threading.Event()
 
     def _background_calc() -> None:
         try:
+            dispatch_ok.set()  # signal that we've entered the function
             _run_cmd("yjkdesign_dsncalculating_all")
             _run_cmd("SetCurrentLabel", "IDDSN_DSP")
             print("[yjk_driver] background calculation finished", file=sys.stderr, flush=True)
         except Exception as exc:
             print(f"[yjk_driver] background calculation error: {exc}", file=sys.stderr, flush=True)
 
-    calc_thread = threading.Thread(target=_background_calc, daemon=True)
+    calc_thread = threading.Thread(target=_background_calc, daemon=False)
     calc_thread.start()
-    # Give the thread a moment to issue the RunCmd call to YJK before we exit.
-    # The YJK GUI process is independent — once the command is dispatched,
-    # calculation continues even after this driver process exits.
-    calc_thread.join(timeout=5)
+    # Wait for the thread to start and dispatch the command to YJK.
+    dispatch_ok.wait(timeout=10)
 
     # -- Build final output (return immediately) ------------------------
     warnings: list[str] = []
@@ -309,7 +319,11 @@ def _run(model_path: str, work_dir: str, yjks_root: str) -> int:
 
     _emit_json(output)
     print("[yjk_driver] done — calculation running in YJK", file=sys.stderr, flush=True)
-    return 0
+    # Force-exit: the non-daemon calc_thread is blocked inside RunCmd
+    # waiting for YJK to finish.  We don't want to wait — os._exit()
+    # terminates immediately without joining threads.  The YJK GUI
+    # process is independent and continues the calculation.
+    os._exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

### 1. Fix multi-story assembly (yjk_converter.py)
- **Root cause**: Floors_Assemb was called in a per-floor loop with (i, flr, 1, h), treating the floor index as H_start and assembling only 1 floor per call. YJK only kept the last call, resulting in a single-story model.
- **Fix**: Group consecutive stories with the same height and loads, then call Floors_Assemb(cumulative_h, std_flr, count, height) once per group, matching the SDK reference script (three_story_steel_frame.py).

### 2. Fire-and-forget calculation (yjk_driver.py)
- **Root cause**: The driver waited synchronously for yjkdesign_dsncalculating_all to complete. YJK calculation time is unpredictable, causing Python worker timeout (300s).
- **Fix**: Preprocessing steps (genmodrel, transload) still run synchronously (fast). The heavy design calculation launches in a daemon thread. The driver returns success immediately with a bilingual message telling the user to check results in YJK.

### 3. Update LLM prompt (intent.md)
- Updated skill description so the LLM knows YJK now returns immediately after model import and preprocessing, and should prompt the user to check progress in the YJK application.

## Impacted areas
- backend/src/agent-skills/analysis/yjk-static/

## Testing
- Verified 3-story steel frame (X: 4 bays at 6m, Y: 3 bays at 4m, story height 3.6m) correctly produces 3 stories in YJK
- YJK calculation launches successfully without timeout

Closes #157 (superseded)