### PR TITLE
feat(backend): add workspace scope to memory tool for cross-session persistence

### DIFF
--- a/backend/src/agent-langgraph/__tests__/memory-tool.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/memory-tool.test.mjs
@@ -1,4 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import os from "os";
 
 describe("memory tool conversation scope", () => {
   let prisma;
@@ -42,6 +45,71 @@ describe("memory tool conversation scope", () => {
     await expect(tool.invoke(
       { action: "list" },
       { configurable: {} },
-    )).rejects.toThrow(/Persistent memory requires a conversation thread_id/);
+    )).rejects.toThrow(/Conversation-scoped memory requires a conversation thread_id/);
+  });
+});
+
+describe("memory tool workspace scope", () => {
+  let tmpDir;
+  let tool;
+
+  beforeAll(async () => {
+    const { createMemoryTool } = await import("../../../dist/agent-langgraph/memory-tool.js");
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "memory-tool-ws-"));
+    tool = createMemoryTool(tmpDir);
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("stores and retrieves workspace memory without thread_id", async () => {
+    const storeRaw = await tool.invoke(
+      { action: "store", key: "default.code", value: { code: "GB50010" }, scope: "workspace" },
+      { configurable: {} },
+    );
+    const storeResult = JSON.parse(storeRaw);
+    expect(storeResult.success).toBe(true);
+    expect(storeResult.entry.scopeType).toBe("workspace");
+    expect(storeResult.entry.scopeId).toBe("default");
+
+    const retrieveRaw = await tool.invoke(
+      { action: "retrieve", key: "default.code", scope: "workspace" },
+      { configurable: {} },
+    );
+    const retrieveResult = JSON.parse(retrieveRaw);
+    expect(retrieveResult.entry.value).toEqual({ code: "GB50010" });
+  });
+
+  test("lists workspace entries", async () => {
+    const listRaw = await tool.invoke(
+      { action: "list", scope: "workspace" },
+      { configurable: {} },
+    );
+    const listResult = JSON.parse(listRaw);
+    expect(listResult.success).toBe(true);
+    expect(listResult.entries.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("deletes workspace entry", async () => {
+    await tool.invoke(
+      { action: "store", key: "to.delete", value: { x: 1 }, scope: "workspace" },
+      { configurable: {} },
+    );
+    const deleteRaw = await tool.invoke(
+      { action: "delete", key: "to.delete", scope: "workspace" },
+      { configurable: {} },
+    );
+    const deleteResult = JSON.parse(deleteRaw);
+    expect(deleteResult.deleted).toBe(true);
+  });
+
+  test("defaults to conversation scope when scope omitted", async () => {
+    const { createMemoryTool } = await import("../../../dist/agent-langgraph/memory-tool.js");
+    const convTool = createMemoryTool();
+    await expect(convTool.invoke(
+      { action: "list" },
+      { configurable: {} },
+    )).rejects.toThrow(/Conversation-scoped memory requires a conversation thread_id/);
   });
 });

--- a/backend/src/agent-langgraph/memory-tool.ts
+++ b/backend/src/agent-langgraph/memory-tool.ts
@@ -1,23 +1,34 @@
 import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 import type { LangGraphRunnableConfig } from '@langchain/langgraph';
-import { AgentMemoryService, type AgentMemoryScope } from '../services/agent-memory.js';
+import { AgentMemoryService, type AgentMemoryScope, type AgentMemoryScopeType } from '../services/agent-memory.js';
 
-const memoryService = new AgentMemoryService();
-
-function resolveScope(config: LangGraphRunnableConfig): AgentMemoryScope {
+function resolveScope(
+  requestedScope: AgentMemoryScopeType,
+  config: LangGraphRunnableConfig,
+): AgentMemoryScope {
+  if (requestedScope === 'workspace') {
+    return { scopeType: 'workspace', scopeId: 'default' };
+  }
   const configurable = config.configurable as { thread_id?: unknown } | undefined;
   const threadId = typeof configurable?.thread_id === 'string' ? configurable.thread_id.trim() : '';
   if (!threadId) {
-    throw new Error('Persistent memory requires a conversation thread_id.');
+    throw new Error('Conversation-scoped memory requires a conversation thread_id.');
   }
   return { scopeType: 'conversation', scopeId: threadId };
 }
 
-export function createMemoryTool() {
+export function createMemoryTool(workspaceRoot?: string) {
+  const memoryService = new AgentMemoryService(workspaceRoot);
+
   return tool(
-    async (input: { action: 'store' | 'retrieve' | 'list' | 'delete'; key?: string; value?: unknown }, config: LangGraphRunnableConfig) => {
-      const scope = resolveScope(config);
+    async (
+      input: { action: 'store' | 'retrieve' | 'list' | 'delete'; key?: string; value?: unknown; scope?: AgentMemoryScopeType },
+      config: LangGraphRunnableConfig,
+    ) => {
+      const effectiveScope = input.scope ?? 'conversation';
+      const scope = resolveScope(effectiveScope, config);
+
       if (input.action === 'store') {
         if (!input.key) throw new Error('key is required for store');
         if (input.value === undefined) throw new Error('value is required for store');
@@ -40,13 +51,18 @@ export function createMemoryTool() {
     {
       name: 'memory',
       description:
-        'Store, retrieve, list, or delete persistent memory for the current engineering conversation. ' +
-        'Use for durable preferences, constraints, and confirmed engineering decisions. ' +
+        'Store, retrieve, list, or delete persistent memory. ' +
+        'Supports two scopes: "conversation" (default, current session only) and ' +
+        '"workspace" (cross-session, persists across conversations). ' +
+        'Use workspace scope for reusable preferences, durable constraints, and confirmed engineering decisions. ' +
         'Do not use for current-turn draft parameters; those live in session state.',
       schema: z.object({
         action: z.enum(['store', 'retrieve', 'list', 'delete']),
         key: z.string().optional(),
         value: z.unknown().optional(),
+        scope: z.enum(['conversation', 'workspace']).optional().describe(
+          'Memory scope: "conversation" (current session, default) or "workspace" (cross-session persistent).',
+        ),
       }),
     },
   );

--- a/backend/src/agent-langgraph/system-prompt.ts
+++ b/backend/src/agent-langgraph/system-prompt.ts
@@ -145,7 +145,7 @@ ${summarizeArtifacts(state)}
 - run_analysis 完成后，立即调用 generate_report 生成报告，不要输出总结文字后停止。
 - 使用 set_session_config 只会更新当前会话配置，不会创建持久记忆。
 - set_session_config 只影响当前会话的分析类型、设计规范和技能选择。
-- memory 用于在当前工程对话中持久保存可复用偏好、长期约束和已确认工程决策；不要把临时草稿参数写入 memory。
+- memory 支持 conversation 和 workspace 两种 scope。conversation scope（默认）存储当前会话的上下文；workspace scope 存储跨会话持久偏好（如默认设计规范、项目约束）。不要把临时草稿参数写入 memory。
 
 **重要**: 工具从会话状态中自动读取数据（模型、分析结果、草稿状态等）。不要将 modelJson、analysisJson、stateJson 等参数传递给工具。工具会自动使用上一步的结果。`;
 }
@@ -201,7 +201,7 @@ When the user makes a structural design or analysis request, follow this workflo
 - Never end the conversation after analysis without generating a report.
 - Use set_session_config only for current-session configuration; it does not create persistent memory.
 - set_session_config only affects the current session's analysis type, design code, and selected skills.
-- memory stores reusable preferences, durable constraints, and confirmed engineering decisions within the current engineering conversation; do not store temporary draft parameters in memory.
+- memory supports conversation and workspace scopes. conversation scope (default) stores current-session context; workspace scope stores cross-session persistent preferences (e.g. default design code, project constraints). Do not store temporary draft parameters in memory.
 
 **IMPORTANT**: Tools read data (model, analysis results, draft state, etc.) from conversation state automatically. Do NOT pass modelJson, analysisJson, stateJson, or other JSON string parameters to tools. Tools automatically use results from previous steps.`;
 }

--- a/backend/src/agent-langgraph/tool-registry.ts
+++ b/backend/src/agent-langgraph/tool-registry.ts
@@ -12,6 +12,7 @@ import {
   createValidateModelTool,
 } from './tools.js';
 import { createMemoryTool } from './memory-tool.js';
+import { getWorkspaceRoot } from './config.js';
 import {
   createDeletePathTool,
   createGlobFilesTool,
@@ -157,10 +158,10 @@ export const AGENT_TOOL_DEFINITIONS: readonly AgentToolDefinition[] = [
     defaultEnabled: true,
     displayName: { zh: '持久记忆', en: 'Persistent Memory' },
     description: {
-      zh: '存储和检索当前工程对话的持久上下文。',
-      en: 'Store and retrieve durable context for the current engineering conversation.',
+      zh: '存储和检索工程记忆。支持 conversation（当前会话）和 workspace（跨会话持久）两种 scope。',
+      en: 'Store and retrieve engineering memory. Supports conversation (current session) and workspace (cross-session persistent) scopes.',
     },
-    create: () => createMemoryTool(),
+    create: () => createMemoryTool(getWorkspaceRoot()),
   },
   {
     id: 'glob_files',

--- a/backend/src/services/__tests__/agent-memory.test.mjs
+++ b/backend/src/services/__tests__/agent-memory.test.mjs
@@ -1,4 +1,7 @@
 import { describe, expect, test, beforeAll, afterAll } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import os from "os";
 
 describe("AgentMemoryService", () => {
   let service;
@@ -33,5 +36,102 @@ describe("AgentMemoryService", () => {
       { value: true },
     ))
       .rejects.toThrow(/Invalid memory key/);
+  });
+});
+
+describe("AgentMemoryFileStore", () => {
+  let fileStore;
+  let tmpDir;
+  let normalizeMemoryKey;
+
+  beforeAll(async () => {
+    const mod = await import("../../../dist/services/agent-memory.js");
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "memory-test-"));
+    fileStore = new mod.AgentMemoryFileStore(tmpDir);
+    normalizeMemoryKey = mod.normalizeMemoryKey;
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("stores and retrieves a value", async () => {
+    const entry = await fileStore.store("design.code", { code: "GB50017" });
+    expect(entry.scopeType).toBe("workspace");
+    expect(entry.scopeId).toBe("default");
+    expect(entry.key).toBe("design.code");
+    expect(entry.value).toEqual({ code: "GB50017" });
+
+    const retrieved = await fileStore.retrieve("design.code");
+    expect(retrieved.value).toEqual({ code: "GB50017" });
+  });
+
+  test("returns null for missing key", async () => {
+    const entry = await fileStore.retrieve("nonexistent");
+    expect(entry).toBeNull();
+  });
+
+  test("lists entries sorted by updatedAt desc", async () => {
+    await fileStore.store("alpha", { v: 1 });
+    await fileStore.store("beta", { v: 2 });
+    const entries = await fileStore.list();
+    expect(entries.length).toBeGreaterThanOrEqual(2);
+    // newest first
+    expect(entries[0].key).toBe("beta");
+    expect(entries[1].key).toBe("alpha");
+  });
+
+  test("deletes an entry", async () => {
+    await fileStore.store("to.delete", { v: 1 });
+    const deleted = await fileStore.delete("to.delete");
+    expect(deleted).toBe(true);
+    const entry = await fileStore.retrieve("to.delete");
+    expect(entry).toBeNull();
+  });
+
+  test("delete returns false for missing key", async () => {
+    const deleted = await fileStore.delete("no.such.key");
+    expect(deleted).toBe(false);
+  });
+
+  test("persists to file on disk", async () => {
+    await fileStore.store("persist.test", { ok: true });
+    const filePath = fileStore.getFilePath();
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const data = JSON.parse(raw);
+    expect(data["persist.test"].value).toEqual({ ok: true });
+  });
+
+  test("normalizes keys via normalizeMemoryKey", () => {
+    expect(normalizeMemoryKey("  Design.Code  ")).toBe("design.code");
+  });
+});
+
+describe("AgentMemoryService workspace scope dispatch", () => {
+  let service;
+  let tmpDir;
+
+  beforeAll(async () => {
+    const mod = await import("../../../dist/services/agent-memory.js");
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "memory-svc-test-"));
+    service = new mod.AgentMemoryService(tmpDir);
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("stores and retrieves via workspace scope", async () => {
+    const scope = { scopeType: "workspace", scopeId: "default" };
+    await service.store(scope, "project.constraint", { seismic_zone: 8 });
+    const entry = await service.retrieve(scope, "project.constraint");
+    expect(entry.value).toEqual({ seismic_zone: 8 });
+    expect(entry.scopeType).toBe("workspace");
+  });
+
+  test("lists workspace entries", async () => {
+    const scope = { scopeType: "workspace", scopeId: "default" };
+    const entries = await service.list(scope);
+    expect(entries.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/backend/src/services/agent-memory.ts
+++ b/backend/src/services/agent-memory.ts
@@ -1,6 +1,6 @@
+import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import { prisma } from '../utils/database.js';
 import type { InputJsonValue, JsonValue } from '../utils/json.js';
 
@@ -78,7 +78,10 @@ export class AgentMemoryFileStore {
         value: entry.value,
         updatedAt: entry.updatedAt,
       }))
-      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+      .sort((a, b) => {
+        const cmp = b.updatedAt.localeCompare(a.updatedAt);
+        return cmp !== 0 ? cmp : a.key.localeCompare(b.key);
+      });
   }
 
   async delete(key: string): Promise<boolean> {
@@ -96,18 +99,26 @@ export class AgentMemoryFileStore {
   }
 
   private async readData(): Promise<FileStoreData> {
+    let raw: string;
     try {
-      const raw = await fs.promises.readFile(this.filePath, 'utf-8');
+      raw = await fs.promises.readFile(this.filePath, 'utf-8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {};
+      throw err;
+    }
+    try {
       return JSON.parse(raw) as FileStoreData;
-    } catch {
-      return {};
+    } catch (err) {
+      throw new Error(
+        `Corrupt workspace memory file (${this.filePath}): ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 
   private async writeData(data: FileStoreData): Promise<void> {
     const dir = path.dirname(this.filePath);
     await fs.promises.mkdir(dir, { recursive: true });
-    const tmp = path.join(dir, `.workspace-memory-${Date.now()}.tmp`);
+    const tmp = path.join(dir, `.workspace-memory-${crypto.randomUUID()}.tmp`);
     await fs.promises.writeFile(tmp, JSON.stringify(data, null, 2), 'utf-8');
     await fs.promises.rename(tmp, this.filePath);
   }

--- a/backend/src/services/agent-memory.ts
+++ b/backend/src/services/agent-memory.ts
@@ -1,7 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 import { prisma } from '../utils/database.js';
 import type { InputJsonValue, JsonValue } from '../utils/json.js';
 
-export type AgentMemoryScopeType = 'conversation';
+export type AgentMemoryScopeType = 'conversation' | 'workspace';
 
 export interface AgentMemoryScope {
   scopeType: AgentMemoryScopeType;
@@ -16,8 +19,118 @@ export interface AgentMemoryEntryView {
   updatedAt: string;
 }
 
+// ---------------------------------------------------------------------------
+// Workspace file-backed store (.runtime/workspace-memory.json)
+// ---------------------------------------------------------------------------
+
+interface FileStoreEntry {
+  value: JsonValue;
+  updatedAt: string;
+}
+
+type FileStoreData = Record<string, FileStoreEntry>;
+
+export class AgentMemoryFileStore {
+  private readonly filePath: string;
+
+  constructor(workspaceRoot: string) {
+    const dir = path.join(workspaceRoot, '.runtime');
+    this.filePath = path.join(dir, 'workspace-memory.json');
+  }
+
+  async store(key: string, value: InputJsonValue): Promise<AgentMemoryEntryView> {
+    const normalizedKey = normalizeMemoryKey(key);
+    const data = await this.readData();
+    const updatedAt = new Date().toISOString();
+    data[normalizedKey] = { value: value as JsonValue, updatedAt };
+    await this.writeData(data);
+    return {
+      scopeType: 'workspace',
+      scopeId: 'default',
+      key: normalizedKey,
+      value: value as JsonValue,
+      updatedAt,
+    };
+  }
+
+  async retrieve(key: string): Promise<AgentMemoryEntryView | null> {
+    const normalizedKey = normalizeMemoryKey(key);
+    const data = await this.readData();
+    const entry = data[normalizedKey];
+    return entry
+      ? {
+          scopeType: 'workspace',
+          scopeId: 'default',
+          key: normalizedKey,
+          value: entry.value,
+          updatedAt: entry.updatedAt,
+        }
+      : null;
+  }
+
+  async list(): Promise<AgentMemoryEntryView[]> {
+    const data = await this.readData();
+    return Object.entries(data)
+      .map(([key, entry]) => ({
+        scopeType: 'workspace' as const,
+        scopeId: 'default',
+        key,
+        value: entry.value,
+        updatedAt: entry.updatedAt,
+      }))
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }
+
+  async delete(key: string): Promise<boolean> {
+    const normalizedKey = normalizeMemoryKey(key);
+    const data = await this.readData();
+    if (!(normalizedKey in data)) return false;
+    delete data[normalizedKey];
+    await this.writeData(data);
+    return true;
+  }
+
+  /* for testing */
+  getFilePath(): string {
+    return this.filePath;
+  }
+
+  private async readData(): Promise<FileStoreData> {
+    try {
+      const raw = await fs.promises.readFile(this.filePath, 'utf-8');
+      return JSON.parse(raw) as FileStoreData;
+    } catch {
+      return {};
+    }
+  }
+
+  private async writeData(data: FileStoreData): Promise<void> {
+    const dir = path.dirname(this.filePath);
+    await fs.promises.mkdir(dir, { recursive: true });
+    const tmp = path.join(dir, `.workspace-memory-${Date.now()}.tmp`);
+    await fs.promises.writeFile(tmp, JSON.stringify(data, null, 2), 'utf-8');
+    await fs.promises.rename(tmp, this.filePath);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unified memory service — dispatches by scopeType
+// ---------------------------------------------------------------------------
+
 export class AgentMemoryService {
+  private readonly fileStore?: AgentMemoryFileStore;
+
+  constructor(workspaceRoot?: string) {
+    if (workspaceRoot) {
+      this.fileStore = new AgentMemoryFileStore(workspaceRoot);
+    }
+  }
+
   async store(scope: AgentMemoryScope, key: string, value: InputJsonValue): Promise<AgentMemoryEntryView> {
+    if (scope.scopeType === 'workspace') {
+      if (!this.fileStore) throw new Error('Workspace memory requires a workspaceRoot.');
+      return this.fileStore.store(key, value);
+    }
     const normalizedKey = normalizeMemoryKey(key);
     const entry = await prisma.agentMemoryEntry.upsert({
       where: {
@@ -45,6 +158,10 @@ export class AgentMemoryService {
   }
 
   async retrieve(scope: AgentMemoryScope, key: string): Promise<AgentMemoryEntryView | null> {
+    if (scope.scopeType === 'workspace') {
+      if (!this.fileStore) throw new Error('Workspace memory requires a workspaceRoot.');
+      return this.fileStore.retrieve(key);
+    }
     const normalizedKey = normalizeMemoryKey(key);
     const entry = await prisma.agentMemoryEntry.findUnique({
       where: {
@@ -67,6 +184,10 @@ export class AgentMemoryService {
   }
 
   async list(scope: AgentMemoryScope): Promise<AgentMemoryEntryView[]> {
+    if (scope.scopeType === 'workspace') {
+      if (!this.fileStore) throw new Error('Workspace memory requires a workspaceRoot.');
+      return this.fileStore.list();
+    }
     const entries = await prisma.agentMemoryEntry.findMany({
       where: { scopeType: scope.scopeType, scopeId: scope.scopeId },
       orderBy: { updatedAt: 'desc' },
@@ -82,6 +203,10 @@ export class AgentMemoryService {
   }
 
   async delete(scope: AgentMemoryScope, key: string): Promise<boolean> {
+    if (scope.scopeType === 'workspace') {
+      if (!this.fileStore) throw new Error('Workspace memory requires a workspaceRoot.');
+      return this.fileStore.delete(key);
+    }
     const normalizedKey = normalizeMemoryKey(key);
     const result = await prisma.agentMemoryEntry.deleteMany({
       where: { scopeType: scope.scopeType, scopeId: scope.scopeId, key: normalizedKey },


### PR DESCRIPTION
## Summary

Add a `workspace` memory scope to the agent memory tool alongside the existing `conversation` scope. Workspace entries persist across conversations via a file-backed store (`.runtime/workspace-memory.json`), enabling the agent to retain reusable preferences, durable constraints, and confirmed engineering decisions between sessions.

- **Problem:** Memory was scoped only to individual conversations (`thread_id`). Users had to re-specify preferences (e.g. default design code, project constraints) in every new session.
- **Why it matters:** Workspace-scoped memory enables persistent engineering context that survives session boundaries — a key UX improvement for the chat-first workflow.
- **What changed:** Added `AgentMemoryFileStore` class for JSON file-backed storage; extended `AgentMemoryService` to dispatch by `scopeType` (`conversation` → Prisma/SQLite, `workspace` → file store); added `scope` parameter to the memory tool schema; updated system prompts and tool descriptions for both `en`/`zh`.
- **What did NOT change:** Conversation-scoped memory behavior, Prisma schema, API routes, frontend.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Follow-up to #186 (Conversation-scoped refactor)
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A — new feature.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Existing coverage already sufficient
- Target tests: `npm test --prefix backend -- --runInBand`
- New tests added:
  - `AgentMemoryFileStore`: store, retrieve, list, delete, file persistence, missing key
  - `AgentMemoryService` workspace scope dispatch
  - `memory-tool` workspace scope: store, retrieve, list, delete, default scope fallback

## User-visible / Behavior Changes

- Memory tool now accepts an optional `scope` parameter: `"conversation"` (default) or `"workspace"`
- System prompts updated to describe both scopes in both `en` and `zh`
- Workspace memory persisted in `.runtime/workspace-memory.json`

## Diagram

```text
Before:  memory tool → conversation scope only (Prisma/SQLite)
After:   memory tool → conversation scope (Prisma/SQLite)
                   ↘ workspace scope  (file store: .runtime/workspace-memory.json)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Steps

1. `npm run db:generate --prefix backend`
2. `npm run build --prefix backend`
3. `npm test --prefix backend -- --runInBand`

### Expected

- All test suites pass
- New `AgentMemoryFileStore` and workspace scope tests pass
- Existing conversation-scoped memory tests unchanged

## Evidence

- [x] New tests added covering the feature

## Human Verification (required)

- Verified scenarios: TypeScript build, Jest full suite including new workspace memory tests
- Edge cases checked: workspace scope without `workspaceRoot` throws, defaults to conversation scope when `scope` omitted, missing key returns null
- What you did **not** verify: Frontend build, E2E tests, LLM integration tests

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — `conversation` remains the default scope
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Concurrent writes to `.runtime/workspace-memory.json` could cause data loss
  - Mitigation: Uses atomic write (write to temp file + rename). Single-user dev tool scenario makes concurrent writes unlikely.
- Risk: File store grows unbounded
  - Mitigation: Workspace memory is for preferences/constraints (small, bounded data). Can add size limits later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)