### PR TITLE
fix(cli): set CWD for bundled Prisma CLI in installed mode

### DIFF
--- a/scripts/cli/main.js
+++ b/scripts/cli/main.js
@@ -505,6 +505,7 @@ function resolveBundledPrismaEntry(rootDir) {
 async function runBundledPrisma(rootDir, args, env) {
   const prismaEntry = resolveBundledPrismaEntry(rootDir);
   await runtime.runCommand(process.execPath, [prismaEntry, ...args], {
+    cwd: path.join(rootDir, "backend"),
     env,
   });
 }


### PR DESCRIPTION
## Summary

- `runBundledPrisma()` was missing `cwd`, causing Prisma 7 CLI to fail discovering `prisma.config.ts` in installed mode
- Prisma 7 moved `datasource.url` from `schema.prisma` to `prisma.config.ts`, which the CLI auto-discovers via CWD — without it, `sclaw doctor` errored with "The datasource.url property is required"

## Impacted areas

- `scripts/cli/` — installed-mode Prisma invocation only (dev mode was unaffected, `sync-sqlite-schema.mjs` already sets correct CWD)

## Test plan

- [x] `npm run build --prefix backend` — passes
- [x] `npm test --prefix backend -- --runInBand` — 627 tests pass
- [ ] Manual: run `sclaw doctor` on a fresh machine with global npm install — database init should succeed