### PR TITLE
fix(ci): switch e2e to single-port architecture

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -114,31 +114,32 @@ jobs:
 
       - name: Setup backend database
         run: |
-          mkdir -p .structureclaw/data
+          mkdir -p $HOME/.structureclaw/data
           npm run db:deploy --prefix backend
         env:
-          DATABASE_URL: file:../../.structureclaw/data/test-e2e.db
+          DATABASE_URL: file:$HOME/.structureclaw/data/test-e2e.db
 
       - name: Install Playwright browsers
         run: npx --prefix frontend playwright install chromium --with-deps
 
+      - name: Write test config to settings.json
+        run: |
+          SETTINGS_PATH="$HOME/.structureclaw/settings.json"
+          TMP=$(mktemp)
+          jq --arg key "${{ secrets.LLM_API_KEY }}" \
+             --arg model "${{ vars.LLM_MODEL }}" \
+             --arg baseUrl "${{ vars.LLM_BASE_URL }}" \
+             --arg dbUrl "file:$HOME/.structureclaw/data/test-e2e.db" \
+             '.llm = (.llm // {}) | .llm.apiKey = $key | .llm.model = $model | .llm.baseUrl = $baseUrl | .database = (.database // {}) | .database.url = $dbUrl' \
+             "$SETTINGS_PATH" > "$TMP" && mv "$TMP" "$SETTINGS_PATH"
+
       - name: Start backend
         run: node backend/dist/index.js &
         env:
-          PORT: 30010
-          DATABASE_URL: file:../../.structureclaw/data/test-e2e.db
-          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-          LLM_MODEL: ${{ vars.LLM_MODEL }}
+          SCLAW_FRONTEND_DIR: ${{ github.workspace }}/frontend/out
 
-      - name: Start frontend
-        run: cd frontend && npx next dev -p 30000 &
-        env:
-          NEXT_PUBLIC_API_URL: http://localhost:30010
-
-      - name: Wait for services
-        run: |
-          npx wait-on http://localhost:30010/api/v1 --timeout 30000
-          npx wait-on http://localhost:30000 --timeout 60000
+      - name: Wait for backend
+        run: npx wait-on http://localhost:31415/api/v1 --timeout 30000
 
       - name: Run E2E tests
         id: run-tests

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   workers: 1,
   reporter: [['html', { open: 'never' }]],
   use: {
-    baseURL: 'http://localhost:31416',
+    baseURL: 'http://localhost:31415',
     locale: 'en',
     timezoneId: 'UTC',
     trace: 'on-first-retry',
@@ -22,28 +22,15 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: [
-    {
-      command: 'cd ../backend && npm run db:deploy && npm run build && node dist/index.js',
-      port: 30010,
-      reuseExistingServer: true,
-      timeout: 60_000,
-      env: {
-        PORT: '30010',
-        DATABASE_URL: 'file:../../.structureclaw/data/test-e2e.db',
-        LLM_API_KEY: process.env.LLM_API_KEY || '',
-        LLM_MODEL: process.env.LLM_MODEL || 'gpt-4o-mini',
-        ...(process.env.LLM_BASE_URL ? { LLM_BASE_URL: process.env.LLM_BASE_URL } : {}),
-      },
+  webServer: {
+    command: 'npm run build && cd ../backend && npm run db:deploy && npm run build && node dist/index.js',
+    port: 31415,
+    reuseExistingServer: true,
+    timeout: 120_000,
+    env: {
+      DATABASE_URL: 'file:../../.structureclaw/data/test-e2e.db',
+      SCLAW_FRONTEND_DIR: '../frontend/out',
+      NEXT_PUBLIC_API_URL: '',
     },
-    {
-      command: 'npx next dev -p 31416',
-      port: 31416,
-      reuseExistingServer: true,
-      timeout: 60_000,
-      env: {
-        NEXT_PUBLIC_API_URL: 'http://localhost:30010',
-      },
-    },
-  ],
+  },
 });


### PR DESCRIPTION
## Summary

- Switch E2E CI and Playwright config to single-port architecture where backend serves frontend via `SCLAW_FRONTEND_DIR`
- Remove separate "Start frontend" step (Next.js dev server) and `PORT` env var override that was ignored by `settings.json`
- Playwright `webServer` config simplified from dual-server array to single server on port 31415

## Root cause

`settings.json` (created by `sclaw doctor`) sets `port: 31415`, which takes priority over `PORT` env var in backend config. The old workflow set `PORT=30010` and waited on that port — timeout every time.

## Test plan

- [ ] E2E workflow triggers on push to this branch
- [ ] Backend starts on 31415 and serves frontend static files
- [ ] `wait-on` succeeds on `http://localhost:31415/api/v1`
- [ ] Playwright tests run against `http://localhost:31415`

🤖 Generated with [Claude Code](https://claude.com/claude-code)