### PR TITLE
fix(backend): remove undefined member_utilization reference in PKPM runtime

### DIFF
--- a/backend/src/agent-skills/analysis/pkpm-static/runtime.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/runtime.py
@@ -807,9 +807,6 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     envelope["controlElementShearForce"] = control_elem_shear
     envelope["controlElementMoment"] = control_elem_moment
 
-    if member_utilization:
-        envelope["elementUtilization"] = member_utilization
-
     # Build result dict
     result_dict: Dict[str, Any] = {
         "status": "success",


### PR DESCRIPTION
## Summary
- Remove dead reference to `member_utilization` in `pkpm-static/runtime.py` that was never defined, causing `NameError: name 'member_utilization' is not defined` at runtime
- Leftover from PR #161 (PKPM utilization mapping cleanup)

## Impacted areas
- `backend` — PKPM SATWE static analysis runtime

## Test plan
- [x] `npm run build --prefix backend` passes (tsc clean)
- [ ] Verify PKPM static analysis no longer throws `NameError`