### PR TITLE
fix: stabilize workspace search and conversation cache

### DIFF
--- a/backend/src/agent-langgraph/__tests__/workspace-tools.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/workspace-tools.test.mjs
@@ -47,6 +47,24 @@ describe("workspace tools", () => {
     expect(result.matches[0].path).toBe("src/agent.ts");
   });
 
+  test("grep_files stops scanning files after the match cap is reached", async () => {
+    await fs.writeFile(
+      path.join(root, "src", "000-cap.ts"),
+      `${Array.from({ length: 1000 }, () => "needle").join("\n")}\n`,
+      "utf8",
+    );
+    await fs.writeFile(path.join(root, "src", "zzz-unsupported.bin"), "needle\n", "utf8");
+    const { createGrepFilesTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    const tool = createGrepFilesTool();
+    const raw = await tool.invoke(
+      { query: "needle" },
+      { configurable: { workspaceRoot: root } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.totalMatches).toBe(1000);
+    expect(result.skippedFiles).toBe(0);
+  });
+
   test("replace_in_file requires exact text", async () => {
     const { createReplaceInFileTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
     const tool = createReplaceInFileTool();

--- a/backend/src/agent-langgraph/__tests__/workspace-tools.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/workspace-tools.test.mjs
@@ -33,6 +33,20 @@ describe("workspace tools", () => {
     expect(result.matches[0].path).toBe("src/agent.ts");
   });
 
+  test("grep_files skips unsupported files instead of failing the search", async () => {
+    await fs.writeFile(path.join(root, "LICENSE"), "needle in a no-extension file\n", "utf8");
+    const { createGrepFilesTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    const tool = createGrepFilesTool();
+    const raw = await tool.invoke(
+      { query: "needle" },
+      { configurable: { workspaceRoot: root } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.totalMatches).toBe(1);
+    expect(result.skippedFiles).toBeGreaterThanOrEqual(1);
+    expect(result.matches[0].path).toBe("src/agent.ts");
+  });
+
   test("replace_in_file requires exact text", async () => {
     const { createReplaceInFileTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
     const tool = createReplaceInFileTool();

--- a/backend/src/agent-langgraph/workspace-tools.ts
+++ b/backend/src/agent-langgraph/workspace-tools.ts
@@ -10,6 +10,7 @@ const SKIP_DIRS = new Set(['.git', 'node_modules', '.venv', '__pycache__', '.age
 const MAX_READ_BYTES = 2 * 1024 * 1024;
 const MAX_WRITE_BYTES = 2 * 1024 * 1024;
 const MAX_SEARCH_BYTES = 512 * 1024;
+const MAX_GREP_MATCHES = 1000;
 const ALLOWED_EXTENSIONS = new Set(['.txt', '.json', '.csv', '.md', '.py', '.tcl', '.log', '.yaml', '.yml', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.prisma']);
 
 function getWorkspaceRoot(config: LangGraphRunnableConfig): string {
@@ -178,6 +179,7 @@ export function createGrepFilesTool() {
       const needle = input.query.toLowerCase();
       let skippedFiles = 0;
       for (const rel of files.sort()) {
+        if (matches.length >= MAX_GREP_MATCHES) break;
         const full = safeResolve(root, rel);
         if (!isAllowedFile(full)) {
           skippedFiles += 1;
@@ -203,7 +205,7 @@ export function createGrepFilesTool() {
         }
         const lines = content.split(/\r?\n/);
         for (let index = 0; index < lines.length; index += 1) {
-          if (matches.length >= 1000) break;
+          if (matches.length >= MAX_GREP_MATCHES) break;
           if (lines[index].toLowerCase().includes(needle)) {
             matches.push({ path: rel, line: index + 1, preview: lines[index].slice(0, 240) });
           }

--- a/backend/src/agent-langgraph/workspace-tools.ts
+++ b/backend/src/agent-langgraph/workspace-tools.ts
@@ -29,10 +29,16 @@ export function safeResolve(workspaceRoot: string, requestedPath: string): strin
 }
 
 function assertAllowedFile(filePath: string): void {
-  const ext = path.extname(filePath).toLowerCase();
-  if (!ALLOWED_EXTENSIONS.has(ext)) {
-    throw new Error(`File extension denied: ${ext || '(none)'}`);
+  if (isAllowedFile(filePath)) {
+    return;
   }
+  const ext = path.extname(filePath).toLowerCase();
+  throw new Error(`File extension denied: ${ext || '(none)'}`);
+}
+
+function isAllowedFile(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  return ALLOWED_EXTENSIONS.has(ext);
 }
 
 function globToRegex(pattern: string): RegExp {
@@ -170,12 +176,32 @@ export function createGrepFilesTool() {
       const offset = Math.max(input.offset ?? 0, 0);
       const maxResults = Math.min(input.maxResults ?? 50, 100);
       const needle = input.query.toLowerCase();
+      let skippedFiles = 0;
       for (const rel of files.sort()) {
         const full = safeResolve(root, rel);
-        assertAllowedFile(full);
-        const stat = await fs.stat(full);
-        if (stat.size > MAX_SEARCH_BYTES) continue;
-        const lines = (await fs.readFile(full, 'utf-8')).split(/\r?\n/);
+        if (!isAllowedFile(full)) {
+          skippedFiles += 1;
+          continue;
+        }
+        let stat;
+        try {
+          stat = await fs.stat(full);
+        } catch {
+          skippedFiles += 1;
+          continue;
+        }
+        if (!stat.isFile() || stat.size > MAX_SEARCH_BYTES) {
+          skippedFiles += 1;
+          continue;
+        }
+        let content: string;
+        try {
+          content = await fs.readFile(full, 'utf-8');
+        } catch {
+          skippedFiles += 1;
+          continue;
+        }
+        const lines = content.split(/\r?\n/);
         for (let index = 0; index < lines.length; index += 1) {
           if (matches.length >= 1000) break;
           if (lines[index].toLowerCase().includes(needle)) {
@@ -189,6 +215,7 @@ export function createGrepFilesTool() {
         shownCount: sliced.length,
         offset,
         nextOffset: offset + maxResults < matches.length ? offset + maxResults : null,
+        skippedFiles,
         matches: sliced,
       });
     },

--- a/backend/src/api/chat.ts
+++ b/backend/src/api/chat.ts
@@ -315,13 +315,10 @@ async function persistConversationMessages(params: {
 }
 
 /**
- * Persist the full LangGraph message history (including tool calls) into the
- * DB. This is called after streaming completes so that conversation restore
- * includes all intermediate tool messages, not just the final user/assistant
- * pair written by persistConversationMessages.
- *
- * Strategy: incremental append — compare DB message count against graph state
- * message count and only insert the delta.
+ * Persist intermediate LangGraph tool messages into the DB. The user/final
+ * assistant pair is already written by persistConversationMessages with the
+ * presentation metadata the UI needs; appending final AI messages from the
+ * graph state would restore the same assistant turn twice.
  */
 async function persistFullConversationMessages(params: {
   conversationId: string;
@@ -331,15 +328,12 @@ async function persistFullConversationMessages(params: {
   if (!conversationId || !Array.isArray(state.messages)) return;
 
   try {
-    const existingCount = await prisma.message.count({
-      where: { conversationId },
+    const existingToolCount = await prisma.message.count({
+      where: { conversationId, role: 'tool' },
     });
 
     const allMessages: BaseMessage[] = state.messages;
-    if (allMessages.length <= existingCount) return;
-
-    const newMessages = allMessages.slice(existingCount);
-    const records = newMessages.map((msg): Record<string, unknown> | null => {
+    const toolRecords = allMessages.map((msg): Record<string, unknown> | null => {
       if (msg == null || typeof msg !== 'object') return null;
 
       const getType = typeof (msg as any)._getType === 'function' ? (msg as any)._getType() : null;
@@ -353,22 +347,6 @@ async function persistFullConversationMessages(params: {
               .join('')
           : JSON.stringify(msg.content);
 
-      if (getType === 'human') {
-        return {
-          conversationId,
-          role: 'user',
-          content: typeof content === 'string' ? content : JSON.stringify(content),
-        };
-      }
-      if (getType === 'ai') {
-        const toolCalls = (msg as any).tool_calls;
-        return {
-          conversationId,
-          role: 'assistant',
-          content: typeof content === 'string' ? content : JSON.stringify(content),
-          toolCalls: Array.isArray(toolCalls) && toolCalls.length > 0 ? toolCalls : undefined,
-        };
-      }
       if (getType === 'tool') {
         return {
           conversationId,
@@ -382,6 +360,7 @@ async function persistFullConversationMessages(params: {
       return null;
     }).filter((r): r is Record<string, unknown> => r !== null);
 
+    const records = toolRecords.slice(existingToolCount);
     if (records.length > 0) {
       await prisma.message.createMany({ data: records as any });
     }

--- a/backend/tests/chat.route.test.mjs
+++ b/backend/tests/chat.route.test.mjs
@@ -25,6 +25,7 @@ describe('chat routes message persistence', () => {
       id: where.id,
       ...data,
     }));
+    prisma.message.count = jest.fn(async () => 0);
     prisma.message.findMany = jest.fn(async () => []);
     prisma.message.createMany = jest.fn(async ({ data }) => ({ count: data.length }));
 
@@ -73,6 +74,7 @@ describe('chat routes message persistence', () => {
     prisma.conversation.create.mockClear();
     prisma.conversation.findFirst.mockClear();
     prisma.conversation.update.mockClear();
+    prisma.message.count.mockClear();
     prisma.message.findMany.mockClear();
     prisma.message.createMany.mockClear();
     agentRunSpy.mockClear();
@@ -209,6 +211,57 @@ describe('chat routes message persistence', () => {
           role: 'assistant',
           content: 'stream assistant reply',
         }),
+      ],
+    });
+  });
+
+  test('persists only tool messages from graph snapshots after stream summary persistence', async () => {
+    getSnapshotSpy.mockResolvedValueOnce({
+      snapshot: {},
+      state: {
+        messages: [
+          { _getType: () => 'human', content: 'Search files' },
+          {
+            _getType: () => 'ai',
+            content: '',
+            tool_calls: [{ id: 'call-grep', name: 'grep_files', args: { query: 'needle' } }],
+          },
+          {
+            _getType: () => 'tool',
+            name: 'grep_files',
+            tool_call_id: 'call-grep',
+            content: '{"totalMatches":1}',
+          },
+          { _getType: () => 'ai', content: 'Found it.' },
+        ],
+      },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/stream',
+      payload: {
+        message: 'Search files',
+        conversationId: 'conv-paused',
+        traceId: 'trace-tools',
+        context: { locale: 'en' },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(prisma.message.count).toHaveBeenCalledWith({
+      where: { conversationId: 'conv-paused', role: 'tool' },
+    });
+    expect(prisma.message.createMany).toHaveBeenCalledTimes(2);
+    expect(prisma.message.createMany.mock.calls[1][0]).toEqual({
+      data: [
+        {
+          conversationId: 'conv-paused',
+          role: 'tool',
+          content: '{"totalMatches":1}',
+          name: 'grep_files',
+          toolCallId: 'call-grep',
+        },
       ],
     });
   });

--- a/frontend/src/components/chat/ai-console.tsx
+++ b/frontend/src/components/chat/ai-console.tsx
@@ -328,6 +328,10 @@ function resolveSkillDomainLabel(domain: SkillDomain, t: (key: MessageKey) => st
 const STORAGE_KEY = 'structureclaw.console.conversations'
 const CONSOLE_UI_PREFERENCES_STORAGE_KEY = 'structureclaw.console.ui-preferences'
 const SIDEBAR_LAYOUT_MIN_WIDTH = 1280
+const ARCHIVE_STORAGE_MAX_CONVERSATIONS = 20
+const ARCHIVE_STORAGE_MAX_MESSAGES = 40
+const ARCHIVE_STORAGE_TEXT_LIMIT = 12000
+const ARCHIVE_STORAGE_REPORT_LIMIT = 30000
 type ConsoleUiPreferences = {
   historyCollapsed: boolean
 }
@@ -369,6 +373,118 @@ function saveConsoleUiPreferences(preferences: ConsoleUiPreferences) {
     window.localStorage.setItem(CONSOLE_UI_PREFERENCES_STORAGE_KEY, JSON.stringify(preferences))
   } catch {
     return
+  }
+}
+
+function isStorageQuotaError(error: unknown) {
+  if (typeof DOMException !== 'undefined' && error instanceof DOMException) {
+    return error.name === 'QuotaExceededError' || error.name === 'NS_ERROR_DOM_QUOTA_REACHED'
+  }
+  return error instanceof Error && (
+    error.name === 'QuotaExceededError'
+    || error.message.includes('exceeded the quota')
+  )
+}
+
+function truncateArchiveText(value: string | undefined, maxLength = ARCHIVE_STORAGE_TEXT_LIMIT) {
+  if (typeof value !== 'string' || value.length <= maxLength) {
+    return value
+  }
+  return `${value.slice(0, maxLength)}\n...`
+}
+
+function compactArchiveMessage(message: Message): Message {
+  return {
+    ...message,
+    content: truncateArchiveText(message.content) || '',
+    debugDetails: undefined,
+    presentation: undefined,
+    toolStep: message.toolStep
+      ? {
+          ...message.toolStep,
+          output: undefined,
+          args: undefined,
+        }
+      : undefined,
+  }
+}
+
+function compactArchiveResult(result: AgentResult | null | undefined): AgentResult | null {
+  if (!result) {
+    return null
+  }
+
+  return {
+    response: truncateArchiveText(result.response),
+    traceId: result.traceId,
+    success: result.success,
+    needsModelInput: result.needsModelInput,
+    plan: result.plan,
+    interaction: result.interaction,
+    clarification: result.clarification,
+    startedAt: result.startedAt,
+    completedAt: result.completedAt,
+    durationMs: result.durationMs,
+    requestedEngineId: result.requestedEngineId,
+    routing: result.routing,
+    report: result.report
+      ? {
+          summary: truncateArchiveText(result.report.summary),
+          markdown: truncateArchiveText(result.report.markdown, ARCHIVE_STORAGE_REPORT_LIMIT),
+        }
+      : undefined,
+  }
+}
+
+function archiveSortTime(conversation: PersistedConversation) {
+  return conversation.updatedAt || conversation.createdAt || ''
+}
+
+function compactConversationArchiveForStorage(
+  archive: Record<string, PersistedConversation>,
+): Record<string, PersistedConversation> {
+  const entries = Object.values(archive)
+    .sort((a, b) => archiveSortTime(b).localeCompare(archiveSortTime(a)))
+    .slice(0, ARCHIVE_STORAGE_MAX_CONVERSATIONS)
+
+  return Object.fromEntries(entries.map((conversation) => {
+    const compacted = sanitizePersistedConversation({
+      ...conversation,
+      messages: (conversation.messages || [])
+        .slice(-ARCHIVE_STORAGE_MAX_MESSAGES)
+        .map((message) => compactArchiveMessage(message)),
+      modelText: truncateArchiveText(conversation.modelText),
+      latestResult: compactArchiveResult(conversation.latestResult),
+      modelVisualizationSnapshot: null,
+      resultVisualizationSnapshot: null,
+      visualizationSnapshot: null,
+    })
+    return [compacted.id, compacted]
+  }))
+}
+
+function saveConversationArchiveToStorage(
+  archive: Record<string, PersistedConversation>,
+): Record<string, PersistedConversation> {
+  if (typeof window === 'undefined') {
+    return archive
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(archive))
+    return archive
+  } catch (error) {
+    if (!isStorageQuotaError(error)) {
+      return archive
+    }
+  }
+
+  const compacted = compactConversationArchiveForStorage(archive)
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(compacted))
+    return compacted
+  } catch {
+    return archive
   }
 }
 
@@ -2066,7 +2182,10 @@ export function AIConsole() {
     if (typeof window === 'undefined') {
       return
     }
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(conversationArchive))
+    const savedArchive = saveConversationArchiveToStorage(conversationArchive)
+    if (savedArchive !== conversationArchive) {
+      setConversationArchive(savedArchive)
+    }
   }, [conversationArchive])
 
   useEffect(() => {

--- a/frontend/tests/integration/console-page.test.tsx
+++ b/frontend/tests/integration/console-page.test.tsx
@@ -398,6 +398,68 @@ describe('ConsolePage Integration (CONS-13)', () => {
     expect(screen.getByRole('button', { name: 'Expand History' })).toBeInTheDocument()
   })
 
+  it('compacts conversation archive saves when localStorage quota is exceeded', async () => {
+    const longText = 'x'.repeat(60000)
+    window.localStorage.setItem('structureclaw.console.conversations', JSON.stringify({
+      'conv-large': {
+        id: 'conv-large',
+        title: 'Large local archive',
+        type: 'analysis',
+        createdAt: '2026-03-12T08:00:00.000Z',
+        updatedAt: '2026-03-12T09:00:00.000Z',
+        messages: [
+          {
+            id: 'm-large',
+            role: 'tool',
+            content: longText,
+            status: 'done',
+            timestamp: '2026-03-12T09:00:00.000Z',
+            debugDetails: { promptSnapshot: longText, skillIds: [], responseSummary: longText, plan: [], toolCalls: [] },
+            toolStep: {
+              id: 'step-large',
+              phase: 'understanding',
+              status: 'done',
+              tool: 'grep_files',
+              title: 'grep_files',
+              output: longText,
+            },
+          },
+        ],
+        latestResult: {
+          response: longText,
+          success: true,
+          report: { summary: longText, markdown: longText, json: { raw: longText } },
+          analysis: { raw: longText },
+          model: { raw: longText },
+        },
+        modelText: longText,
+        modelVisualizationSnapshot: archivedVisualizationSnapshot,
+        resultVisualizationSnapshot: archivedVisualizationSnapshot,
+        visualizationSnapshot: archivedVisualizationSnapshot,
+      },
+    }))
+
+    const originalSetItem = Storage.prototype.setItem
+    let quotaTriggered = false
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function setItem(key: string, value: string) {
+      if (key === 'structureclaw.console.conversations' && value.length > 50000 && !quotaTriggered) {
+        quotaTriggered = true
+        throw new DOMException('Storage quota exceeded', 'QuotaExceededError')
+      }
+      return originalSetItem.call(this, key, value)
+    })
+
+    await renderConsolePage()
+
+    await waitFor(() => {
+      expect(quotaTriggered).toBe(true)
+      const stored = JSON.parse(window.localStorage.getItem('structureclaw.console.conversations') || '{}')
+      expect(stored['conv-large']?.modelVisualizationSnapshot).toBeNull()
+      expect(stored['conv-large']?.messages?.[0]?.debugDetails).toBeUndefined()
+      expect(stored['conv-large']?.messages?.[0]?.content.length).toBeLessThan(longText.length)
+    })
+  })
+
   it('shows the conversational composer controls', async () => {
     await renderConsolePage()
 


### PR DESCRIPTION
## Summary

- Problem: `grep_files` could abort when a broad search encountered unsupported/no-extension files, restored tool turns could show duplicate assistant messages, and large local conversation archives could exceed browser `localStorage` quota.
- Why it matters: these failures interrupt workspace-tool conversations and can make the chat UI unstable after larger grep/glob/tool-result sessions.
- What changed: workspace grep now skips unsupported/unreadable/oversized files; graph snapshot persistence now appends only tool messages after the summary pair; frontend archive saves compact oversized local cache on quota errors.
- What did NOT change (scope boundary): no new tool permissions, no schema changes, no changes to backend conversation/database source of truth.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: broad workspace grep collected files before extension filtering, then threw on unsupported extensions; conversation snapshot persistence mixed summary persistence with raw LangGraph message deltas; frontend local archive writes assumed the serialized cache would fit in `localStorage`.
- Missing detection / guardrail: no regression coverage for unsupported grep files, graph snapshot persistence after stream summary persistence, or quota fallback for the local conversation archive.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: richer tool-result persistence and local snapshots made large workspace-tool sessions more likely to hit these edges.
- If unknown, what was ruled out: the backend DB remains the source of truth; the quota failure is isolated to the browser cache key `structureclaw.console.conversations`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/src/agent-langgraph/__tests__/workspace-tools.test.mjs`, `backend/tests/chat.route.test.mjs`, `frontend/tests/integration/console-page.test.tsx`.
- Scenario the test should lock in: unsupported/no-extension files do not fail grep; stream persistence does not duplicate final assistant messages; quota errors compact the local conversation cache.
- Why this is the smallest reliable guardrail: each test isolates the failing boundary without requiring an LLM or full browser E2E flow.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Workspace grep searches should no longer abruptly stop when broad patterns encounter unsupported files.
- Restored tool conversations should no longer show the same assistant turn twice.
- If the browser conversation cache grows too large, the UI now compacts local-only cached data instead of throwing `QuotaExceededError`. Backend conversation history and snapshots remain the primary persisted state.

## Diagram (if applicable)

```text
Before:
[large grep/tool session] -> [unsupported file or huge local archive] -> [tool abort / UI storage error]
[stream summary persisted] -> [full graph assistant persisted again] -> [duplicate restored assistant bubble]

After:
[large grep/tool session] -> [skip unsupported/cache-heavy payloads] -> [search/UI continues]
[stream summary persisted] -> [tool messages only appended] -> [single restored assistant turn]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows / PowerShell
- Runtime/container: local Node.js workspace
- Model/provider: N/A
- Integration/channel (if any): Fastify backend + Next.js frontend tests
- Relevant config (redacted): default local development config

### Steps

1. Run `grep_files` with the default broad pattern in a workspace containing a no-extension file such as `LICENSE`.
2. Stream a tool-using conversation and restore it from backend persisted messages.
3. Save an oversized `structureclaw.console.conversations` local cache payload.

### Expected

- Grep skips unsupported files and returns supported matches.
- Restored chat shows one assistant response for the turn plus tool messages.
- Browser cache save compacts local-only data instead of throwing `QuotaExceededError`.

### Actual

- Before this PR, those scenarios could abort tool execution, duplicate an assistant turn, or throw a storage quota exception.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing after:

```text
npm test --prefix backend -- --runInBand src/agent-langgraph/__tests__/workspace-tools.test.mjs tests/chat.route.test.mjs
PASS tests/chat.route.test.mjs
PASS src/agent-langgraph/__tests__/workspace-tools.test.mjs
Test Suites: 2 passed, 2 total
Tests: 9 passed, 9 total

npm run type-check --prefix frontend
passed

npm run lint --prefix frontend
passed with pre-existing <img> warnings in ai-console.tsx
```

## Human Verification (required)

- Verified scenarios: targeted backend workspace-tool and chat-route regression tests; frontend type-check; frontend lint.
- Edge cases checked: no-extension file during grep, existing tool-message count during snapshot persistence, oversized local cache save path.
- What you did **not** verify: full frontend integration test execution; the integration runner's test backend did not start within its 30 second fixture timeout in this local environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: local browser archive compaction can remove local-only debug details and visualization snapshots after quota pressure.
  - Mitigation: backend conversation messages/snapshots remain the source of truth, and compaction only runs after a quota failure.
