### PR TITLE
fix(e2e): chat stream test timeout diagnostics

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -114,10 +114,8 @@ jobs:
 
       - name: Setup backend database
         run: |
-          mkdir -p $HOME/.structureclaw/data
-          npm run db:deploy --prefix backend
-        env:
-          DATABASE_URL: file:$HOME/.structureclaw/data/test-e2e.db
+          mkdir -p "$HOME/.structureclaw/data"
+          DATABASE_URL="file:$HOME/.structureclaw/data/test-e2e.db" npm run db:deploy --prefix backend
 
       - name: Install Playwright browsers
         run: npx --prefix frontend playwright install chromium --with-deps

--- a/frontend/tests/e2e/specs/console-chat.spec.ts
+++ b/frontend/tests/e2e/specs/console-chat.spec.ts
@@ -44,17 +44,17 @@ test.describe('Console chat flow', () => {
 
   test('sends a message and triggers stream request', async ({ page }) => {
     test.skip(!hasLlmKey, 'Requires LLM_API_KEY for real LLM streaming');
-    test.setTimeout(60_000);
 
     await consolePage.goto();
 
-    // Capture stream endpoint responses (any status) for diagnostics
+    // Wait for the real stream response from the backend
     const streamResponse = page.waitForResponse(
-      (resp) => resp.url().includes('/api/v1/chat/stream'),
+      (resp) => resp.url().includes('/api/v1/chat/stream') && resp.status() === 200,
     );
 
     await consolePage.sendMessage('Analyze a simply supported beam');
 
+    // Verify the stream endpoint was called and returned 200
     const response = await streamResponse;
     expect(response.status()).toBe(200);
   });

--- a/frontend/tests/e2e/specs/console-chat.spec.ts
+++ b/frontend/tests/e2e/specs/console-chat.spec.ts
@@ -44,17 +44,17 @@ test.describe('Console chat flow', () => {
 
   test('sends a message and triggers stream request', async ({ page }) => {
     test.skip(!hasLlmKey, 'Requires LLM_API_KEY for real LLM streaming');
+    test.setTimeout(60_000);
 
     await consolePage.goto();
 
-    // Wait for the real stream response from the backend
+    // Capture stream endpoint responses (any status) for diagnostics
     const streamResponse = page.waitForResponse(
-      (resp) => resp.url().includes('/api/v1/chat/stream') && resp.status() === 200,
+      (resp) => resp.url().includes('/api/v1/chat/stream'),
     );
 
     await consolePage.sendMessage('Analyze a simply supported beam');
 
-    // Verify the stream endpoint was called and returned 200
     const response = await streamResponse;
     expect(response.status()).toBe(200);
   });


### PR DESCRIPTION
## Summary
- Remove `resp.status() === 200` filter from `waitForResponse` in the console-chat stream test so any response from the stream endpoint is captured
- Increase test timeout from 30s to 60s
- If the backend returns a non-200 status, the assertion will now show the actual status instead of silently timing out

## Why
The test was consistently timing out because `waitForResponse` only matched HTTP 200 responses. If the backend returns an error (e.g., 400 or 500) before `reply.hijack()`, the predicate never matched and the test timed out with no useful diagnostics.

This change lets us see the actual response status on failure.

## Test plan
- [ ] E2E tests pass or fail with a clear error message showing the actual HTTP status