### PR TITLE
fix(ci): allow same-version in publish-npm workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -79,7 +79,7 @@ jobs:
           fi
 
       - name: Set version
-        run: npm version ${{ steps.meta.outputs.version }} --no-git-tag-version
+        run: npm version --allow-same-version ${{ steps.meta.outputs.version }} --no-git-tag-version
 
       - name: Assemble package
         run: node scripts/prepare-package.js


### PR DESCRIPTION
## Summary
- Add `--allow-same-version` to `npm version` step in `publish-npm.yml` so re-publishing the same version (e.g. after a failed publish run) doesn't cause the workflow to fail

## Impacted areas
- `.github/workflows/` (publish-npm.yml only)

## Test plan
- [ ] Trigger a publish workflow with a version that already exists in `package.json` and verify it no longer errors