### PR TITLE
feat(config): hot-reload LLM settings

### DIFF
--- a/backend/src/api/admin-settings.ts
+++ b/backend/src/api/admin-settings.ts
@@ -780,19 +780,6 @@ function resolveYjkInstallRoot(input: SettingsFileYjk | undefined, current: Sett
   return detected;
 }
 
-function applyYjkRuntimeConfig(yjk: SettingsFileYjk): void {
-  config.yjkInstallRoot = yjk.installRoot ?? '';
-  config.yjkExePath = yjk.exePath ?? '';
-  config.yjkPythonBin = yjk.pythonBin ?? '';
-  config.yjkWorkDir = yjk.workDir ?? config.yjkWorkDir;
-  config.yjkVersion = yjk.version ?? '8.0.0';
-  config.yjkTimeoutS = yjk.timeoutS ?? 600;
-  config.yjkInvisible = yjk.invisible ?? false;
-  config.yjkLauncherPrewarm = yjk.launcherPrewarm ?? 'auto';
-  config.yjkLauncherPrewarmS = yjk.launcherPrewarmS ?? 18;
-  config.yjkDirectReadyTimeoutS = yjk.directReadyTimeoutS ?? 12;
-}
-
 function autoConfigureYjk(input: YjkAutoConfigureInput): { settings: SettingsResponse; steps: YjkAutoConfigureStep[] } {
   const current = readSettingsFile() ?? {};
   const requestedYjk = input.yjk;
@@ -857,7 +844,6 @@ function autoConfigureYjk(input: YjkAutoConfigureInput): { settings: SettingsRes
   });
 
   writeSettingsFile({ ...current, yjk });
-  applyYjkRuntimeConfig(yjk);
   steps.push({ name: 'Save StructureClaw YJK settings', status: 'applied' });
 
   return { settings: buildSettingsResponse(), steps };

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -35,9 +35,6 @@ function resolveReportsDir(rawValue: string | undefined): string {
   return path.resolve(__dirname, '../../../', trimmed);
 }
 
-const llmApiKey = fileSettings?.llm?.apiKey ?? '';
-const llmModel = fileSettings?.llm?.model || process.env.LLM_MODEL || 'gpt-4-turbo-preview';
-const llmBaseUrl = fileSettings?.llm?.baseUrl || process.env.LLM_BASE_URL || 'https://api.openai.com/v1';
 const frontendPort = fileSettings?.server?.frontendPort?.toString() ?? (process.env.FRONTEND_PORT || '31416');
 const backendPort = fileSettings?.server?.port ?? (parseInt(process.env.PORT || '', 10) || 31415);
 const analysisEngineManifestPath = fileSettings?.analysis?.engineManifestPath
@@ -60,6 +57,17 @@ const corsOrigins = (fileSettings?.cors?.origins ?? defaultCorsOrigins.join(',')
 
 export { runtimeBaseDir };
 
+const LLM_DEFAULTS = {
+  baseUrl: 'https://api.openai.com/v1',
+  model: 'gpt-4-turbo-preview',
+  timeoutMs: 180000,
+  maxRetries: 0,
+} as const;
+
+function getCurrentLlmSettings() {
+  return readSettingsFile()?.llm;
+}
+
 export const config = {
   // 服务配置
   port: typeof backendPort === 'number' ? backendPort : parseInt(String(backendPort), 10),
@@ -72,11 +80,21 @@ export const config = {
   databaseUrl: process.env.DATABASE_URL || fileSettings?.database?.url || defaultSqliteDatabaseUrl,
 
   // AI 配置
-  llmApiKey,
-  llmModel,
-  llmBaseUrl,
-  llmTimeoutMs: fileSettings?.llm?.timeoutMs ?? 180000,
-  llmMaxRetries: fileSettings?.llm?.maxRetries ?? 0,
+  get llmApiKey() {
+    return getCurrentLlmSettings()?.apiKey ?? '';
+  },
+  get llmModel() {
+    return getCurrentLlmSettings()?.model || process.env.LLM_MODEL || LLM_DEFAULTS.model;
+  },
+  get llmBaseUrl() {
+    return getCurrentLlmSettings()?.baseUrl || process.env.LLM_BASE_URL || LLM_DEFAULTS.baseUrl;
+  },
+  get llmTimeoutMs() {
+    return getCurrentLlmSettings()?.timeoutMs ?? LLM_DEFAULTS.timeoutMs;
+  },
+  get llmMaxRetries() {
+    return getCurrentLlmSettings()?.maxRetries ?? LLM_DEFAULTS.maxRetries;
+  },
 
   // 分析执行配置
   analysisPythonBin: fileSettings?.analysis?.pythonBin ?? defaultAnalysisPythonBin,

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -37,8 +37,6 @@ function resolveReportsDir(rawValue: string | undefined): string {
 
 const frontendPort = fileSettings?.server?.frontendPort?.toString() ?? (process.env.FRONTEND_PORT || '31416');
 const backendPort = fileSettings?.server?.port ?? (parseInt(process.env.PORT || '', 10) || 31415);
-const analysisEngineManifestPath = fileSettings?.analysis?.engineManifestPath
-  ?? path.join(runtimeBaseDir, 'analysis-engines.json');
 const defaultAnalysisPythonBin = process.platform === 'win32'
   ? path.join(runtimeBaseDir, '.venv', 'Scripts', 'python.exe')
   : path.join(runtimeBaseDir, '.venv', 'bin', 'python');
@@ -64,8 +62,55 @@ const LLM_DEFAULTS = {
   maxRetries: 0,
 } as const;
 
+const ANALYSIS_DEFAULTS = {
+  engineManifestPath: path.join(runtimeBaseDir, 'analysis-engines.json'),
+  pythonTimeoutMs: 600000,
+} as const;
+
+const AGENT_DEFAULTS = {
+  workspaceRoot: runtimeBaseDir,
+  checkpointDir: path.join(runtimeBaseDir, 'agent-checkpoints'),
+  allowShell: false,
+  allowedShellCommands: 'node,npm,python,python3,./sclaw,./sclaw_cn',
+  shellTimeoutMs: 300000,
+} as const;
+
+const PKPM_DEFAULTS = {
+  cyclePath: '',
+  workDir: path.join(runtimeBaseDir, 'analysis', 'pkpm'),
+} as const;
+
+const YJK_DEFAULTS = {
+  installRoot: '',
+  exePath: '',
+  pythonBin: '',
+  workDir: path.join(runtimeBaseDir, 'analysis', 'yjk'),
+  version: '8.0.0',
+  timeoutS: 600,
+  invisible: false,
+  launcherPrewarm: 'auto',
+  launcherPrewarmS: 18,
+  directReadyTimeoutS: 12,
+} as const;
+
 function getCurrentLlmSettings() {
   return readSettingsFile()?.llm;
+}
+
+function getCurrentAnalysisSettings() {
+  return readSettingsFile()?.analysis;
+}
+
+function getCurrentAgentSettings() {
+  return readSettingsFile()?.agent;
+}
+
+function getCurrentPkpmSettings() {
+  return readSettingsFile()?.pkpm;
+}
+
+function getCurrentYjkSettings() {
+  return readSettingsFile()?.yjk;
 }
 
 export const config = {
@@ -97,9 +142,15 @@ export const config = {
   },
 
   // 分析执行配置
-  analysisPythonBin: fileSettings?.analysis?.pythonBin ?? defaultAnalysisPythonBin,
-  analysisPythonTimeoutMs: fileSettings?.analysis?.pythonTimeoutMs ?? 600000,
-  analysisEngineManifestPath,
+  get analysisPythonBin() {
+    return getCurrentAnalysisSettings()?.pythonBin ?? defaultAnalysisPythonBin;
+  },
+  get analysisPythonTimeoutMs() {
+    return getCurrentAnalysisSettings()?.pythonTimeoutMs ?? ANALYSIS_DEFAULTS.pythonTimeoutMs;
+  },
+  get analysisEngineManifestPath() {
+    return getCurrentAnalysisSettings()?.engineManifestPath ?? ANALYSIS_DEFAULTS.engineManifestPath;
+  },
 
   // CORS
   corsOrigins,
@@ -122,27 +173,61 @@ export const config = {
   llmLogDir: fileSettings?.logging?.llmLogDir ?? path.join(runtimeBaseDir, 'logs'),
 
   // Agent 配置
-  agentWorkspaceRoot: fileSettings?.agent?.workspaceRoot ?? runtimeBaseDir,
-  agentCheckpointDir: fileSettings?.agent?.checkpointDir ?? path.join(runtimeBaseDir, 'agent-checkpoints'),
-  agentAllowShell: fileSettings?.agent?.allowShell ?? false,
-  agentAllowedShells: fileSettings?.agent?.allowedShellCommands ?? 'node,npm,python,python3,./sclaw,./sclaw_cn',
-  agentShellTimeoutMs: fileSettings?.agent?.shellTimeoutMs ?? 300000,
+  get agentWorkspaceRoot() {
+    return getCurrentAgentSettings()?.workspaceRoot ?? AGENT_DEFAULTS.workspaceRoot;
+  },
+  get agentCheckpointDir() {
+    return getCurrentAgentSettings()?.checkpointDir ?? AGENT_DEFAULTS.checkpointDir;
+  },
+  get agentAllowShell() {
+    return getCurrentAgentSettings()?.allowShell ?? AGENT_DEFAULTS.allowShell;
+  },
+  get agentAllowedShells() {
+    return getCurrentAgentSettings()?.allowedShellCommands ?? AGENT_DEFAULTS.allowedShellCommands;
+  },
+  get agentShellTimeoutMs() {
+    return getCurrentAgentSettings()?.shellTimeoutMs ?? AGENT_DEFAULTS.shellTimeoutMs;
+  },
 
   // PKPM 引擎配置
-  pkpmCyclePath: fileSettings?.pkpm?.cyclePath ?? '',
-  pkpmWorkDir: fileSettings?.pkpm?.workDir ?? path.join(runtimeBaseDir, 'analysis', 'pkpm'),
+  get pkpmCyclePath() {
+    return getCurrentPkpmSettings()?.cyclePath ?? PKPM_DEFAULTS.cyclePath;
+  },
+  get pkpmWorkDir() {
+    return getCurrentPkpmSettings()?.workDir ?? PKPM_DEFAULTS.workDir;
+  },
 
   // YJK 引擎配置
-  yjkInstallRoot: fileSettings?.yjk?.installRoot ?? '',
-  yjkExePath: fileSettings?.yjk?.exePath ?? '',
-  yjkPythonBin: fileSettings?.yjk?.pythonBin ?? '',
-  yjkWorkDir: fileSettings?.yjk?.workDir ?? path.join(runtimeBaseDir, 'analysis', 'yjk'),
-  yjkVersion: fileSettings?.yjk?.version ?? '8.0.0',
-  yjkTimeoutS: fileSettings?.yjk?.timeoutS ?? 600,
-  yjkInvisible: fileSettings?.yjk?.invisible ?? false,
-  yjkLauncherPrewarm: fileSettings?.yjk?.launcherPrewarm ?? 'auto',
-  yjkLauncherPrewarmS: fileSettings?.yjk?.launcherPrewarmS ?? 18,
-  yjkDirectReadyTimeoutS: fileSettings?.yjk?.directReadyTimeoutS ?? 12,
+  get yjkInstallRoot() {
+    return getCurrentYjkSettings()?.installRoot ?? YJK_DEFAULTS.installRoot;
+  },
+  get yjkExePath() {
+    return getCurrentYjkSettings()?.exePath ?? YJK_DEFAULTS.exePath;
+  },
+  get yjkPythonBin() {
+    return getCurrentYjkSettings()?.pythonBin ?? YJK_DEFAULTS.pythonBin;
+  },
+  get yjkWorkDir() {
+    return getCurrentYjkSettings()?.workDir ?? YJK_DEFAULTS.workDir;
+  },
+  get yjkVersion() {
+    return getCurrentYjkSettings()?.version ?? YJK_DEFAULTS.version;
+  },
+  get yjkTimeoutS() {
+    return getCurrentYjkSettings()?.timeoutS ?? YJK_DEFAULTS.timeoutS;
+  },
+  get yjkInvisible() {
+    return getCurrentYjkSettings()?.invisible ?? YJK_DEFAULTS.invisible;
+  },
+  get yjkLauncherPrewarm() {
+    return getCurrentYjkSettings()?.launcherPrewarm ?? YJK_DEFAULTS.launcherPrewarm;
+  },
+  get yjkLauncherPrewarmS() {
+    return getCurrentYjkSettings()?.launcherPrewarmS ?? YJK_DEFAULTS.launcherPrewarmS;
+  },
+  get yjkDirectReadyTimeoutS() {
+    return getCurrentYjkSettings()?.directReadyTimeoutS ?? YJK_DEFAULTS.directReadyTimeoutS;
+  },
 };
 
 export type Config = typeof config;

--- a/backend/src/config/settings-file.ts
+++ b/backend/src/config/settings-file.ts
@@ -344,10 +344,34 @@ function normalizeSettingsFile(raw: unknown): SettingsFile | null {
 
 let cachedSettings: SettingsFile | null | undefined;
 let cachedSettingsPath: string | undefined;
+let cachedSettingsFingerprint: { mtimeMs: number; size: number } | null | undefined;
 
-function setCache(filePath: string, settings: SettingsFile | null): void {
+function getSettingsFileFingerprint(filePath: string): { mtimeMs: number; size: number } | null {
+  try {
+    const stat = fs.statSync(filePath);
+    return { mtimeMs: stat.mtimeMs, size: stat.size };
+  } catch {
+    return null;
+  }
+}
+
+function isSameFingerprint(
+  left: { mtimeMs: number; size: number } | null | undefined,
+  right: { mtimeMs: number; size: number } | null,
+): boolean {
+  if (left === undefined) return false;
+  if (left === null || right === null) return left === right;
+  return left.mtimeMs === right.mtimeMs && left.size === right.size;
+}
+
+function setCache(
+  filePath: string,
+  settings: SettingsFile | null,
+  fingerprint: { mtimeMs: number; size: number } | null = getSettingsFileFingerprint(filePath),
+): void {
   cachedSettingsPath = filePath;
   cachedSettings = settings;
+  cachedSettingsFingerprint = fingerprint;
 }
 
 function readSettingsFromDisk(): SettingsFile | null {
@@ -363,11 +387,16 @@ function readSettingsFromDisk(): SettingsFile | null {
 
 export function readSettingsFile(): SettingsFile | null {
   const filePath = getSettingsFilePath();
-  if (cachedSettingsPath === filePath && cachedSettings !== undefined) {
+  const currentFingerprint = getSettingsFileFingerprint(filePath);
+  if (
+    cachedSettingsPath === filePath
+    && cachedSettings !== undefined
+    && isSameFingerprint(cachedSettingsFingerprint, currentFingerprint)
+  ) {
     return cachedSettings;
   }
   const settings = readSettingsFromDisk();
-  setCache(filePath, settings);
+  setCache(filePath, settings, currentFingerprint);
   return settings;
 }
 

--- a/backend/src/config/settings-file.ts
+++ b/backend/src/config/settings-file.ts
@@ -4,6 +4,7 @@
  * All fields are optional; missing values fall back to hardcoded defaults.
  * Extends the same cache/read/write pattern as llm-runtime.ts.
  */
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { runtimeBaseDir } from './index.js';
@@ -344,40 +345,58 @@ function normalizeSettingsFile(raw: unknown): SettingsFile | null {
 
 let cachedSettings: SettingsFile | null | undefined;
 let cachedSettingsPath: string | undefined;
-let cachedSettingsFingerprint: { mtimeMs: number; size: number } | null | undefined;
+type SettingsFileFingerprint = {
+  mtimeMs: number;
+  ctimeMs: number;
+  size: number;
+  sha256: string;
+};
 
-function getSettingsFileFingerprint(filePath: string): { mtimeMs: number; size: number } | null {
+let cachedSettingsFingerprint: SettingsFileFingerprint | null | undefined;
+
+function getSettingsFileFingerprint(filePath: string): SettingsFileFingerprint | null {
+  const stat = fs.statSync(filePath, { throwIfNoEntry: false });
+  if (!stat?.isFile()) {
+    return null;
+  }
+
   try {
-    const stat = fs.statSync(filePath);
-    return { mtimeMs: stat.mtimeMs, size: stat.size };
+    const content = fs.readFileSync(filePath);
+    return {
+      mtimeMs: stat.mtimeMs,
+      ctimeMs: stat.ctimeMs,
+      size: stat.size,
+      sha256: crypto.createHash('sha256').update(content).digest('hex'),
+    };
   } catch {
     return null;
   }
 }
 
 function isSameFingerprint(
-  left: { mtimeMs: number; size: number } | null | undefined,
-  right: { mtimeMs: number; size: number } | null,
+  left: SettingsFileFingerprint | null | undefined,
+  right: SettingsFileFingerprint | null,
 ): boolean {
   if (left === undefined) return false;
   if (left === null || right === null) return left === right;
-  return left.mtimeMs === right.mtimeMs && left.size === right.size;
+  return left.mtimeMs === right.mtimeMs
+    && left.ctimeMs === right.ctimeMs
+    && left.size === right.size
+    && left.sha256 === right.sha256;
 }
 
 function setCache(
   filePath: string,
   settings: SettingsFile | null,
-  fingerprint: { mtimeMs: number; size: number } | null = getSettingsFileFingerprint(filePath),
+  fingerprint: SettingsFileFingerprint | null = getSettingsFileFingerprint(filePath),
 ): void {
   cachedSettingsPath = filePath;
   cachedSettings = settings;
   cachedSettingsFingerprint = fingerprint;
 }
 
-function readSettingsFromDisk(): SettingsFile | null {
-  const filePath = getSettingsFilePath();
+function readSettingsFromDisk(filePath: string): SettingsFile | null {
   try {
-    if (!fs.existsSync(filePath)) return null;
     const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
     return normalizeSettingsFile(raw);
   } catch {
@@ -395,7 +414,7 @@ export function readSettingsFile(): SettingsFile | null {
   ) {
     return cachedSettings;
   }
-  const settings = readSettingsFromDisk();
+  const settings = readSettingsFromDisk(filePath);
   setCache(filePath, settings, currentFingerprint);
   return settings;
 }

--- a/backend/tests/config.llm-env.test.mjs
+++ b/backend/tests/config.llm-env.test.mjs
@@ -17,24 +17,16 @@ function cleanupIsolatedDataDir(dir) {
 }
 
 async function importConfigFresh(dataDir) {
-  const prev = process.env.SCLAW_DATA_DIR;
   process.env.SCLAW_DATA_DIR = dataDir;
-  try {
-    // Bust the module cache with a unique query string
-    return await import(`${configModuleUrl}?ts=${Date.now()}-${Math.random()}`);
-  } finally {
-    if (prev === undefined) {
-      delete process.env.SCLAW_DATA_DIR;
-    } else {
-      process.env.SCLAW_DATA_DIR = prev;
-    }
-  }
+  // Bust the module cache with a unique query string
+  return import(`${configModuleUrl}?ts=${Date.now()}-${Math.random()}`);
 }
 
 describe('backend llm config', () => {
   test('uses settings.json overrides when present, env vars as fallback, hardcoded defaults last', async () => {
     const dataDir = createIsolatedDataDir();
     const previous = {
+      SCLAW_DATA_DIR: process.env.SCLAW_DATA_DIR,
       LLM_API_KEY: process.env.LLM_API_KEY,
       LLM_MODEL: process.env.LLM_MODEL,
       LLM_BASE_URL: process.env.LLM_BASE_URL,
@@ -72,6 +64,7 @@ describe('backend llm config', () => {
     // This test confirms the config module still exports the expected shape.
     const dataDir = createIsolatedDataDir();
     const previous = {
+      SCLAW_DATA_DIR: process.env.SCLAW_DATA_DIR,
       LLM_API_KEY: process.env.LLM_API_KEY,
       LLM_MODEL: process.env.LLM_MODEL,
       LLM_BASE_URL: process.env.LLM_BASE_URL,

--- a/backend/tests/config.llm-env.test.mjs
+++ b/backend/tests/config.llm-env.test.mjs
@@ -16,9 +16,10 @@ function cleanupIsolatedDataDir(dir) {
   fs.rmSync(dir, { recursive: true, force: true });
 }
 
-async function importConfigFresh(dataDir) {
+async function importConfigWithDataDirSet(dataDir) {
   process.env.SCLAW_DATA_DIR = dataDir;
   // Bust the module cache with a unique query string
+  // Keep SCLAW_DATA_DIR set while callers read dynamic config getters.
   return import(`${configModuleUrl}?ts=${Date.now()}-${Math.random()}`);
 }
 
@@ -38,7 +39,7 @@ describe('backend llm config', () => {
     process.env.LLM_BASE_URL = '';
 
     try {
-      const { config } = await importConfigFresh(dataDir);
+      const { config } = await importConfigWithDataDirSet(dataDir);
       // Without settings.json overrides, hardcoded defaults apply (empty env vars are falsy)
       expect(config.llmApiKey).toBe('');
       expect(config.llmModel).toBe('gpt-4-turbo-preview');
@@ -75,7 +76,7 @@ describe('backend llm config', () => {
     process.env.LLM_BASE_URL = '';
 
     try {
-      const { config } = await importConfigFresh(dataDir);
+      const { config } = await importConfigWithDataDirSet(dataDir);
       expect(config).toHaveProperty('llmApiKey');
       expect(config).toHaveProperty('llmModel');
       expect(config).toHaveProperty('llmBaseUrl');

--- a/backend/tests/llm-runtime-settings.test.mjs
+++ b/backend/tests/llm-runtime-settings.test.mjs
@@ -106,6 +106,63 @@ describe('backend runtime llm settings', () => {
     }
   });
 
+  test('hot-reloads same-size settings.json rewrites with unchanged mtime', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'structureclaw-llm-settings-'));
+    const previous = {
+      SCLAW_DATA_DIR: process.env.SCLAW_DATA_DIR,
+      LLM_MODEL: process.env.LLM_MODEL,
+      LLM_BASE_URL: process.env.LLM_BASE_URL,
+    };
+
+    delete process.env.LLM_MODEL;
+    delete process.env.LLM_BASE_URL;
+    process.env.SCLAW_DATA_DIR = tempDir;
+
+    const settingsPath = path.join(tempDir, 'settings.json');
+    const fixedTime = new Date('2026-01-01T00:00:00.000Z');
+    const beforeRaw = JSON.stringify({
+      llm: {
+        apiKey: 'runtime-secret-aa',
+        model: 'same-size-model-a',
+        baseUrl: 'https://a.example.com/v1',
+      },
+    });
+    const afterRaw = JSON.stringify({
+      llm: {
+        apiKey: 'runtime-secret-bb',
+        model: 'same-size-model-b',
+        baseUrl: 'https://b.example.com/v1',
+      },
+    });
+    expect(Buffer.byteLength(afterRaw)).toBe(Buffer.byteLength(beforeRaw));
+
+    fs.writeFileSync(settingsPath, beforeRaw);
+    fs.utimesSync(settingsPath, fixedTime, fixedTime);
+
+    try {
+      const { llmRuntime } = await getModules();
+      expect(llmRuntime.getEffectiveLlmSettings()).toMatchObject({
+        llmApiKey: 'runtime-secret-aa',
+        llmModel: 'same-size-model-a',
+        llmBaseUrl: 'https://a.example.com/v1',
+      });
+
+      fs.writeFileSync(settingsPath, afterRaw);
+      fs.utimesSync(settingsPath, fixedTime, fixedTime);
+
+      expect(llmRuntime.getEffectiveLlmSettings()).toMatchObject({
+        llmApiKey: 'runtime-secret-bb',
+        llmModel: 'same-size-model-b',
+        llmBaseUrl: 'https://b.example.com/v1',
+      });
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key]; else process.env[key] = value;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test('hot-reloads python worker execution settings without restart', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'structureclaw-runtime-settings-'));
     const previous = {

--- a/backend/tests/llm-runtime-settings.test.mjs
+++ b/backend/tests/llm-runtime-settings.test.mjs
@@ -106,6 +106,87 @@ describe('backend runtime llm settings', () => {
     }
   });
 
+  test('hot-reloads python worker execution settings without restart', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'structureclaw-runtime-settings-'));
+    const previous = {
+      SCLAW_DATA_DIR: process.env.SCLAW_DATA_DIR,
+    };
+
+    process.env.SCLAW_DATA_DIR = tempDir;
+
+    const settingsPath = path.join(tempDir, 'settings.json');
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      analysis: {
+        pythonBin: 'python-before',
+        pythonTimeoutMs: 111,
+      },
+      agent: {
+        allowShell: true,
+        allowedShellCommands: 'node',
+      },
+      pkpm: {
+        cyclePath: 'C:/PKPM/JWSCYCLE.exe',
+        workDir: 'C:/structureclaw/pkpm-before',
+      },
+      yjk: {
+        installRoot: 'C:/YJKS/YJKS_8_0_0',
+        timeoutS: 11,
+        invisible: true,
+      },
+    }));
+
+    try {
+      const { settingsFile, config } = await getModules();
+      expect(config.config.analysisPythonBin).toBe('python-before');
+      expect(config.config.analysisPythonTimeoutMs).toBe(111);
+      expect(config.config.agentAllowShell).toBe(true);
+      expect(config.config.agentAllowedShells).toBe('node');
+      expect(config.config.pkpmCyclePath).toBe('C:/PKPM/JWSCYCLE.exe');
+      expect(config.config.pkpmWorkDir).toBe('C:/structureclaw/pkpm-before');
+      expect(config.config.yjkInstallRoot).toBe('C:/YJKS/YJKS_8_0_0');
+      expect(config.config.yjkTimeoutS).toBe(11);
+      expect(config.config.yjkInvisible).toBe(true);
+
+      settingsFile.writeSettingsFile({
+        analysis: {
+          pythonBin: 'python-after',
+          pythonTimeoutMs: 222,
+        },
+        agent: {
+          allowShell: false,
+          allowedShellCommands: 'npm',
+        },
+        pkpm: {
+          cyclePath: '',
+          workDir: 'C:/structureclaw/pkpm-after',
+        },
+        yjk: {
+          installRoot: '',
+          timeoutS: 22,
+          invisible: false,
+        },
+      });
+
+      expect(config.config.analysisPythonBin).toBe('python-after');
+      expect(config.config.analysisPythonTimeoutMs).toBe(222);
+      expect(config.config.agentAllowShell).toBe(false);
+      expect(config.config.agentAllowedShells).toBe('npm');
+      expect(config.config.pkpmCyclePath).toBe('');
+      expect(config.config.pkpmWorkDir).toBe('C:/structureclaw/pkpm-after');
+      expect(config.config.yjkInstallRoot).toBe('');
+      expect(config.config.yjkTimeoutS).toBe(22);
+      expect(config.config.yjkInvisible).toBe(false);
+
+      const stored = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      expect(stored.pkpm).not.toHaveProperty('cyclePath');
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key]; else process.env[key] = value;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test('keeps the previous runtime api key when apiKeyMode is keep', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'structureclaw-llm-settings-'));
     const previous = {

--- a/backend/tests/llm-runtime-settings.test.mjs
+++ b/backend/tests/llm-runtime-settings.test.mjs
@@ -53,6 +53,59 @@ describe('backend runtime llm settings', () => {
     }
   });
 
+  test('hot-reloads direct settings.json changes without module reload', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'structureclaw-llm-settings-'));
+    const previous = {
+      SCLAW_DATA_DIR: process.env.SCLAW_DATA_DIR,
+      LLM_MODEL: process.env.LLM_MODEL,
+      LLM_BASE_URL: process.env.LLM_BASE_URL,
+    };
+
+    delete process.env.LLM_MODEL;
+    delete process.env.LLM_BASE_URL;
+    process.env.SCLAW_DATA_DIR = tempDir;
+
+    const settingsPath = path.join(tempDir, 'settings.json');
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      llm: {
+        apiKey: 'runtime-secret-before',
+        model: 'runtime-model-before',
+        baseUrl: 'https://before.example.com/v1',
+      },
+    }));
+
+    try {
+      const { llmRuntime, config } = await getModules();
+      expect(llmRuntime.getEffectiveLlmSettings()).toMatchObject({
+        llmApiKey: 'runtime-secret-before',
+        llmModel: 'runtime-model-before',
+        llmBaseUrl: 'https://before.example.com/v1',
+      });
+      expect(config.config.llmModel).toBe('runtime-model-before');
+
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        llm: {
+          apiKey: 'runtime-secret-after-hot-reload',
+          model: 'runtime-model-after-hot-reload',
+          baseUrl: 'https://after-hot-reload.example.com/v1',
+        },
+      }));
+
+      expect(llmRuntime.getEffectiveLlmSettings()).toMatchObject({
+        llmApiKey: 'runtime-secret-after-hot-reload',
+        llmModel: 'runtime-model-after-hot-reload',
+        llmBaseUrl: 'https://after-hot-reload.example.com/v1',
+      });
+      expect(config.config.llmModel).toBe('runtime-model-after-hot-reload');
+      expect(config.config.llmBaseUrl).toBe('https://after-hot-reload.example.com/v1');
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key]; else process.env[key] = value;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test('keeps the previous runtime api key when apiKeyMode is keep', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'structureclaw-llm-settings-'));
     const previous = {


### PR DESCRIPTION
## Summary

- Problem: updates to `settings.json` could continue using cached runtime settings until the backend process restarted.
- Why it matters: changing `llm.model`, `llm.baseUrl`, PKPM/YJK paths, analysis Python settings, or agent execution settings should affect the next backend read/worker launch without `sclaw stop && sclaw start`.
- What changed: `settings.json` reads now invalidate the cache using file metadata plus a SHA-256 content fingerprint, and runtime-facing `config.*` fields are dynamic getters for LLM, analysis, agent, PKPM, and YJK settings.
- What did NOT change (scope boundary): process-start configuration such as server/database/CORS wiring, UI flows, and provider defaults.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #222
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `readSettingsFile()` memoized the first `settings.json` value for the process lifetime, and several exported `config.*` compatibility fields were computed at module load.
- Missing detection / guardrail: there was no runtime test that rewrote or saved `settings.json` after module import and asserted the next config read changed.
- Prior context (`git blame`, prior PR, issue, or refactor if known): unified settings cache in `backend/src/config/settings-file.ts` and static exports in `backend/src/config/index.ts`.
- Why this regressed now: N/A; this closes the hot-reload gap reported in #222.
- If unknown, what was ruled out: `createChatModel()` and Python worker launch paths already read config per call; the stale value was below them in the settings cache/static config path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/tests/llm-runtime-settings.test.mjs`
- Scenario the test should lock in: import runtime/config modules, rewrite or save `settings.json`, then verify `getEffectiveLlmSettings()` and runtime-facing `config.*` fields reflect the new values without module reload.
- Why this is the smallest reliable guardrail: it exercises the process-lifetime cache/static config behavior directly without needing a live LLM provider or commercial PKPM/YJK installation.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Settings changes in `settings.json` are picked up by subsequent backend reads without restarting for:

- LLM model/base URL/API key/timeout/retries
- analysis Python executable/timeout
- agent execution settings
- PKPM cycle/work paths
- YJK install/exe/python/work paths and launcher/runtime settings

## Diagram (if applicable)

```text
Before:
[settings.json edited] -> [process cache/static config unchanged] -> [next chat/worker uses old settings]

After:
[settings.json edited] -> [metadata/hash fingerprint changes or write cache updates] -> [next config read reloads] -> [next chat/worker uses new settings]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows 10/11 PowerShell
- Runtime/container: local Node backend + frontend build
- Model/provider: OpenAI-compatible LLM settings, provider not contacted by the new tests
- Integration/channel (if any): backend config/runtime and Python worker config path
- Relevant config (redacted): isolated temp `SCLAW_DATA_DIR/settings.json`

### Steps

1. Start with `settings.json` containing one set of LLM and execution settings.
2. Import backend runtime/config modules and read effective settings.
3. Rewrite/save the same `settings.json` with different values, including clearing `pkpm.cyclePath`.
4. Read effective settings again in the same process.

### Expected

- The second read returns the updated values without process restart or module reload.
- Clearing `pkpm.cyclePath` makes `config.pkpmCyclePath` empty before the next Python worker launch.

### Actual

- Verified by the new targeted Jest tests.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing checks:

```text
npm run build --prefix backend
$env:NODE_OPTIONS='--experimental-vm-modules'; npx jest --runInBand tests/llm-runtime-settings.test.mjs tests/config.llm-env.test.mjs
npm run lint --prefix backend
npm run build
& 'C:\Program Files\Git\cmd\git.exe' diff --check
```

Earlier local validation was blocked by a local Prisma generation/runtime issue on this checkout, but GitHub CI backend regression passed on the PR before this follow-up commit and will re-run on the updated head:

```text
npm test --prefix backend -- --runInBand
# failed before Jest during prisma generate:
# Error code: P1012
# error: Argument "url" is missing in data source block "db".
```

## Human Verification (required)

- Verified scenarios: settings cache invalidates after direct file rewrite; `writeSettingsFile()` updates runtime-visible settings; clearing `pkpm.cyclePath` makes `config.pkpmCyclePath` empty without restart; dynamic LLM and execution config accessors return updated values; root build succeeds with aligned frontend dependencies.
- Edge cases checked: missing settings file cache path, direct overwrite after module import, same-size rewrite with unchanged mtime, admin-write path, compatibility config getters.
- What you did **not** verify: live PKPM/YJK execution, because that depends on local commercial engine installation/licensing.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: every runtime-facing settings read now performs a lightweight `statSync` plus content fingerprint read on `settings.json` when the file exists, unless the value was just written through `writeSettingsFile()`.
  - Mitigation: unchanged settings are not reparsed, the settings file is tiny, and chat/model/worker operations are far heavier than this filesystem check.


