### PR TITLE
fix(frontend): restore tool step skillId after page refresh

### DIFF
--- a/frontend/src/components/chat/ai-console.tsx
+++ b/frontend/src/components/chat/ai-console.tsx
@@ -2622,6 +2622,11 @@ export function AIConsole() {
         ? payload.messages.flatMap((message): Message[] => {
             // Handle tool messages — these come from persistFullConversationMessages
             if (message.role === 'tool') {
+              let restoredSkillId: string | undefined
+              try {
+                const parsed = JSON.parse(message.content)
+                if (typeof parsed?.skillId === 'string') restoredSkillId = parsed.skillId
+              } catch {}
               return [{
                 id: message.id,
                 role: 'tool' as const,
@@ -2634,6 +2639,7 @@ export function AIConsole() {
                   status: 'done' as const,
                   tool: (message as any).name || 'unknown',
                   title: (message as any).name || 'unknown',
+                  skillId: restoredSkillId,
                   output: message.content,
                   completedAt: message.createdAt,
                 },


### PR DESCRIPTION
## Summary

- **Problem:** Tool step cards show a skill badge (e.g. "frame", "opensees-static") during streaming, but after page refresh the badge disappears
- **Why it matters:** The tool message content JSON already contains `skillId` (e.g. `{"success":true,"skillId":"frame"}`), but `handleSelectConversation()` never extracts it when restoring tool messages from the backend
- **What changed:** Added `skillId` extraction from tool message content JSON during conversation restore, matching the same logic used by `extractSkillIdFromContent()` in streaming
- **What did NOT change:** No backend changes. Tool message persistence already stores the full content JSON with skillId. No changes to streaming behavior or other restore logic.

## Change Type

- Bug fix

## Scope

- UI / DX

## Root Cause

`handleSelectConversation()` in `ai-console.tsx` (line 2624-2640) reconstructs `toolStep` objects from persisted tool messages but only populated `id`, `phase`, `status`, `tool`, `title`, `output`, and `completedAt` — missing `skillId`. The data was always available in the message content JSON but was never parsed during restore.

## User-visible / Behavior Changes

- Tool step skill badges now persist across page refreshes and conversation switches

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification

- Verified: `npm run type-check --prefix frontend` passes
- Verified: `npm run test:run --prefix frontend` passes (191 passed)
- To verify manually: Start `./sclaw start`, send a message triggering tool calls, observe skill badges on tool steps, refresh page, confirm badges still show

🤖 Generated with [Claude Code](https://claude.com/claude-code)