### PR TITLE
fix(agent): preserve drafts and stabilize tool follow-ups

### DIFF
--- a/backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs
@@ -49,8 +49,9 @@ describe("draft extraction preservation", () => {
     })).toBe(false);
   });
 
-  test("preserves the previous stable draft instead of reporting inferredType missing", async () => {
+  test("preserves the previous stable draft but stays conservative without a plugin", async () => {
     const { buildPreservedDraftExtractionResult } = await import("../../../dist/agent-langgraph/tools.js");
+    const before = Date.now();
     const existingState = {
       inferredType: "beam",
       skillId: "beam",
@@ -84,10 +85,12 @@ describe("draft extraction preservation", () => {
         skillId: "beam",
       }),
       rejectedStructuralTypeMatch: unknownFallbackMatch,
-      canProceed: true,
-      nextAction: "build_model",
+      criticalMissing: ["skillPlugin"],
+      canProceed: false,
+      nextAction: "ask_user_clarification",
     }));
     expect(result.responseJson.criticalMissing).not.toContain("inferredType");
+    expect(result.responseJson.nextState.updatedAt).toBeGreaterThanOrEqual(before);
     expect(result.stateUpdate).toEqual(expect.objectContaining({
       draftState: expect.objectContaining({ inferredType: "beam" }),
       structuralTypeKey: "beam",
@@ -96,6 +99,7 @@ describe("draft extraction preservation", () => {
 
   test("uses the existing draft plugin to keep real missing fields without downgrading inferredType", async () => {
     const { buildPreservedDraftExtractionResult } = await import("../../../dist/agent-langgraph/tools.js");
+    const before = Date.now();
     const existingState = {
       inferredType: "beam",
       skillId: "beam",
@@ -133,5 +137,6 @@ describe("draft extraction preservation", () => {
       }),
     }));
     expect(result.responseJson.criticalMissing).not.toContain("inferredType");
+    expect(result.responseJson.nextState.updatedAt).toBeGreaterThanOrEqual(before);
   });
 });

--- a/backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "@jest/globals";
+
+const unknownFallbackMatch = {
+  key: "unknown",
+  mappedType: "unknown",
+  skillId: "generic",
+  supportLevel: "fallback",
+};
+
+describe("draft extraction preservation", () => {
+  test("detects when an unknown fallback should preserve an existing draft", async () => {
+    const { shouldPreserveExistingDraftState } = await import("../../../dist/agent-langgraph/tools.js");
+
+    expect(shouldPreserveExistingDraftState({
+      inferredType: "beam",
+      skillId: "beam",
+      structuralTypeKey: "beam",
+      lengthM: 10,
+      updatedAt: 0,
+    }, unknownFallbackMatch)).toBe(true);
+
+    expect(shouldPreserveExistingDraftState({
+      inferredType: "unknown",
+      skillId: "generic",
+      structuralTypeKey: "unknown",
+      updatedAt: 0,
+    }, unknownFallbackMatch)).toBe(false);
+
+    expect(shouldPreserveExistingDraftState({
+      inferredType: "beam",
+      skillId: "beam",
+      structuralTypeKey: "beam",
+      updatedAt: 0,
+    }, {
+      key: "frame",
+      mappedType: "frame",
+      skillId: "frame",
+      supportLevel: "supported",
+    })).toBe(false);
+  });
+
+  test("preserves the previous stable draft instead of reporting inferredType missing", async () => {
+    const { buildPreservedDraftExtractionResult } = await import("../../../dist/agent-langgraph/tools.js");
+    const existingState = {
+      inferredType: "beam",
+      skillId: "beam",
+      structuralTypeKey: "beam",
+      lengthM: 10,
+      supportType: "simply-supported",
+      loadKN: 1,
+      loadType: "point",
+      loadPosition: "midspan",
+      updatedAt: 0,
+    };
+
+    const result = buildPreservedDraftExtractionResult({
+      existingState,
+      structuralTypeMatch: unknownFallbackMatch,
+      locale: "zh",
+    });
+
+    expect(result.responseJson).toEqual(expect.objectContaining({
+      nextState: expect.objectContaining({
+        inferredType: "beam",
+        skillId: "beam",
+        structuralTypeKey: "beam",
+        lengthM: 10,
+      }),
+      criticalMissing: [],
+      extractionMode: "preserved",
+      structuralTypeMatch: expect.objectContaining({
+        key: "beam",
+        mappedType: "beam",
+        skillId: "beam",
+      }),
+      rejectedStructuralTypeMatch: unknownFallbackMatch,
+      canProceed: true,
+      nextAction: "build_model",
+    }));
+    expect(result.responseJson.criticalMissing).not.toContain("inferredType");
+    expect(result.stateUpdate).toEqual(expect.objectContaining({
+      draftState: expect.objectContaining({ inferredType: "beam" }),
+      structuralTypeKey: "beam",
+    }));
+  });
+
+  test("uses the existing draft plugin to keep real missing fields without downgrading inferredType", async () => {
+    const { buildPreservedDraftExtractionResult } = await import("../../../dist/agent-langgraph/tools.js");
+    const existingState = {
+      inferredType: "beam",
+      skillId: "beam",
+      structuralTypeKey: "beam",
+      lengthM: 10,
+      updatedAt: 0,
+    };
+    const plugin = {
+      id: "beam",
+      handler: {
+        mergeState(existing, patch) {
+          return { ...existing, ...patch, updatedAt: 1 };
+        },
+        computeMissing() {
+          return { critical: ["loadKN"], optional: [] };
+        },
+      },
+    };
+
+    const result = buildPreservedDraftExtractionResult({
+      existingState,
+      structuralTypeMatch: unknownFallbackMatch,
+      plugin,
+      locale: "en",
+    });
+
+    expect(result.responseJson).toEqual(expect.objectContaining({
+      criticalMissing: ["loadKN"],
+      canProceed: false,
+      nextAction: "ask_user_clarification",
+      structuralTypeMatch: expect.objectContaining({
+        key: "beam",
+        mappedType: "beam",
+        skillId: "beam",
+      }),
+    }));
+    expect(result.responseJson.criticalMissing).not.toContain("inferredType");
+  });
+});

--- a/backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs
@@ -8,6 +8,16 @@ const unknownFallbackMatch = {
 };
 
 describe("draft extraction preservation", () => {
+  test("prefers explicit tool messages over the raw last user message", async () => {
+    const { resolveToolInputMessage } = await import("../../../dist/agent-langgraph/tools.js");
+
+    expect(resolveToolInputMessage(
+      "荷载信息：楼面恒载4.5kN/m²，楼面活载2.0kN/m²",
+      "你说？",
+    )).toBe("荷载信息：楼面恒载4.5kN/m²，楼面活载2.0kN/m²");
+    expect(resolveToolInputMessage("", "继续")).toBe("继续");
+  });
+
   test("detects when an unknown fallback should preserve an existing draft", async () => {
     const { shouldPreserveExistingDraftState } = await import("../../../dist/agent-langgraph/tools.js");
 

--- a/backend/src/agent-langgraph/__tests__/graph-empty-response.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/graph-empty-response.test.mjs
@@ -1,0 +1,45 @@
+import { describe, expect, test } from '@jest/globals';
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+
+describe('agent graph empty final response guard', () => {
+  test('replaces an empty final response after tool results', async () => {
+    const {
+      buildEmptyFinalResponseFallback,
+      shouldReplaceEmptyFinalResponse,
+    } = await import('../../../dist/agent-langgraph/graph.js');
+
+    const toolMessage = new ToolMessage({
+      name: 'memory',
+      tool_call_id: 'call-memory',
+      content: '{"success":true,"entries":[]}',
+    });
+    const emptyResponse = new AIMessage('');
+
+    expect(shouldReplaceEmptyFinalResponse(emptyResponse, [toolMessage])).toBe(true);
+    expect(buildEmptyFinalResponseFallback('zh', ['glob_files', 'memory'])).toContain('本轮工具已执行完成');
+    expect(buildEmptyFinalResponseFallback('zh', ['glob_files', 'memory'])).toContain('glob_files, memory');
+  });
+
+  test('keeps normal content and tool-call responses unchanged', async () => {
+    const { shouldReplaceEmptyFinalResponse } = await import('../../../dist/agent-langgraph/graph.js');
+    const toolMessage = new ToolMessage({
+      name: 'memory',
+      tool_call_id: 'call-memory',
+      content: '{}',
+    });
+
+    expect(shouldReplaceEmptyFinalResponse(new AIMessage('done'), [toolMessage])).toBe(false);
+    expect(shouldReplaceEmptyFinalResponse(new AIMessage(''), [])).toBe(false);
+
+    const responseWithToolCall = new AIMessage({
+      content: '',
+      tool_calls: [{
+        name: 'memory',
+        args: { action: 'list' },
+        id: 'call-memory',
+        type: 'tool_call',
+      }],
+    });
+    expect(shouldReplaceEmptyFinalResponse(responseWithToolCall, [toolMessage])).toBe(false);
+  });
+});

--- a/backend/src/agent-langgraph/graph.ts
+++ b/backend/src/agent-langgraph/graph.ts
@@ -117,7 +117,11 @@ function createCallModelNode(
   ): Promise<Partial<AgentState>> {
     const log = getAgentLogger(config);
     const configurable = config.configurable as Partial<AgentConfigurable> | undefined;
-    const model = createChatModel(0);
+    // LangGraph's `messages` stream mode installs a callback handler that
+    // prefers streaming. LangChain may then make `invoke()` return message
+    // chunks; GLM-compatible streaming can yield empty/generic chunks after
+    // tool calls. Keep graph state on complete AIMessage instances.
+    const model = createChatModel(0, { disableStreaming: true });
     if (!model) {
       return {
         messages: [

--- a/backend/src/agent-langgraph/graph.ts
+++ b/backend/src/agent-langgraph/graph.ts
@@ -44,6 +44,65 @@ function getAgentLogger(config: LangGraphRunnableConfig) {
 
 const MAX_TOOL_CALLS_PER_TURN = 15;
 
+function getMessageType(message: BaseMessage): string | null {
+  return typeof (message as any)._getType === 'function'
+    ? (message as any)._getType()
+    : null;
+}
+
+function extractMessageText(message: BaseMessage): string {
+  const content = message.content;
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (typeof block === 'string') return block;
+        if (block && typeof block === 'object' && 'text' in block) {
+          return String((block as { text?: unknown }).text ?? '');
+        }
+        return '';
+      })
+      .join('');
+  }
+  return content == null ? '' : JSON.stringify(content);
+}
+
+function getToolName(message: BaseMessage): string | undefined {
+  return typeof (message as any).name === 'string' && (message as any).name.trim().length > 0
+    ? (message as any).name
+    : undefined;
+}
+
+export function buildEmptyFinalResponseFallback(
+  locale: 'zh' | 'en',
+  toolNames: string[],
+): string {
+  const tools = [...new Set(toolNames)].filter(Boolean).join(', ');
+  if (locale === 'zh') {
+    return tools
+      ? `本轮工具已执行完成（${tools}），但模型没有生成最终说明。为避免会话静默结束，请基于这些工具结果继续检查当前模型、荷载或分析状态。`
+      : '模型没有生成有效回复。为避免会话静默结束，请继续说明你希望检查的结构、荷载或分析状态。';
+  }
+  return tools
+    ? `The tools for this turn completed (${tools}), but the model did not produce a final explanation. To avoid a silent stop, continue from these tool results and inspect the current model, loads, or analysis state.`
+    : 'The model did not produce a valid response. To avoid a silent stop, please continue with the structure, load, or analysis state you want to inspect.';
+}
+
+export function shouldReplaceEmptyFinalResponse(response: BaseMessage, currentTurnMessages: BaseMessage[]): boolean {
+  const hasToolCalls = 'tool_calls' in response
+    && Array.isArray((response as any).tool_calls)
+    && (response as any).tool_calls.length > 0;
+  if (hasToolCalls) {
+    return false;
+  }
+  if (extractMessageText(response).trim().length > 0) {
+    return false;
+  }
+  return currentTurnMessages.some((message) => getMessageType(message) === 'tool');
+}
+
 // ---------------------------------------------------------------------------
 // Node: agent (LLM reasoning)
 // ---------------------------------------------------------------------------
@@ -215,6 +274,15 @@ function createCallModelNode(
 
     const hasToolCalls = 'tool_calls' in response && Array.isArray((response as any).tool_calls) && (response as any).tool_calls.length > 0;
     log.info({ node: 'agent', durationMs: llmDuration, hasToolCalls }, 'agent node LLM response received');
+
+    if (shouldReplaceEmptyFinalResponse(response, currentTurnMessages)) {
+      const toolNames = currentTurnMessages
+        .filter((message) => getMessageType(message) === 'tool')
+        .map((message) => getToolName(message))
+        .filter((name): name is string => !!name);
+      log.warn({ node: 'agent', toolNames }, 'empty final LLM response after tool calls');
+      return { messages: [new AIMessage(buildEmptyFinalResponseFallback(state.locale, toolNames))] };
+    }
 
     return { messages: [response] };
   };

--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -39,6 +39,14 @@ function getToolCallId(config: LangGraphRunnableConfig): string {
   return id;
 }
 
+export function resolveToolInputMessage(inputMessage: string | undefined, lastUserMessage: string | undefined): string {
+  const explicitMessage = inputMessage?.trim();
+  if (explicitMessage) {
+    return explicitMessage;
+  }
+  return lastUserMessage || '';
+}
+
 /**
  * Create a Command that updates graph state channels AND adds a ToolMessage.
  * This is the recommended LangGraph pattern for tools that produce artifacts.
@@ -425,7 +433,7 @@ export function createDetectStructureTypeTool(skillRuntime: AgentSkillRuntime) {
       const toolCallId = getToolCallId(config);
       const skillIds = configurable.skillScope;
       const locale = (input.locale === 'en' ? 'en' : (state?.locale || 'zh')) as 'zh' | 'en';
-      const message = state?.lastUserMessage || input.message || '';
+      const message = resolveToolInputMessage(input.message, state?.lastUserMessage);
       try {
         const match = await skillRuntime.detectStructuralType(
           message,
@@ -477,7 +485,7 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
       const existingState = state?.draftState || undefined;
       const skillIds = configurable.skillScope;
       const locale = (input.locale === 'en' ? 'en' : (state?.locale || 'zh')) as 'zh' | 'en';
-      const message = state?.lastUserMessage || input.message || '';
+      const message = resolveToolInputMessage(input.message, state?.lastUserMessage);
 
       try {
         // Step 1: Detect structural type

--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -86,6 +86,18 @@ function buildDraftProgress(
   };
 }
 
+function buildPluginUnavailableProgress(
+  locale: 'zh' | 'en',
+): { canProceed: false; nextAction: 'ask_user_clarification'; reason: string } {
+  return {
+    canProceed: false,
+    nextAction: 'ask_user_clarification',
+    reason: locale === 'zh'
+      ? '已保留上一版有效草稿，但无法解析对应结构类型插件，不能可靠计算缺失字段或继续建模。请先确认结构类型或恢复可用 skillScope。'
+      : 'The previous valid draft was preserved, but its structure-type plugin could not be resolved. Missing fields cannot be computed reliably, so ask the user to confirm the structural type or restore the available skill scope before building a model.',
+  };
+}
+
 function hasStableDraftType(state: DraftState | null | undefined): state is DraftState {
   return !!state?.inferredType && state.inferredType !== 'unknown';
 }
@@ -122,12 +134,16 @@ export function buildPreservedDraftExtractionResult(args: {
   stateUpdate: Partial<AgentState>;
 } {
   const plugin = args.plugin ?? null;
-  const nextState = plugin
+  const mergedState = plugin
     ? plugin.handler.mergeState(args.existingState, {})
-    : { ...args.existingState, updatedAt: Date.now() };
+    : args.existingState;
+  const nextState = { ...mergedState, updatedAt: Date.now() };
   const missing = plugin
     ? plugin.handler.computeMissing(nextState, 'execution')
-    : { critical: [], optional: [] };
+    : { critical: ['skillPlugin'], optional: [] };
+  const progress = plugin
+    ? buildDraftProgress(args.locale, missing.critical)
+    : buildPluginUnavailableProgress(args.locale);
   const preservedMatch = buildPreservedStructuralTypeMatch(nextState, plugin);
   const preservationWarning = args.locale === 'zh'
     ? '本轮描述未能稳定识别为新的结构类型，已保留上一版有效草稿，避免将状态覆盖为 unknown/generic。'
@@ -143,7 +159,7 @@ export function buildPreservedDraftExtractionResult(args: {
       skillId: preservedMatch.skillId,
       extractionMode: 'preserved',
       preservationWarning,
-      ...buildDraftProgress(args.locale, missing.critical),
+      ...progress,
     },
     stateUpdate: {
       draftState: nextState,

--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -21,6 +21,7 @@ import { logger } from '../utils/logger.js';
 import { getLogger, logToolCall } from '../utils/agent-logger.js';
 import type { AgentState } from './state.js';
 import type { AgentConfigurable } from './configurable.js';
+import type { AgentSkillPlugin, DraftState, StructuralTypeMatch } from '../agent-runtime/types.js';
 import { runPkpmCalcbook } from '../agent-skills/report-export/calculation-book/pkpm-calcbook/runner.js';
 // ---------------------------------------------------------------------------
 // Helpers
@@ -74,6 +75,72 @@ function buildDraftProgress(
     reason: locale === 'zh'
       ? `草稿仍缺少关键参数：${missingText}。需要继续向用户澄清，不能直接构建模型或写入 memory。`
       : `The draft is still missing critical parameters: ${missingText}. Continue by asking the user for clarification; do not build the model or store draft values in memory.`,
+  };
+}
+
+function hasStableDraftType(state: DraftState | null | undefined): state is DraftState {
+  return !!state?.inferredType && state.inferredType !== 'unknown';
+}
+
+export function shouldPreserveExistingDraftState(
+  existingState: DraftState | null | undefined,
+  structuralTypeMatch: StructuralTypeMatch,
+): existingState is DraftState {
+  return hasStableDraftType(existingState)
+    && structuralTypeMatch.key === 'unknown'
+    && structuralTypeMatch.mappedType === 'unknown';
+}
+
+function buildPreservedStructuralTypeMatch(
+  state: DraftState,
+  plugin: AgentSkillPlugin | null | undefined,
+): StructuralTypeMatch {
+  return {
+    key: state.structuralTypeKey ?? state.inferredType,
+    mappedType: state.inferredType,
+    skillId: state.skillId ?? plugin?.id,
+    supportLevel: state.supportLevel ?? 'supported',
+    supportNote: state.supportNote,
+  };
+}
+
+export function buildPreservedDraftExtractionResult(args: {
+  existingState: DraftState;
+  structuralTypeMatch: StructuralTypeMatch;
+  plugin?: AgentSkillPlugin | null;
+  locale: 'zh' | 'en';
+}): {
+  responseJson: Record<string, unknown>;
+  stateUpdate: Partial<AgentState>;
+} {
+  const plugin = args.plugin ?? null;
+  const nextState = plugin
+    ? plugin.handler.mergeState(args.existingState, {})
+    : { ...args.existingState, updatedAt: Date.now() };
+  const missing = plugin
+    ? plugin.handler.computeMissing(nextState, 'execution')
+    : { critical: [], optional: [] };
+  const preservedMatch = buildPreservedStructuralTypeMatch(nextState, plugin);
+  const preservationWarning = args.locale === 'zh'
+    ? '本轮描述未能稳定识别为新的结构类型，已保留上一版有效草稿，避免将状态覆盖为 unknown/generic。'
+    : 'The current message was not recognized as a stable new structural type, so the previous valid draft was preserved instead of being overwritten as unknown/generic.';
+
+  return {
+    responseJson: {
+      nextState,
+      criticalMissing: missing.critical,
+      optionalMissing: missing.optional,
+      structuralTypeMatch: preservedMatch,
+      rejectedStructuralTypeMatch: args.structuralTypeMatch,
+      skillId: preservedMatch.skillId,
+      extractionMode: 'preserved',
+      preservationWarning,
+      ...buildDraftProgress(args.locale, missing.critical),
+    },
+    stateUpdate: {
+      draftState: nextState,
+      structuralTypeKey: preservedMatch.key,
+    },
   };
 }
 
@@ -323,6 +390,27 @@ export function buildModelToolStateUpdate(
   return { model };
 }
 
+async function resolveExistingDraftPlugin(
+  skillRuntime: AgentSkillRuntime,
+  existingState: DraftState,
+  skillIds: string[] | undefined,
+  fallbackPlugin: AgentSkillPlugin | null,
+): Promise<AgentSkillPlugin | null> {
+  const pluginBySkill = existingState.skillId
+    ? await skillRuntime.resolvePluginForType(existingState.skillId, skillIds)
+    : null;
+  if (pluginBySkill) {
+    return pluginBySkill;
+  }
+
+  const pluginByType = await skillRuntime.resolvePluginForType(existingState.inferredType, skillIds);
+  if (pluginByType) {
+    return pluginByType;
+  }
+
+  return fallbackPlugin?.id === 'generic' ? fallbackPlugin : null;
+}
+
 // ---------------------------------------------------------------------------
 // Engineering tools (wrap AgentSkillRuntime)
 // ---------------------------------------------------------------------------
@@ -396,6 +484,40 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
         const match = await skillRuntime.detectStructuralType(
           message, locale, existingState, skillIds,
         );
+        const matchedPlugin = match.skillId
+          ? await skillRuntime.resolvePluginForType(match.skillId, skillIds)
+          : null;
+
+        if (shouldPreserveExistingDraftState(existingState, match)) {
+          const preservationPlugin = await resolveExistingDraftPlugin(
+            skillRuntime,
+            existingState,
+            skillIds,
+            matchedPlugin,
+          );
+          const preserved = buildPreservedDraftExtractionResult({
+            existingState,
+            structuralTypeMatch: match,
+            plugin: preservationPlugin,
+            locale,
+          });
+          logToolCall(log, {
+            tool: 'extract_draft_params',
+            durationMs: Date.now() - start,
+            extra: {
+              preservedExistingDraft: true,
+              previousSkillId: existingState.skillId,
+              rejectedSkillId: match.skillId,
+              rejectedKey: match.key,
+            },
+          });
+          return toolResult(
+            toolCallId,
+            'extract_draft_params',
+            JSON.stringify(preserved.responseJson),
+            preserved.stateUpdate,
+          );
+        }
 
         // Early return when no skill matched
         if (!match.skillId) {
@@ -422,7 +544,7 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
         }
 
         // Step 2: Resolve plugin
-        const plugin = await skillRuntime.resolvePluginForType(match.skillId, skillIds);
+        const plugin = matchedPlugin;
         if (!plugin) {
           const nextState = existingState || { inferredType: 'unknown' as const, updatedAt: Date.now() };
           const responseJson = {
@@ -439,9 +561,10 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
         }
 
         // Generic skill: deterministic path (no LLM extraction needed)
-        if (plugin.id === 'generic' && existingState?.inferredType && existingState.inferredType !== 'unknown') {
+        const stableExistingState = hasStableDraftType(existingState) ? existingState : undefined;
+        if (plugin.id === 'generic' && stableExistingState) {
           const { withStructuralTypeState } = await import('../agent-runtime/plugin-helpers.js');
-          const nextState = withStructuralTypeState(plugin.handler.mergeState(existingState, {}), match);
+          const nextState = withStructuralTypeState(plugin.handler.mergeState(stableExistingState, {}), match);
           const missing = plugin.handler.computeMissing(nextState, 'execution');
           const responseJson = {
             nextState,

--- a/backend/src/utils/__tests__/llm-options.test.mjs
+++ b/backend/src/utils/__tests__/llm-options.test.mjs
@@ -1,0 +1,29 @@
+import { describe, expect, test } from '@jest/globals';
+
+const baseConfig = {
+  llmApiKey: 'test-key',
+  llmModel: 'glm-5-turbo',
+  llmTimeoutMs: 30000,
+  llmMaxRetries: 1,
+  llmBaseUrl: 'https://example.com/v1',
+};
+
+describe('LLM model options', () => {
+  test('keeps streaming available by default', async () => {
+    const { buildChatModelOptions } = await import('../../../dist/utils/llm.js');
+
+    const options = buildChatModelOptions(baseConfig, 0.2);
+
+    expect(options.disableStreaming).toBe(false);
+  });
+
+  test('can disable LangChain invoke streaming for graph-state correctness', async () => {
+    const { buildChatModelOptions } = await import('../../../dist/utils/llm.js');
+
+    const options = buildChatModelOptions(baseConfig, 0, { disableStreaming: true });
+
+    expect(options.disableStreaming).toBe(true);
+    expect(options.modelName).toBe('glm-5-turbo');
+    expect(options.configuration.baseURL).toBe('https://example.com/v1');
+  });
+});

--- a/backend/src/utils/__tests__/llm-options.test.mjs
+++ b/backend/src/utils/__tests__/llm-options.test.mjs
@@ -15,6 +15,7 @@ describe('LLM model options', () => {
     const options = buildChatModelOptions(baseConfig, 0.2);
 
     expect(options.disableStreaming).toBe(false);
+    expect(options.streaming).toBeUndefined();
   });
 
   test('can disable LangChain invoke streaming for graph-state correctness', async () => {
@@ -23,6 +24,7 @@ describe('LLM model options', () => {
     const options = buildChatModelOptions(baseConfig, 0, { disableStreaming: true });
 
     expect(options.disableStreaming).toBe(true);
+    expect(options.streaming).toBe(false);
     expect(options.modelName).toBe('glm-5-turbo');
     expect(options.configuration.baseURL).toBe('https://example.com/v1');
   });

--- a/backend/src/utils/llm.ts
+++ b/backend/src/utils/llm.ts
@@ -9,26 +9,38 @@ type ChatModelConfigLike = Pick<
   'llmApiKey' | 'llmModel' | 'llmTimeoutMs' | 'llmMaxRetries' | 'llmBaseUrl'
 >;
 
-export function buildChatModelOptions(modelConfig: ChatModelConfigLike, temperature: number) {
+export interface ChatModelRuntimeOptions {
+  disableStreaming?: boolean;
+}
+
+export function buildChatModelOptions(
+  modelConfig: ChatModelConfigLike,
+  temperature: number,
+  runtimeOptions: ChatModelRuntimeOptions = {},
+) {
   return {
     modelName: modelConfig.llmModel,
     temperature,
     timeout: modelConfig.llmTimeoutMs,
     maxRetries: modelConfig.llmMaxRetries,
     apiKey: modelConfig.llmApiKey,
+    disableStreaming: runtimeOptions.disableStreaming ?? false,
     configuration: {
       baseURL: modelConfig.llmBaseUrl,
     },
   };
 }
 
-export function createChatModel(temperature: number): ChatOpenAI | null {
+export function createChatModel(
+  temperature: number,
+  runtimeOptions: ChatModelRuntimeOptions = {},
+): ChatOpenAI | null {
   const effectiveSettings = getEffectiveLlmSettings();
   if (!effectiveSettings.llmApiKey.trim()) {
     return null;
   }
 
-  const model = new ChatOpenAI(buildChatModelOptions(effectiveSettings, temperature));
+  const model = new ChatOpenAI(buildChatModelOptions(effectiveSettings, temperature, runtimeOptions));
 
   return wrapWithLlmLogging(model);
 }

--- a/backend/src/utils/llm.ts
+++ b/backend/src/utils/llm.ts
@@ -18,13 +18,15 @@ export function buildChatModelOptions(
   temperature: number,
   runtimeOptions: ChatModelRuntimeOptions = {},
 ) {
+  const disableStreaming = runtimeOptions.disableStreaming ?? false;
   return {
     modelName: modelConfig.llmModel,
     temperature,
     timeout: modelConfig.llmTimeoutMs,
     maxRetries: modelConfig.llmMaxRetries,
     apiKey: modelConfig.llmApiKey,
-    disableStreaming: runtimeOptions.disableStreaming ?? false,
+    disableStreaming,
+    ...(disableStreaming ? { streaming: false } : {}),
     configuration: {
       baseURL: modelConfig.llmBaseUrl,
     },


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: failed or low-confidence re-extraction could overwrite a previously valid draft with `unknown/generic`, and follow-up tool turns could silently end after tools because streaming message chunks were stored as final graph messages.
- Why it matters: users could see a valid structural model degrade into a 0-node/0-element model, lose explicit follow-up tool input, or get no final explanation after tool execution.
- What changed: preserve valid draft state on unknown fallback, reject empty generic models, prefer explicit tool messages over raw last-user follow-ups, normalize/recover empty tool-final replies, and disable internal LangChain streaming for the agent graph state so final messages are complete `AIMessage` instances.
- What did NOT change (scope boundary): no frontend behavior, schema, persistence, permissions, or analysis engine logic was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #246
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the agent recovery path treated fallback `unknown/generic` extraction as authoritative and allowed it to replace valid draft state; additionally, graph `messages` stream mode made LangChain prefer streaming inside `model.invoke()`, so GLM-compatible streaming chunks could be written into graph state as blank/generic final messages.
- Missing detection / guardrail: no guard prevented low-confidence extraction from deleting valid draft fields; generic `build_model` considered empty models successful; explicit tool input could be overwritten by `lastUserMessage`; graph state did not force complete non-streaming model messages.
- Prior context (`git blame`, prior PR, issue, or refactor if known): reported in #246 from repeated `extract_draft_params` / `build_model` recovery attempts after analysis failure.
- Why this regressed now: issue #246 exposed the recovery path with follow-up turns such as retry/clarification messages, where the latest user utterance was not a complete structural request.
- If unknown, what was ruled out: ruled out frontend rendering as the blank-message source; persisted checkpoints already contained empty `ChatMessageChunk` final messages.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs`, `backend/src/agent-langgraph/__tests__/graph-empty-response.test.mjs`, `backend/src/utils/__tests__/llm-options.test.mjs`
- Scenario the test should lock in: valid draft state must survive `unknown/generic` fallback; generic empty models must fail; explicit tool messages must be used; blank final responses after tools must be guarded; graph LLM construction can disable internal streaming.
- Why this is the smallest reliable guardrail: these tests cover the state transitions and model options directly without requiring a live LLM provider.
- Existing test that already covers this (if any): existing stream contract coverage remains relevant and was rerun.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Follow-up recovery should keep the last valid structural draft instead of degrading to `unknown/generic`.
- Empty generic models now fail instead of reporting `success: true` with 0 nodes / 0 elements.
- Tool follow-ups that carry explicit synthetic context should no longer be replaced by vague user messages such as “你说？”.
- After tools run, the conversation should not silently end with a blank final assistant message.

## Diagram (if applicable)

```text
Before:
[user follow-up] -> [fallback extraction unknown/generic] -> [valid draft overwritten]
[tools complete] -> [streaming ChatMessageChunk(content="")] -> [silent final response]

After:
[user follow-up] -> [fallback extraction warning] -> [valid draft preserved]
[tools complete] -> [complete non-streaming AIMessage] -> [visible final response]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows / PowerShell local dev workspace
- Runtime/container: Node backend test runner
- Model/provider: GLM-compatible OpenAI endpoint was the reported runtime; tests use no live provider
- Integration/channel (if any): LangGraph chat stream
- Relevant config (redacted): API keys redacted; default backend test configuration

### Steps

1. Start from a valid structural draft and trigger a failed/low-confidence re-extraction with a vague follow-up.
2. Call `build_model` after the fallback extraction.
3. Execute a tool-follow-up turn where the tool input carries explicit context while `lastUserMessage` is vague.
4. Complete a tool turn where the final LLM response may be empty.

### Expected

- Existing valid draft fields remain available.
- Empty generic models are not reported as successful.
- Explicit tool input is preserved.
- Final assistant response is visible and graph state stores complete assistant messages.

### Actual

- Covered by regression tests added in this PR.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run successfully:

```text
npm test --prefix backend -- --runInBand src/utils/__tests__/llm-options.test.mjs src/agent-langgraph/__tests__/graph-empty-response.test.mjs src/agent-langgraph/__tests__/draft-preservation.test.mjs src/agent-langgraph/__tests__/streaming.test.mjs
npm run lint --prefix backend
node tests/runner.mjs validate validate-chat-stream-contract
npm test --prefix backend -- --runInBand
```

## Human Verification (required)

- Verified scenarios: target backend regressions, backend lint, chat stream contract, full backend Jest suite.
- Edge cases checked: low-confidence fallback over valid state, empty generic build result, explicit tool input versus vague last user message, blank final response after tool calls, graph LLM `disableStreaming` option.
- What you did **not** verify: live browser UI replay and live production LLM provider replay after the fix.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: disabling internal streaming for the agent graph may reduce token-by-token final-answer streaming from that node.
  - Mitigation: chat stream contract still passes; tool/update events continue flowing, and graph state correctness is prioritized. If needed, token display streaming can be reintroduced separately without writing chunks into persistent graph state.