### PR TITLE
fix(scripts): add python-docx, reportlab, Pillow for calcbook export

### DIFF
--- a/backend/src/agent-skills/analysis/runtime/requirements.txt
+++ b/backend/src/agent-skills/analysis/runtime/requirements.txt
@@ -15,6 +15,11 @@ pydantic==2.11.5
 # PKPM API (Windows only)
 pkpm-api; sys_platform == "win32"
 
+# Report Export (calculation book)
+python-docx==1.2.0
+reportlab==4.4.10
+Pillow==11.2.1
+
 # Utilities
 httpx==0.28.1
 PyYAML==6.0.3

--- a/scripts/cli/runtime.js
+++ b/scripts/cli/runtime.js
@@ -265,6 +265,15 @@ function resolvePaths(rootDir) {
     dataInputSkillRoot: path.join(rootDir, "backend", "src", "agent-skills", "data-input"),
     codeCheckSkillRoot: path.join(rootDir, "backend", "src", "agent-skills", "code-check"),
     materialSkillRoot: path.join(rootDir, "backend", "src", "agent-skills", "material"),
+    reportExportCalcbookRoot: path.join(
+      rootDir,
+      "backend",
+      "src",
+      "agent-skills",
+      "report-export",
+      "calculation-book",
+      "pkpm-calcbook",
+    ),
   };
 }
 
@@ -813,6 +822,7 @@ function buildAnalysisPaths(rootDir) {
     paths.dataInputSkillRoot,
     paths.codeCheckSkillRoot,
     paths.materialSkillRoot,
+    paths.reportExportCalcbookRoot,
     // After code-check so `from runtime import …` resolves to code-check/runtime.py,
     // not opensees-static/runtime.py; `opensees_runtime` still imports from this dir.
     paths.analysisOpenseesStaticRoot,

--- a/scripts/cli/runtime.js
+++ b/scripts/cli/runtime.js
@@ -221,6 +221,7 @@ function resolveProjectRoot(explicitRoot) {
 function resolvePaths(rootDir) {
   const installedMode = isInstalledPackageLayout(rootDir);
   const runtimeDir = resolveRuntimeDataDir(rootDir);
+  const agentSkillsRoot = path.join(rootDir, "backend", "src", "agent-skills");
 
   return {
     rootDir,
@@ -237,39 +238,19 @@ function resolvePaths(rootDir) {
       ? path.join(rootDir, "dist", "frontend")
       : path.join(rootDir, "frontend"),
     analysisRequirementsFile: path.join(
-      rootDir,
-      "backend",
-      "src",
-      "agent-skills",
+      agentSkillsRoot,
       "analysis",
       "runtime",
       "requirements.txt",
     ),
-    analysisPythonRoot: path.join(
-      rootDir,
-      "backend",
-      "src",
-      "agent-skills",
-      "analysis",
-      "runtime",
-    ),
-    analysisOpenseesStaticRoot: path.join(
-      rootDir,
-      "backend",
-      "src",
-      "agent-skills",
-      "analysis",
-      "opensees-static",
-    ),
+    analysisPythonRoot: path.join(agentSkillsRoot, "analysis", "runtime"),
+    analysisOpenseesStaticRoot: path.join(agentSkillsRoot, "analysis", "opensees-static"),
     skillSharedPythonRoot: path.join(rootDir, "backend", "src", "skill-shared", "python"),
-    dataInputSkillRoot: path.join(rootDir, "backend", "src", "agent-skills", "data-input"),
-    codeCheckSkillRoot: path.join(rootDir, "backend", "src", "agent-skills", "code-check"),
-    materialSkillRoot: path.join(rootDir, "backend", "src", "agent-skills", "material"),
+    dataInputSkillRoot: path.join(agentSkillsRoot, "data-input"),
+    codeCheckSkillRoot: path.join(agentSkillsRoot, "code-check"),
+    materialSkillRoot: path.join(agentSkillsRoot, "material"),
     reportExportCalcbookRoot: path.join(
-      rootDir,
-      "backend",
-      "src",
-      "agent-skills",
+      agentSkillsRoot,
       "report-export",
       "calculation-book",
       "pkpm-calcbook",


### PR DESCRIPTION
## Summary
- Add `python-docx`, `reportlab`, and `Pillow` to the unified Python requirements.txt so `sclaw doctor` installs them into the analysis venv
- Add `pkpm-calcbook` directory to `PYTHONPATH` via `buildAnalysisPaths()` so Python can resolve local module imports (`out_parsers`, `api_extractors`, `report_render`) at runtime

## Impacted areas
- `backend` (requirements.txt)
- `scripts` (runtime.js PYTHONPATH)

## Test plan
- [ ] Run `./sclaw doctor` on a clean environment and verify the three packages are installed
- [ ] Run a PKPM calcbook export and confirm DOCX/PDF generation works