### PR TITLE
chore: add repository metadata and remove dotenv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "structureclaw",
+  "name": "@structureclaw/structureclaw",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "structureclaw",
+      "name": "@structureclaw/structureclaw",
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "MIT",
@@ -23,7 +23,6 @@
         "@langchain/langgraph": "^1.2.9",
         "@langchain/openai": "^1.4.4",
         "@prisma/client": "^6.19.2",
-        "dotenv": "^17.3.1",
         "fastify": "^5.8.5",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
@@ -36,7 +35,7 @@
         "sclaw_cn": "bin/sclaw_cn.js"
       },
       "devDependencies": {
-        "typescript": "^5.4.3"
+        "typescript": "^5.8.3"
       },
       "engines": {
         "node": ">=20"
@@ -902,18 +901,6 @@
       "resolved": "https://registry.npmmirror.com/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "license": "MIT"
-    },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmmirror.com/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
     },
     "node_modules/effect": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,14 @@
     "sclaw": "./bin/sclaw.js",
     "sclaw_cn": "./bin/sclaw_cn.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/structureclaw/structureclaw.git"
+  },
+  "homepage": "https://github.com/structureclaw/structureclaw",
+  "bugs": {
+    "url": "https://github.com/structureclaw/structureclaw/issues"
+  },
   "files": [
     "bin/",
     "dist/backend/",


### PR DESCRIPTION
## Summary
- Add `repository`, `homepage`, `bugs` fields to `package.json`
- Sync `package-lock.json` with `@structureclaw/structureclaw` scoped name
- Remove unused `dotenv` dependency

## Test plan
- [ ] `npm i` succeeds
- [ ] `npm pack --dry-run` shows correct metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)