### PR TITLE
Feat/visualization skills skeleton

### DIFF
--- a/frontend/src/components/visualization/skills/README.md
+++ b/frontend/src/components/visualization/skills/README.md
@@ -2,7 +2,7 @@
 
 This directory is the step-1 skeleton for moving visualization extensions toward a detachable skill architecture.
 
-The current PR intentionally keeps runtime behavior unchanged. Existing visualization logic still lives in the legacy extension registry, and `registry.ts` only re-exports that registry as a bridge for later steps.
+The current PR intentionally keeps runtime behavior unchanged. Existing visualization logic still lives in the legacy extension module, and `registry.ts` only re-exports the public lookup helpers (`getVisualizationExtensionByView`, `getVisualizationViewLabelKey`) so future skill consumers have a single import surface.
 
 ## Current Status
 
@@ -65,9 +65,9 @@ This keeps built-in visualization data and SkillHub-provided visualization data 
 
 ## Registry Bridge
 
-`registry.ts` currently re-exports the old `visualizationExtensionRegistry` as `legacyExtensionRegistry` on purpose.
+`registry.ts` currently re-exports only the public legacy lookup helpers (`getVisualizationExtensionByView`, `getVisualizationViewLabelKey`). The legacy `visualizationExtensionRegistry` array and `getAvailableVisualizationExtensions` filter remain module-private inside `extensions.tsx` on purpose.
 
-That bridge exists because step 1 only introduces contracts. It avoids changing runtime registration, toolbar rendering, aside rendering, scene rendering, or snapshot adaptation in the same PR.
+That narrow bridge exists because step 1 only introduces contracts. It avoids changing runtime registration, toolbar rendering, aside rendering, scene rendering, or snapshot adaptation in the same PR, while still giving step-2 callers a single import path.
 
 After step 2, `registry.ts` should become the canonical frontend visualization skill registry. At that point it can adapt or replace the old registry while keeping call sites stable.
 

--- a/frontend/src/components/visualization/skills/README.md
+++ b/frontend/src/components/visualization/skills/README.md
@@ -1,0 +1,78 @@
+﻿# Visualization Skills Migration Plan
+
+This directory is the step-1 skeleton for moving visualization extensions toward a detachable skill architecture.
+
+The current PR intentionally keeps runtime behavior unchanged. Existing visualization logic still lives in the legacy extension registry, and `registry.ts` only re-exports that registry as a bridge for later steps.
+
+## Current Status
+
+- Step 1 is complete: shared skill contracts, namespaced state helpers, schema guard helpers, and a registry bridge exist under `skills/`.
+- No built-in visualization skill has moved here yet.
+- `modal.tsx`, `structural-scene.tsx`, and `extensions.tsx` should continue to behave as they did before this skeleton.
+- Snapshot extension data must continue to flow through `snapshot.extensions`.
+
+## Five-Step Migration Route
+
+1. **Step 1 — Skeleton contracts (done)**
+   - Add reusable TypeScript contracts in `types.ts`.
+   - Add `useSkillState` and `useSkillStateValue` with namespaced keys in `state.ts`.
+   - Add small schema validator helpers in `schema.ts`.
+   - Keep `registry.ts` as a compatibility bridge to the legacy registry.
+
+2. **Step 2 — Registry adapter**
+   - Replace the bridge with a real skill registry shape.
+   - Adapt the existing built-in utilization and buckling extension definitions into the new registry contract.
+   - Keep public behavior and existing snapshot format stable while the registry internals change.
+
+3. **Step 3 — Modal and toolbar integration**
+   - Route aside, legend, toolbar, and activation hooks through skill definitions.
+   - Remove view-specific branching from modal-level UI where a registered skill can provide the behavior.
+   - After this step, view literals such as `view === 'buckling'` or `view === 'utilization'` must not appear in `modal.tsx`.
+
+4. **Step 4 — Scene contribution integration**
+   - Let skills contribute scene coloring, transforms, overlays, and frame-loop preferences through `SceneContribution`.
+   - Keep `structural-scene.tsx` generic: it should consume skill contributions, not import individual skill internals.
+   - Preserve existing rendering output for built-in views while moving the ownership boundary.
+
+5. **Step 5 — Built-in skill extraction**
+   - Move `builtin/utilization` and `builtin/buckling` into `skills/builtin/`.
+   - Keep the registry as the only public import surface for built-in and external skills.
+   - Add focused tests for registry discovery, availability, schema validation, and scene contributions.
+
+## Do Not Do
+
+- Do not add `view === 'buckling'` or `view === 'utilization'` literals in `modal.tsx` after step 3.
+- Do not add a top-level `skill` field to visualization snapshots.
+- Do not store skill payloads outside `snapshot.extensions`.
+- Do not import a single skill's internal module from outside `skills/`.
+- Do not move buckling or utilization rendering logic into this skeleton step.
+- Do not add npm dependencies just to support the migration scaffolding.
+- Do not make `skills/` responsible for backend SkillHub manifests; this directory is the frontend visualization contract layer.
+
+## Snapshot Extension Boundary
+
+Visualization skill data belongs under `snapshot.extensions` so the frontend has one stable extension payload boundary.
+
+A snapshot-level shape should continue to look like this:
+
+```ts
+snapshot.extensions?.['builtin.utilization']
+snapshot.extensions?.['builtin.buckling']
+snapshot.extensions?.['skillhub.some-extension']
+```
+
+This keeps built-in visualization data and SkillHub-provided visualization data on the same channel without adding another top-level snapshot namespace.
+
+## Registry Bridge
+
+`registry.ts` currently re-exports the old `visualizationExtensionRegistry` as `legacyExtensionRegistry` on purpose.
+
+That bridge exists because step 1 only introduces contracts. It avoids changing runtime registration, toolbar rendering, aside rendering, scene rendering, or snapshot adaptation in the same PR.
+
+After step 2, `registry.ts` should become the canonical frontend visualization skill registry. At that point it can adapt or replace the old registry while keeping call sites stable.
+
+## Import Boundary
+
+Code outside this directory should import from the registry or shared contracts only. It should not reach into a future path such as `skills/builtin/buckling/internal`.
+
+That boundary keeps each detachable skill replaceable and makes it possible to load built-in and external visualization skills through the same registry pipeline later.

--- a/frontend/src/components/visualization/skills/registry.ts
+++ b/frontend/src/components/visualization/skills/registry.ts
@@ -1,0 +1,15 @@
+import {
+  visualizationExtensionRegistry,
+  getAvailableVisualizationExtensions,
+  getVisualizationExtensionByView,
+  getVisualizationViewLabelKey,
+} from '../extensions'
+
+export {
+  visualizationExtensionRegistry as legacyExtensionRegistry,
+  getAvailableVisualizationExtensions,
+  getVisualizationExtensionByView,
+  getVisualizationViewLabelKey,
+}
+
+export const visualizationSkillRegistry: ReadonlyArray<never> = []

--- a/frontend/src/components/visualization/skills/registry.ts
+++ b/frontend/src/components/visualization/skills/registry.ts
@@ -1,14 +1,10 @@
 import {
-  visualizationExtensionRegistry,
-  getAvailableVisualizationExtensions,
   getVisualizationExtensionByView,
   getVisualizationViewLabelKey,
 } from '../extensions'
 import type { SkillRenderer } from './types'
 
 export {
-  visualizationExtensionRegistry as legacyExtensionRegistry,
-  getAvailableVisualizationExtensions,
   getVisualizationExtensionByView,
   getVisualizationViewLabelKey,
 }

--- a/frontend/src/components/visualization/skills/registry.ts
+++ b/frontend/src/components/visualization/skills/registry.ts
@@ -4,6 +4,7 @@ import {
   getVisualizationExtensionByView,
   getVisualizationViewLabelKey,
 } from '../extensions'
+import type { SkillRenderer } from './types'
 
 export {
   visualizationExtensionRegistry as legacyExtensionRegistry,
@@ -12,4 +13,4 @@ export {
   getVisualizationViewLabelKey,
 }
 
-export const visualizationSkillRegistry: ReadonlyArray<never> = []
+export const visualizationSkillRegistry: ReadonlyArray<SkillRenderer> = []

--- a/frontend/src/components/visualization/skills/schema.ts
+++ b/frontend/src/components/visualization/skills/schema.ts
@@ -1,0 +1,27 @@
+import type { MessageKey } from '@/lib/i18n'
+import type { SkillSchemaValidator } from './types'
+
+export function defineValidator<TData>(
+  check: (raw: unknown) => raw is TData,
+  reasonKey: MessageKey = 'visualizationViewModel'
+): SkillSchemaValidator<TData> {
+  return (raw) => (check(raw) ? { ok: true, data: raw } : { ok: false, reasonKey })
+}
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+export function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!isPlainObject(value)) return false
+  return Object.values(value).every((entry) => typeof entry === 'string')
+}
+
+export function isNumberRecord(value: unknown): value is Record<string, number> {
+  if (!isPlainObject(value)) return false
+  return Object.values(value).every(isFiniteNumber)
+}

--- a/frontend/src/components/visualization/skills/state.ts
+++ b/frontend/src/components/visualization/skills/state.ts
@@ -1,0 +1,64 @@
+'use client'
+
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
+import { createStore } from 'zustand/vanilla'
+import type { SkillStateApi } from './types'
+
+type SkillStateStore = {
+  values: Record<string, unknown>
+  setValue: (key: string, value: unknown) => void
+}
+
+const skillStateStore = createStore<SkillStateStore>((set) => ({
+  values: {},
+  setValue: (key, value) =>
+    set((prev) => {
+      if (prev.values[key] === value) return prev
+      return { ...prev, values: { ...prev.values, [key]: value } }
+    }),
+}))
+
+function namespaced(skillId: string, key: string): string {
+  return `${skillId}::${key}`
+}
+
+function readValue<T>(fullKey: string, fallback: T): T {
+  const stored = skillStateStore.getState().values[fullKey]
+  return stored === undefined ? fallback : (stored as T)
+}
+
+export function useSkillStateValue<T>(
+  skillId: string,
+  key: string,
+  fallback: T
+): [T, (value: T) => void] {
+  const fullKey = namespaced(skillId, key)
+  const value = useSyncExternalStore(
+    skillStateStore.subscribe,
+    () => readValue(fullKey, fallback),
+    () => fallback
+  )
+  const setter = useCallback(
+    (next: T) => skillStateStore.getState().setValue(fullKey, next),
+    [fullKey]
+  )
+  return [value, setter]
+}
+
+export function useSkillState(skillId: string): SkillStateApi {
+  return useMemo<SkillStateApi>(
+    () => ({
+      get: <T,>(key: string, fallback: T): T => readValue(namespaced(skillId, key), fallback),
+      set: <T,>(key: string, value: T): void => {
+        skillStateStore.getState().setValue(namespaced(skillId, key), value)
+      },
+      use: <T,>(key: string, fallback: T) => useSkillStateValue<T>(skillId, key, fallback),
+    }),
+    [skillId]
+  )
+}
+
+export function __resetSkillStateForTest(): void {
+  const setter = skillStateStore.getState().setValue
+  skillStateStore.setState({ values: {}, setValue: setter })
+}

--- a/frontend/src/components/visualization/skills/state.ts
+++ b/frontend/src/components/visualization/skills/state.ts
@@ -46,6 +46,15 @@ export function useSkillStateValue<T>(
 }
 
 export function useSkillState(skillId: string): SkillStateApi {
+  // 订阅整个 values map：任何 skill 的状态变化都会让消费者重渲染。
+  // 这里允许跨 skill 的"过度重渲染"，因为 step 1 还没有任何 skill 注册；
+  // 需要细粒度订阅时使用 useSkillStateValue。
+  useSyncExternalStore(
+    skillStateStore.subscribe,
+    () => skillStateStore.getState().values,
+    () => skillStateStore.getState().values
+  )
+
   return useMemo<SkillStateApi>(
     () => ({
       get: <T,>(key: string, fallback: T): T => readValue(namespaced(skillId, key), fallback),

--- a/frontend/src/components/visualization/skills/state.ts
+++ b/frontend/src/components/visualization/skills/state.ts
@@ -52,7 +52,6 @@ export function useSkillState(skillId: string): SkillStateApi {
       set: <T,>(key: string, value: T): void => {
         skillStateStore.getState().setValue(namespaced(skillId, key), value)
       },
-      use: <T,>(key: string, fallback: T) => useSkillStateValue<T>(skillId, key, fallback),
     }),
     [skillId]
   )

--- a/frontend/src/components/visualization/skills/types.ts
+++ b/frontend/src/components/visualization/skills/types.ts
@@ -1,0 +1,71 @@
+import type { ComponentType, ReactNode } from 'react'
+import type { MessageKey } from '@/lib/i18n'
+import type {
+  VisualizationCase,
+  VisualizationExtensionId,
+  VisualizationSnapshot,
+  VisualizationViewMode,
+} from '../types'
+
+export type SkillAvailability =
+  | { ok: true }
+  | { ok: false; reasonKey: MessageKey }
+
+export type SkillCategory = 'metric' | 'shape' | 'interaction'
+
+export type SkillStateApi = {
+  get: <T>(key: string, fallback: T) => T
+  set: <T>(key: string, value: T) => void
+  use: <T>(key: string, fallback: T) => [T, (value: T) => void]
+}
+
+export type SkillActions = {
+  setView: (view: VisualizationViewMode) => void
+  selectElement: (elementId: string | null) => void
+}
+
+export type SkillRenderContext = {
+  snapshot: VisualizationSnapshot
+  activeCase: VisualizationCase
+  activeView: VisualizationViewMode
+  locale: 'zh' | 'en'
+  t: (key: MessageKey) => string
+  state: SkillStateApi
+  actions: SkillActions
+}
+
+export type SceneContribution = {
+  memberColor?: (elementId: string, ctx: SkillRenderContext) => string | null
+  memberTransform?: (
+    elementId: string,
+    ctx: SkillRenderContext
+  ) => { positions?: [number, number, number][]; scale?: number } | null
+  frameloop?: 'always' | 'demand'
+  r3fOverlay?: ComponentType<{ ctx: SkillRenderContext }>
+}
+
+export type SkillRenderer = {
+  id: VisualizationExtensionId | string
+  view: VisualizationViewMode
+  viewLabelKey: MessageKey
+  descriptionKey?: MessageKey
+  category: SkillCategory
+  schemaVersion: number
+  isAvailable: (snapshot: VisualizationSnapshot | null) => SkillAvailability
+  renderAside?: (ctx: SkillRenderContext) => ReactNode
+  renderLegend?: (ctx: SkillRenderContext) => ReactNode
+  renderToolbarItem?: (ctx: SkillRenderContext) => ReactNode
+  scene?: SceneContribution
+  onActivate?: (ctx: SkillRenderContext) => void
+  onDeactivate?: (ctx: SkillRenderContext) => void
+}
+
+export type SkillSchemaValidator<TData = unknown> = (raw: unknown) =>
+  | { ok: true; data: TData }
+  | { ok: false; reasonKey: MessageKey }
+
+export type SkillContract<TData = unknown> = {
+  id: VisualizationExtensionId | string
+  schemaVersion: number
+  validate: SkillSchemaValidator<TData>
+}

--- a/frontend/src/components/visualization/skills/types.ts
+++ b/frontend/src/components/visualization/skills/types.ts
@@ -16,7 +16,6 @@ export type SkillCategory = 'metric' | 'shape' | 'interaction'
 export type SkillStateApi = {
   get: <T>(key: string, fallback: T) => T
   set: <T>(key: string, value: T) => void
-  use: <T>(key: string, fallback: T) => [T, (value: T) => void]
 }
 
 export type SkillActions = {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause:
- Missing detection / guardrail:
- Prior context (`git blame`, prior PR, issue, or refactor if known):
- Why this regressed now:
- If unknown, what was ruled out:

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user action] -> [old state]

After:
[user action] -> [new state] -> [result]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

## 请维护者确认方向

  本 PR 与 #108 的 SkillHub 体系存在概念重叠（`SkillRenderer` ↔ `VisualizationExtensionDefinition`、
  `SceneContribution` ↔ 现有 `renderToolbarActions` 等）。两条路可选，烦请告知偏好后我再做 step 2：

  - **路线 A（替换）**：把 `extensions.tsx` 中的 registry 逐步迁入 `skills/`，最终删除旧文件。
    优点：架构统一；缺点：需要协调 #108 后续工作。
  - **路线 B（共存）**：`skills/` 仅承载新增 skill（如 `stress-contour`），
    内置的 utilization/buckling 留在 `extensions.tsx`。
    优点：零打扰；缺点：长期维护两套 registry。

  我倾向 A，但听你们的。