### PR TITLE
fix(backend): surface analysis artifact feedback

### DIFF
--- a/backend/src/agent-langgraph/__tests__/analysis-tool-summary.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/analysis-tool-summary.test.mjs
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "@jest/globals";
+
+describe("analysis tool summary", () => {
+  test("surfaces failed analysis artifact feedback to the model", async () => {
+    const { buildAnalysisToolSummary } = await import("../../../dist/agent-langgraph/tools.js");
+
+    const summary = buildAnalysisToolSummary({
+      skillId: "yjk-static",
+      result: {
+        success: false,
+        error_code: "ANALYSIS_EXECUTION_FAILED",
+        message: [
+          "YJK analysis failed (phase=analysis, command=yjkdesign_dsncalculating_all): calculation failed",
+          "",
+          "Artifact feedback:",
+          "- workDir: C:\\Users\\demo\\.structureclaw\\analysis\\yjk\\sc_lg-1",
+          "",
+          "driver stderr tail:",
+          "YJK generated error log content",
+        ].join("\n"),
+        meta: {
+          engineId: "builtin-yjk",
+          analysisSkillId: "yjk-static",
+          analysisAdapterKey: "builtin-yjk",
+          workDir: "C:\\Users\\demo\\.structureclaw\\analysis\\yjk\\sc_lg-1",
+          stderrPath: "C:\\Users\\demo\\.structureclaw\\analysis\\yjk\\sc_lg-1\\driver.stderr.txt",
+          stderrTail: "YJK generated error log content",
+        },
+      },
+    });
+
+    expect(summary.success).toBe(false);
+    expect(summary.errorCode).toBe("ANALYSIS_EXECUTION_FAILED");
+    expect(summary.message).toContain("YJK generated error log content");
+    expect(summary.diagnostics).toMatchObject({
+      engineId: "builtin-yjk",
+      analysisSkillId: "yjk-static",
+      analysisAdapterKey: "builtin-yjk",
+      stderrTail: "YJK generated error log content",
+    });
+  });
+});

--- a/backend/src/agent-langgraph/__tests__/analysis-tool-summary.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/analysis-tool-summary.test.mjs
@@ -39,4 +39,28 @@ describe("analysis tool summary", () => {
       stderrTail: "YJK generated error log content",
     });
   });
+
+  test("keeps recent log tails when compacting large failed analysis messages", async () => {
+    const { buildAnalysisToolSummary } = await import("../../../dist/agent-langgraph/tools.js");
+    const tailMarker = "YJK_LATEST_STDERR_MARKER";
+    const longPrefix = Array.from({ length: 900 }, (_, index) => `older diagnostic ${index}`).join("\n");
+    const longTail = `${Array.from({ length: 250 }, () => "intermediate stderr").join("\n")}\n${tailMarker}`;
+
+    const summary = buildAnalysisToolSummary({
+      skillId: "yjk-static",
+      result: {
+        success: false,
+        error_code: { unexpected: "object" },
+        message: `${longPrefix}\n\ndriver stderr tail:\n${longTail}`,
+        meta: {
+          stderrTail: longTail,
+        },
+      },
+    });
+
+    expect(summary.errorCode).toBe("ANALYSIS_EXECUTION_FAILED");
+    expect(summary.message).toContain(tailMarker);
+    expect(summary.message).toContain("[truncated");
+    expect(summary.diagnostics.stderrTail).toContain(tailMarker);
+  });
 });

--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -61,17 +61,41 @@ function toolResult(
 }
 
 const ANALYSIS_MESSAGE_LIMIT = 6000;
+type TextCompaction = 'middle' | 'tail';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function compactText(value: unknown, limit = ANALYSIS_MESSAGE_LIMIT): string | undefined {
+function compactText(
+  value: unknown,
+  limit = ANALYSIS_MESSAGE_LIMIT,
+  mode: TextCompaction = 'middle',
+): string | undefined {
   if (typeof value !== 'string') return undefined;
   const text = value.trim();
   if (!text) return undefined;
   if (text.length <= limit) return text;
-  return `${text.slice(0, limit)}\n...[truncated ${text.length - limit} chars]`;
+  const omitted = text.length - limit;
+  if (mode === 'tail') {
+    const marker = `...[truncated ${omitted} chars]\n`;
+    const tailLength = Math.max(0, limit - marker.length);
+    return `${marker}${text.slice(-tailLength)}`;
+  }
+  const marker = `\n...[truncated ${omitted} chars]...\n`;
+  const bodyLength = Math.max(0, limit - marker.length);
+  const headLength = Math.ceil(bodyLength * 0.35);
+  const tailLength = bodyLength - headLength;
+  return `${text.slice(0, headLength)}${marker}${text.slice(-tailLength)}`;
+}
+
+function normalizeAnalysisErrorCode(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return 'ANALYSIS_EXECUTION_FAILED';
 }
 
 function pickAnalysisDiagnostics(
@@ -81,7 +105,10 @@ function pickAnalysisDiagnostics(
   const diagnostics: Record<string, unknown> = {};
   const copy = (targetKey: string, value: unknown) => {
     if (value === undefined || value === null || value === '') return;
-    diagnostics[targetKey] = typeof value === 'string' ? compactText(value, 2000) ?? value : value;
+    const isTail = targetKey.endsWith('Tail');
+    diagnostics[targetKey] = typeof value === 'string'
+      ? compactText(value, 2000, isTail ? 'tail' : 'middle') ?? value
+      : value;
   };
 
   copy('engineId', meta.engineId);
@@ -111,10 +138,10 @@ export function buildAnalysisToolSummary(args: {
   const meta = isRecord(result.meta) ? result.meta : {};
   const data = isRecord(result.data) ? result.data : undefined;
   const status = typeof result.status === 'string' ? result.status : undefined;
-  const success = result.success === false || status === 'error' ? false : true;
+  const success = result.success !== false && status !== 'error';
 
   if (!success) {
-    const errorCode = result.error_code || result.errorCode || 'ANALYSIS_EXECUTION_FAILED';
+    const errorCode = normalizeAnalysisErrorCode(result.error_code, result.errorCode);
     const diagnostics = pickAnalysisDiagnostics(result, meta);
     return {
       success: false,

--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -60,6 +60,78 @@ function toolResult(
   });
 }
 
+const ANALYSIS_MESSAGE_LIMIT = 6000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function compactText(value: unknown, limit = ANALYSIS_MESSAGE_LIMIT): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const text = value.trim();
+  if (!text) return undefined;
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit)}\n...[truncated ${text.length - limit} chars]`;
+}
+
+function pickAnalysisDiagnostics(
+  result: Record<string, unknown>,
+  meta: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const diagnostics: Record<string, unknown> = {};
+  const copy = (targetKey: string, value: unknown) => {
+    if (value === undefined || value === null || value === '') return;
+    diagnostics[targetKey] = typeof value === 'string' ? compactText(value, 2000) ?? value : value;
+  };
+
+  copy('engineId', meta.engineId);
+  copy('engineName', meta.engineName);
+  copy('exceptionType', meta.exceptionType);
+  copy('analysisSkillId', meta.analysisSkillId);
+  copy('analysisAdapterKey', meta.analysisAdapterKey);
+  copy('workDir', meta.workDir);
+  copy('runMetaPath', meta.runMetaPath);
+  copy('driverResultPath', meta.driverResultPath);
+  copy('driverOutputPath', meta.driverOutputPath);
+  copy('stdoutPath', meta.stdoutPath);
+  copy('stderrPath', meta.stderrPath);
+  copy('stdoutTail', meta.stdoutTail);
+  copy('stderrTail', meta.stderrTail);
+  copy('stepsTail', meta.stepsTail);
+  copy('message', result.message);
+
+  return Object.keys(diagnostics).length > 0 ? diagnostics : undefined;
+}
+
+export function buildAnalysisToolSummary(args: {
+  result: unknown;
+  skillId?: string;
+}): Record<string, unknown> {
+  const result = isRecord(args.result) ? args.result : {};
+  const meta = isRecord(result.meta) ? result.meta : {};
+  const data = isRecord(result.data) ? result.data : undefined;
+  const status = typeof result.status === 'string' ? result.status : undefined;
+  const success = result.success === false || status === 'error' ? false : true;
+
+  if (!success) {
+    const errorCode = result.error_code || result.errorCode || 'ANALYSIS_EXECUTION_FAILED';
+    const diagnostics = pickAnalysisDiagnostics(result, meta);
+    return {
+      success: false,
+      skillId: args.skillId,
+      errorCode,
+      message: compactText(result.message) || 'Analysis execution failed',
+      ...(diagnostics ? { diagnostics } : {}),
+    };
+  }
+
+  return {
+    success: true,
+    skillId: args.skillId,
+    analysisMode: data?.analysisMode,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Engineering tools (wrap AgentSkillRuntime)
 // ---------------------------------------------------------------------------
@@ -494,12 +566,17 @@ export function createRunAnalysisTool(skillRuntime: AgentSkillRuntime) {
       // Store analysis result in graph state via Command.
       // Keep ToolMessage content compact — the full data lives in graph state.
       // The streaming layer reads analysisResult from nodeState for artifact_payload_sync.
-      const analysisSummary = typeof result.result === 'object' && result.result !== null
-        ? { success: true, skillId: result.skillId, analysisMode: (result.result as Record<string, unknown>)?.data
-            ? ((result.result as Record<string, unknown>).data as Record<string, unknown>)?.analysisMode
-            : undefined }
-        : { success: true, skillId: result.skillId };
-      logToolCall(log, { tool: 'run_analysis', durationMs: Date.now() - start, extra: { analysisType, skillId: result.skillId, success: true } });
+      const analysisSummary = buildAnalysisToolSummary({
+        result: result.result,
+        skillId: result.skillId,
+      });
+      const analysisSucceeded = analysisSummary.success !== false;
+      logToolCall(log, {
+        tool: 'run_analysis',
+        durationMs: Date.now() - start,
+        success: analysisSucceeded,
+        extra: { analysisType, skillId: result.skillId, success: analysisSucceeded },
+      });
       return toolResult(
         toolCallId,
         'run_analysis',

--- a/backend/src/agent-skills/analysis/runtime/api.py
+++ b/backend/src/agent-skills/analysis/runtime/api.py
@@ -20,6 +20,12 @@ logger = logging.getLogger(__name__)
 def _include_error_traceback() -> bool:
     return os.getenv("ANALYSIS_INCLUDE_TRACEBACK", "").strip().lower() in {"1", "true", "yes", "on"}
 
+
+def _exception_dict_attr(exc: Exception, name: str) -> Dict[str, Any]:
+    value = getattr(exc, name, None)
+    return value if isinstance(value, dict) else {}
+
+
 app = FastAPI(
     title="StructureClaw Analysis Runtime",
     description="Backend-hosted structural analysis runtime",
@@ -152,6 +158,10 @@ async def analyze(request: AnalysisRequest) -> AnalysisResponse:
             "timestamp": now,
             "exceptionType": type(e).__name__,
         }
+        error_meta.update(_exception_dict_attr(e, "meta"))
+        error_detail = _exception_dict_attr(e, "detail")
+        if error_detail:
+            error_meta["detail"] = error_detail
         if _include_error_traceback():
             traceback_summary = "".join(
                 traceback.format_exception(type(e), e, e.__traceback__, limit=8)

--- a/backend/src/agent-skills/analysis/yjk-static/runtime.py
+++ b/backend/src/agent-skills/analysis/yjk-static/runtime.py
@@ -71,6 +71,18 @@ from contracts import EngineNotAvailableError
 
 YJK_LOG_SNIPPET_LIMIT = 2000
 YJK_STEP_LIMIT = 8
+YJK_DETAIL_STRING_LIMIT = 500
+YJK_DETAIL_COLLECTION_LIMIT = 12
+YJK_DETAIL_DEPTH_LIMIT = 3
+YJK_MESSAGE_DETAIL_KEYS = (
+    "returncode",
+    "timeoutSeconds",
+    "phase",
+    "command",
+    "error",
+    "results_path",
+    "windowTitle",
+)
 
 
 def _env_text(key: str, default: str = "") -> str:
@@ -137,6 +149,59 @@ def _tail_text(text: str, limit: int = YJK_LOG_SNIPPET_LIMIT) -> str:
     return f"...[truncated {omitted} chars]\n{text[-limit:]}"
 
 
+def _compact_detail_text(text: str, limit: int = YJK_DETAIL_STRING_LIMIT) -> str:
+    text = str(text or "").strip()
+    if len(text) <= limit:
+        return text
+    omitted = len(text) - limit
+    marker = f"\n...[truncated {omitted} chars]...\n"
+    body_limit = max(0, limit - len(marker))
+    head_limit = int(body_limit * 0.35)
+    tail_limit = body_limit - head_limit
+    return f"{text[:head_limit]}{marker}{text[-tail_limit:]}"
+
+
+def _sanitize_detail_value(value: Any, depth: int = 0) -> Any:
+    if depth >= YJK_DETAIL_DEPTH_LIMIT:
+        return "<truncated>"
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return _compact_detail_text(value)
+    if isinstance(value, (list, tuple)):
+        items = [
+            _sanitize_detail_value(item, depth + 1)
+            for item in value[:YJK_DETAIL_COLLECTION_LIMIT]
+        ]
+        omitted = len(value) - YJK_DETAIL_COLLECTION_LIMIT
+        if omitted > 0:
+            items.append(f"...[truncated {omitted} items]")
+        return items
+    if isinstance(value, dict):
+        items = list(value.items())
+        sanitized: Dict[str, Any] = {}
+        for key, item in items[:YJK_DETAIL_COLLECTION_LIMIT]:
+            sanitized[_compact_detail_text(str(key), 120)] = _sanitize_detail_value(
+                item,
+                depth + 1,
+            )
+        omitted = len(items) - YJK_DETAIL_COLLECTION_LIMIT
+        if omitted > 0:
+            sanitized["_truncated"] = f"{omitted} keys"
+        return sanitized
+    return _compact_detail_text(str(value))
+
+
+def _message_detail_summary(detail: Dict[str, Any] | None) -> Dict[str, Any]:
+    if not isinstance(detail, dict):
+        return {}
+    return {
+        key: _sanitize_detail_value(detail[key])
+        for key in YJK_MESSAGE_DETAIL_KEYS
+        if key in detail
+    }
+
+
 def _summarize_steps(output: dict | None, limit: int = YJK_STEP_LIMIT) -> list[str]:
     if not isinstance(output, dict):
         return []
@@ -173,6 +238,10 @@ def _raise_yjk_runtime_error(
     stdout_tail = _tail_text(stdout)
     stderr_tail = _tail_text(stderr)
     steps_tail = _summarize_steps(output)
+    safe_detail = _sanitize_detail_value(detail) if detail else None
+    message_detail = _message_detail_summary(
+        safe_detail if isinstance(safe_detail, dict) else None,
+    )
     run_meta_path = work_dir / "run-meta.json"
     driver_result_path = work_dir / "driver-result.json"
 
@@ -193,8 +262,8 @@ def _raise_yjk_runtime_error(
     lines = [headline, "", "Artifact feedback:"]
     for label, path in paths.items():
         lines.append(f"- {label}: {path}")
-    if detail:
-        lines.append(f"- detail: {json.dumps(detail, ensure_ascii=False)}")
+    if message_detail:
+        lines.append(f"- detail: {json.dumps(message_detail, ensure_ascii=False)}")
     if steps_tail:
         lines.extend(["", "Recent driver steps:", *steps_tail])
     if stderr_tail:
@@ -209,13 +278,13 @@ def _raise_yjk_runtime_error(
         meta["stderrTail"] = stderr_tail
     if steps_tail:
         meta["stepsTail"] = steps_tail
-    if detail:
-        meta["yjkErrorDetail"] = detail
+    if safe_detail:
+        meta["yjkErrorDetail"] = safe_detail
 
     error = RuntimeError("\n".join(lines))
     setattr(error, "meta", meta)
-    if detail:
-        setattr(error, "detail", detail)
+    if safe_detail:
+        setattr(error, "detail", safe_detail)
     raise error
 
 

--- a/backend/src/agent-skills/analysis/yjk-static/runtime.py
+++ b/backend/src/agent-skills/analysis/yjk-static/runtime.py
@@ -69,6 +69,9 @@ from typing import Any, Dict
 
 from contracts import EngineNotAvailableError
 
+YJK_LOG_SNIPPET_LIMIT = 2000
+YJK_STEP_LIMIT = 8
+
 
 def _env_text(key: str, default: str = "") -> str:
     """Read an environment variable as stripped text."""
@@ -122,6 +125,98 @@ def _read_json(path: Path) -> dict | None:
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return None
     return data if isinstance(data, dict) else None
+
+
+def _tail_text(text: str, limit: int = YJK_LOG_SNIPPET_LIMIT) -> str:
+    text = str(text or "").strip()
+    if not text:
+        return ""
+    if len(text) <= limit:
+        return text
+    omitted = len(text) - limit
+    return f"...[truncated {omitted} chars]\n{text[-limit:]}"
+
+
+def _summarize_steps(output: dict | None, limit: int = YJK_STEP_LIMIT) -> list[str]:
+    if not isinstance(output, dict):
+        return []
+    steps = output.get("steps")
+    if not isinstance(steps, list):
+        return []
+    lines: list[str] = []
+    for step in steps[-limit:]:
+        if not isinstance(step, dict):
+            continue
+        name = str(step.get("name") or "step")
+        parts = [name]
+        for key in ("phase", "status", "command", "message"):
+            value = step.get(key)
+            if value:
+                parts.append(f"{key}={value}")
+        lines.append("- " + "; ".join(parts))
+    return lines
+
+
+def _raise_yjk_runtime_error(
+    headline: str,
+    *,
+    work_dir: Path,
+    stdout_path: Path | None = None,
+    stderr_path: Path | None = None,
+    driver_output_path: Path | None = None,
+    stdout: str = "",
+    stderr: str = "",
+    output: dict | None = None,
+    detail: Dict[str, Any] | None = None,
+    extra_paths: Dict[str, Path] | None = None,
+) -> None:
+    stdout_tail = _tail_text(stdout)
+    stderr_tail = _tail_text(stderr)
+    steps_tail = _summarize_steps(output)
+    run_meta_path = work_dir / "run-meta.json"
+    driver_result_path = work_dir / "driver-result.json"
+
+    paths: Dict[str, Path] = {
+        "workDir": work_dir,
+        "runMetaPath": run_meta_path,
+        "driverResultPath": driver_result_path,
+    }
+    if driver_output_path is not None:
+        paths["driverOutputPath"] = driver_output_path
+    if stdout_path is not None:
+        paths["stdoutPath"] = stdout_path
+    if stderr_path is not None:
+        paths["stderrPath"] = stderr_path
+    if extra_paths:
+        paths.update(extra_paths)
+
+    lines = [headline, "", "Artifact feedback:"]
+    for label, path in paths.items():
+        lines.append(f"- {label}: {path}")
+    if detail:
+        lines.append(f"- detail: {json.dumps(detail, ensure_ascii=False)}")
+    if steps_tail:
+        lines.extend(["", "Recent driver steps:", *steps_tail])
+    if stderr_tail:
+        lines.extend(["", "driver stderr tail:", stderr_tail])
+    if stdout_tail:
+        lines.extend(["", "driver stdout tail:", stdout_tail])
+
+    meta: Dict[str, Any] = {label: str(path) for label, path in paths.items()}
+    if stdout_tail:
+        meta["stdoutTail"] = stdout_tail
+    if stderr_tail:
+        meta["stderrTail"] = stderr_tail
+    if steps_tail:
+        meta["stepsTail"] = steps_tail
+    if detail:
+        meta["yjkErrorDetail"] = detail
+
+    error = RuntimeError("\n".join(lines))
+    setattr(error, "meta", meta)
+    if detail:
+        setattr(error, "detail", detail)
+    raise error
 
 
 def _yjk_install_root() -> str:
@@ -498,6 +593,7 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     # even after yjk_driver.py has emitted the final JSON and exited.
     stdout_path = work_dir / "driver.stdout.txt"
     stderr_path = work_dir / "driver.stderr.txt"
+    driver_output_path = work_dir / "driver-output.json"
     try:
         with stdout_path.open("w", encoding="utf-8") as stdout_file, stderr_path.open(
             "w",
@@ -532,13 +628,27 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
                         "stderr": stderr,
                     },
                 )
-                raise RuntimeError(f"YJK analysis timed out after {timeout}s")
+                _raise_yjk_runtime_error(
+                    f"YJK analysis timed out after {timeout}s",
+                    work_dir=work_dir,
+                    stdout_path=stdout_path,
+                    stderr_path=stderr_path,
+                    driver_output_path=driver_output_path,
+                    stdout=stdout,
+                    stderr=stderr,
+                    detail={
+                        "timeoutSeconds": timeout,
+                        "returncode": proc.returncode,
+                    },
+                    extra_paths={
+                        "driverTimeoutPath": work_dir / "driver-timeout.json",
+                    },
+                )
     except FileNotFoundError as exc:
         raise RuntimeError(f"Cannot launch YJK Python: {exc}")
 
     stdout = _read_text(stdout_path)
     stderr = _read_text(stderr_path)
-    driver_output_path = work_dir / "driver-output.json"
     _write_json(
         work_dir / "driver-result.json",
         {
@@ -566,30 +676,46 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     output = _read_json(driver_output_path)
 
     if returncode != 0 and not stdout and output is None:
-        stderr_snippet = stderr[:800] if stderr else "(no stderr)"
-        raise RuntimeError(
-            f"YJK driver exited with code {returncode}.\n"
-            f"stderr: {stderr_snippet}"
+        _raise_yjk_runtime_error(
+            f"YJK driver exited with code {returncode}.",
+            work_dir=work_dir,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+            driver_output_path=driver_output_path,
+            stdout=stdout,
+            stderr=stderr,
+            detail={"returncode": returncode},
         )
 
     if not stdout and output is None:
-        stderr_snippet = stderr[:800] if stderr else "(no stderr)"
-        raise RuntimeError(
-            f"YJK driver produced no stdout output.\n"
-            f"stderr: {stderr_snippet}"
+        _raise_yjk_runtime_error(
+            "YJK driver produced no stdout output.",
+            work_dir=work_dir,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+            driver_output_path=driver_output_path,
+            stdout=stdout,
+            stderr=stderr,
+            detail={"returncode": returncode},
         )
 
     output = output or _extract_last_json(stdout)
     if output is None:
-        raise RuntimeError(
-            f"YJK driver output is not valid JSON.\n"
-            f"stdout (first 500 chars): {stdout[:500]}\n"
-            f"stderr (first 500 chars): {stderr[:500]}"
+        _raise_yjk_runtime_error(
+            "YJK driver output is not valid JSON.",
+            work_dir=work_dir,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+            driver_output_path=driver_output_path,
+            stdout=stdout,
+            stderr=stderr,
+            detail={"returncode": returncode},
         )
 
     status = output.get("status", "error")
     if status == "error":
-        error_detail = output.get("detailed", {})
+        raw_error_detail = output.get("detailed", {})
+        error_detail = raw_error_detail if isinstance(raw_error_detail, dict) else {}
         error_msg = error_detail.get("error", "Unknown YJK error")
         phase = error_detail.get("phase")
         command = error_detail.get("command")
@@ -599,7 +725,22 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
         if command:
             context.append(f"command={command}")
         context_text = f" ({', '.join(context)})" if context else ""
-        raise RuntimeError(f"YJK analysis failed{context_text}: {error_msg}")
+        detail = {
+            "returncode": returncode,
+            "error": error_msg,
+            **error_detail,
+        }
+        _raise_yjk_runtime_error(
+            f"YJK analysis failed{context_text}: {error_msg}",
+            work_dir=work_dir,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+            driver_output_path=driver_output_path,
+            stdout=stdout,
+            stderr=stderr,
+            output=output,
+            detail=detail,
+        )
 
     if stderr:
         warnings.append(f"YJK stderr: {stderr[:300]}")


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

* Problem: failed YJK analysis artifacts could return `success:false`, but the LangGraph `run_analysis` tool message still summarized the run as `success:true` with almost no diagnostic detail.
* Why it matters: the agent could not read artifact feedback such as YJK driver stderr/stdout logs, so it could not explain generated YJK errors or guide the user toward the failing phase.
* What changed: failed analysis responses now surface `success:false`, error code, message, and selected diagnostics to the model; YJK runtime errors now include work directory, driver artifact paths, recent steps, and capped stdout/stderr tails; the Python analysis API preserves structured exception metadata.
* What did NOT change (scope boundary): no UI, schema, storage, configuration, or successful-analysis result format changes.

## Change Type (select all)

* [x] Bug fix
* [ ] Feature
* [ ] Refactor required for the fix
* [ ] Docs
* [ ] Security hardening
* [ ] Chore/infra

## Scope (select all touched areas)

* [x] Gateway / orchestration
* [x] Skills / tool execution
* [ ] Auth / tokens
* [ ] Memory / storage
* [x] Integrations
* [x] API / contracts
* [ ] UI / DX
* [ ] CI/CD / infra

## Linked Issue/PR

* Closes N/A
* Related N/A
* This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

* Root cause: `run_analysis` treated any returned analysis artifact as a successful tool execution summary, even when the artifact payload itself had `success:false`.
* Missing detection / guardrail: there was no regression test asserting that failed analysis artifacts are visible to the model as failures.
* Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
* Why this regressed now: YJK failures are delivered through the analysis response artifact rather than thrown as a TypeScript-side tool exception, so the compact tool summary hid the failure details.
* If unknown, what was ruled out: the full artifact was still stored in state; the missing piece was the compact ToolMessage content consumed by the model.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

* Coverage level that should have caught this:
  * Unit test
* Target test or file: `backend/src/agent-langgraph/__tests__/analysis-tool-summary.test.mjs`
* Scenario the test should lock in: a `success:false` YJK analysis artifact produces a `success:false` tool summary containing error code, message, and diagnostics such as stderr tail.
* Why this is the smallest reliable guardrail: the bug was in summary construction before the model sees the tool result, so a focused unit test catches it without requiring a live YJK installation.
* Existing test that already covers this (if any): None.
* If no new test is added, why not: N/A.

## User-visible / Behavior Changes

When YJK analysis fails, the assistant should now be able to explain the failing phase and relevant driver log tail instead of acting as if analysis succeeded or giving a generic artifact-reading failure. No settings or defaults changed.

## Diagram (if applicable)

    Before:
    YJK failure artifact -> run_analysis ToolMessage { success: true } -> model misses logs

    After:
    YJK failure artifact -> run_analysis ToolMessage { success: false, diagnostics } -> model can explain logs

## Security Impact (required)

* New permissions/capabilities? (`Yes/No`): No
* Secrets/tokens handling changed? (`Yes/No`): No
* New/changed network calls? (`Yes/No`): No
* Command/tool execution surface changed? (`Yes/No`): No
* Data access scope changed? (`Yes/No`): Yes
* If any `Yes`, explain risk + mitigation: the model now receives capped tails and paths from artifacts produced by the current YJK run. The runtime does not read additional arbitrary files, and stdout/stderr snippets are capped before being added to metadata/tool summaries.

## Repro + Verification

### Environment

* OS: Windows
* Runtime/container: backend Node/Jest/TypeScript; Python 3.12 venv for syntax checks
* Model/provider: N/A
* Integration/channel (if any): LangGraph `run_analysis`, YJK static analysis runtime
* Relevant config (redacted): N/A

### Steps

1. Trigger or mock a failed YJK analysis response with `success:false` and stderr artifact feedback.
2. Build the `run_analysis` tool summary.
3. Inspect the returned ToolMessage summary and diagnostics.

### Expected

* The tool summary reports `success:false` and includes the error code, message, YJK artifact paths, recent steps, and capped stdout/stderr tails where available.

### Actual

* Before this PR, the tool summary reported `success:true` and omitted the YJK diagnostic context even when the artifact payload was a failure.

## Evidence

* Passing focused regression: `npm test --prefix backend -- --runInBand src/agent-langgraph/__tests__/analysis-tool-summary.test.mjs`
* Passing LangGraph tool suite: `npm test --prefix backend -- --runInBand src/agent-langgraph/__tests__`
* Passing lint: `npm run lint --prefix backend`
* Passing Python syntax check: `$HOME\.structureclaw\.venv\Scripts\python.exe -m py_compile backend/src/agent-skills/analysis/runtime/api.py backend/src/agent-skills/analysis/yjk-static/runtime.py`

## Human Verification (required)

What you personally verified (not just CI), and how:

* Verified scenarios: failed analysis artifacts now produce failed tool summaries with diagnostic fields; YJK runtime failure branches include artifact feedback; existing LangGraph tool tests still pass.
* Edge cases checked: timeout, empty stdout, invalid JSON, and driver `status:error` branches now use the same artifact-feedback formatter.
* What you did not verify: a live licensed YJK GUI/API run was not executed in this session.

## Review Conversations

* I replied to or resolved every bot review conversation I addressed in this PR.
* I left unresolved only the conversations that still need reviewer or maintainer judgment.

No review conversations exist yet.

## Compatibility / Migration

* Backward compatible? (`Yes/No`): Yes
* Config/env changes? (`Yes/No`): No
* Migration needed? (`Yes/No`): No
* If yes, exact upgrade steps: N/A

## Risks and Mitigations

* Risk: YJK stderr/stdout can be noisy.
  * Mitigation: log text is capped before being added to exception metadata and the model-facing summary.
* Risk: local artifact paths are surfaced in model context.
  * Mitigation: only paths from the current generated analysis work directory are included; no arbitrary extra files are read.
