### PR TITLE
fix(frontend): anchor load arrows at nodes

### DIFF
--- a/frontend/src/components/visualization/structural-scene.tsx
+++ b/frontend/src/components/visualization/structural-scene.tsx
@@ -683,7 +683,7 @@ function SceneContent({
                   <VectorArrow
                     color={typeof selectedLoadIndex === 'number' && snapshot.loads[selectedLoadIndex]?.nodeId === entry.id ? '#f59e0b' : '#22c55e'}
                     key={`${entry.id}-load-${index}`}
-                    origin={finalPosition.clone().sub(vector.clone().multiplyScalar(0.22))}
+                    origin={finalPosition}
                     selected={typeof selectedLoadIndex === 'number' && snapshot.loads[selectedLoadIndex]?.nodeId === entry.id}
                     vector={projectPosition(vector, plane, snapshot.dimension)}
                   />

--- a/frontend/src/components/visualization/structural-scene.tsx
+++ b/frontend/src/components/visualization/structural-scene.tsx
@@ -581,7 +581,7 @@ function SceneContent({
                     key={`${element.id}-distributed-${vectorIndex}`}
                     start={currentStart}
                     end={currentEnd}
-                    vector={projectPosition(vector, plane, snapshot.dimension)}
+                    vector={vector}
                   />
                 ))}
               </group>
@@ -685,7 +685,7 @@ function SceneContent({
                     key={`${entry.id}-load-${index}`}
                     origin={finalPosition}
                     selected={typeof selectedLoadIndex === 'number' && snapshot.loads[selectedLoadIndex]?.nodeId === entry.id}
-                    vector={projectPosition(vector, plane, snapshot.dimension)}
+                    vector={vector}
                   />
                 ))}
               </group>


### PR DESCRIPTION
## Summary

- Problem: Nodal load arrows started slightly behind the node, and load vectors were projected twice before rendering in 2D views.
- Why it matters: Load direction and point of application are visual engineering cues; offset or double-projected arrows can make applied loads look detached or point in the wrong plane direction.
- What changed: Nodal load arrows now use the node position as `VectorArrow.origin`, and nodal/distributed load arrows now pass the already-projected vector directly to their arrow components.
- What did NOT change (scope boundary): Reaction arrows, load scaling, selection styling, camera behavior, and result data are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `VectorArrow` treats `origin` as the arrow tail, but the node-load rendering path subtracted `0.22 * vector` from the node position. Separately, nodal and distributed load vectors were already projected during vector construction but were projected again at render time.
- Missing detection / guardrail: No visual regression coverage currently asserts that load arrows originate at the rendered node coordinate and preserve direction across 2D planes.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Not traced to a specific PR; this is a localized rendering-coordinate issue in `StructuralScene`.
- Why this regressed now: Unknown.
- If unknown, what was ruled out: Reaction arrows only project once at render time because their raw vector is not pre-projected.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: A future Playwright visual regression around the visualization canvas load display.
- Scenario the test should lock in: Create or load a model with nodal and distributed loads, switch 2D planes, and verify arrows remain anchored and point in the expected projected direction.
- Why this is the smallest reliable guardrail: The issue is visual placement inside a Three.js canvas, so a browser-level rendered check is more reliable than a pure unit test.
- Existing test that already covers this (if any): None found.
- If no new test is added, why not: This PR is a small coordinate fix and the current test stack does not expose a stable canvas pixel/scene-object assertion for this placement.

## User-visible / Behavior Changes

Load arrows now visibly originate and point correctly in the frontend structural visualization, including 2D plane views.

## Diagram (if applicable)

```text
Before:
[node] <- offset tail -> arrow may be double-projected in 2D planes

After:
[node / arrow tail] -> already-projected arrow vector -> correct rendered load direction
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Native frontend TypeScript check
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Render a model with nodal and distributed loads in the frontend visualization.
2. Enable load display.
3. Switch 2D visualization planes and inspect arrow origins/directions.

### Expected

- Nodal load arrow tails start at rendered node positions.
- Nodal and distributed load arrows point in the expected projected direction for the active view plane.

### Actual

- Before this fix, nodal arrow tails were shifted behind nodes and load vectors could be projected twice.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run locally:

```text
npm run type-check --prefix frontend
# passed

git diff --check
# passed; only Windows LF-to-CRLF warning from Git
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Reviewed `VectorArrow` origin semantics, load vector construction, and render call sites for nodal/distributed loads.
- Edge cases checked: Confirmed reaction arrows were left unchanged because they do not pre-project their vector.
- What you did **not** verify: Did not capture a browser screenshot or run a Playwright visual regression for the canvas.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
