### PR TITLE
chore: rename npm package to @structureclaw/structureclaw

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "structureclaw",
+  "name": "@structureclaw/structureclaw",
   "version": "1.0.0",
   "description": "AI-assisted structural engineering workspace",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Rename npm package from `structureclaw` to `@structureclaw/structureclaw`

## Test plan
- [ ] Verify `npm pack --dry-run` shows correct package name
- [ ] Verify `npm publish --dry-run` resolves the scoped name

🤖 Generated with [Claude Code](https://claude.com/claude-code)