### PR TITLE
fix(cli): sync stale analysis pip requirements

### DIFF
--- a/backend/tests/analysis-python-setup.test.mjs
+++ b/backend/tests/analysis-python-setup.test.mjs
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, jest, test } from '@jest/globals';
 import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 const repoRoot = path.resolve(process.cwd(), '..');
@@ -42,6 +44,7 @@ describe('analysis python setup', () => {
       }
       return false;
     });
+    jest.spyOn(runtime, 'pythonRequirementsSatisfied').mockResolvedValue(true);
 
     await cliMain.main(['setup-analysis-python'], { rootDir: repoRoot });
 
@@ -61,5 +64,93 @@ describe('analysis python setup', () => {
       ]),
       expect.objectContaining({ env }),
     );
+  });
+
+  test('reinstalls analysis requirements when package versions drift', async () => {
+    const paths = runtime.resolvePaths(repoRoot);
+    const env = {
+      ...process.env,
+      SCLAW_PROFILE: 'test',
+      SCLAW_PROGRAM_NAME: 'sclaw',
+    };
+    let requirementsSynced = false;
+    const runCommand = jest.spyOn(runtime, 'runCommand').mockImplementation(async (command, args) => {
+      if (command === 'uv' && Array.isArray(args) && args.includes('pip') && args.includes('install')) {
+        requirementsSynced = true;
+      }
+    });
+
+    jest.spyOn(runtime, 'loadProjectEnvironment').mockReturnValue({
+      paths,
+      env,
+      dotEnv: {},
+    });
+    jest.spyOn(runtime, 'resolveAnalysisPython').mockReturnValue('/virtual/backend/.venv/bin/python');
+    jest.spyOn(runtime, 'hasCommand').mockReturnValue(true);
+    jest.spyOn(runtime, 'pythonModuleExists').mockResolvedValue(true);
+    jest.spyOn(runtime, 'pythonRequirementsSatisfied').mockImplementation(async () => requirementsSynced);
+
+    await cliMain.main(['setup-analysis-python'], { rootDir: repoRoot });
+
+    expect(runCommand).not.toHaveBeenCalledWith(
+      'uv',
+      expect.arrayContaining(['venv']),
+    );
+    expect(runCommand).toHaveBeenCalledWith(
+      'uv',
+      expect.arrayContaining([
+        'pip',
+        'install',
+        '--python',
+        '/virtual/backend/.venv/bin/python',
+        '-r',
+        paths.analysisRequirementsFile,
+      ]),
+      expect.objectContaining({ env }),
+    );
+  });
+
+  test('parses inline comments in analysis Python requirements', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sclaw-requirements-'));
+    const requirementsFile = path.join(tempDir, 'requirements.txt');
+    const sysPlatform =
+      process.platform === 'win32'
+        ? 'win32'
+        : process.platform === 'darwin'
+          ? 'darwin'
+          : 'linux';
+
+    try {
+      fs.writeFileSync(
+        requirementsFile,
+        [
+          '# comment',
+          'numpy==1.26.4 # pinned dependency',
+          `platformpkg==2.0; sys_platform == "${sysPlatform}" # platform marker`,
+          `skippedpkg==1.0; sys_platform == "not-${sysPlatform}" # skipped marker`,
+          '-r nested.txt',
+          '',
+        ].join('\n'),
+        'utf8',
+      );
+
+      expect(runtime.parsePythonRequirements(requirementsFile)).toEqual([
+        { name: 'numpy', version: '1.26.4' },
+        { name: 'platformpkg', version: '2.0' },
+      ]);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('builds one Python metadata check for all requirements', () => {
+    const script = runtime.buildPythonRequirementsCheckScript([
+      { name: 'PyYAML', version: '6.0.3' },
+      { name: 'pkpm-api', version: null },
+    ]);
+
+    expect(script).toContain('json.loads');
+    expect(script).toContain('expected_version is not None');
+    expect(script).toContain('\\"version\\":null');
   });
 });

--- a/scripts/cli/main.js
+++ b/scripts/cli/main.js
@@ -258,6 +258,26 @@ async function ensureNpmDependencies(projectDir, projectName, packageNames = [])
   }
 }
 
+async function getMissingAnalysisPythonModules(pythonPath) {
+  const moduleStates = await Promise.all(
+    ANALYSIS_REQUIRED_PYTHON_MODULES.map(async (moduleName) => [
+      moduleName,
+      await runtime.pythonModuleExists(pythonPath, moduleName),
+    ]),
+  );
+  return moduleStates
+    .filter(([, present]) => !present)
+    .map(([moduleName]) => moduleName);
+}
+
+async function analysisPythonEnvironmentReady(pythonPath, requirementsFile) {
+  const missingModules = await getMissingAnalysisPythonModules(pythonPath);
+  if (missingModules.length > 0) {
+    return false;
+  }
+  return runtime.pythonRequirementsSatisfied(pythonPath, requirementsFile);
+}
+
 async function ensureAnalysisPython(rootDir, env) {
   const { paths } = runtime.loadProjectEnvironment(rootDir, () => {}, {
     profile: env.SCLAW_PROFILE,
@@ -268,13 +288,11 @@ async function ensureAnalysisPython(rootDir, env) {
   }
 
   const currentPython = runtime.resolveAnalysisPython(rootDir, env);
-  if (currentPython) {
-    const currentModuleStates = await Promise.all(
-      ANALYSIS_REQUIRED_PYTHON_MODULES.map(async (moduleName) => [moduleName, await runtime.pythonModuleExists(currentPython, moduleName)]),
-    );
-    if (currentModuleStates.every(([, present]) => present)) {
-      return currentPython;
-    }
+  if (
+    currentPython &&
+    await analysisPythonEnvironmentReady(currentPython, paths.analysisRequirementsFile)
+  ) {
+    return currentPython;
   }
 
   await ensureUv(rootDir);
@@ -318,14 +336,12 @@ async function ensureAnalysisPython(rootDir, env) {
     env,
   });
 
-  const installedModuleStates = await Promise.all(
-    ANALYSIS_REQUIRED_PYTHON_MODULES.map(async (moduleName) => [moduleName, await runtime.pythonModuleExists(resolvedPython, moduleName)]),
-  );
-  const missingModules = installedModuleStates
-    .filter(([, present]) => !present)
-    .map(([moduleName]) => moduleName);
+  const missingModules = await getMissingAnalysisPythonModules(resolvedPython);
   if (missingModules.length > 0) {
     throw new Error(`Python venv is present but missing required analysis modules: ${missingModules.join(", ")}.`);
+  }
+  if (!await runtime.pythonRequirementsSatisfied(resolvedPython, paths.analysisRequirementsFile)) {
+    throw new Error("Python venv is present but analysis requirements are not synchronized.");
   }
 
   return resolvedPython;

--- a/scripts/cli/runtime.js
+++ b/scripts/cli/runtime.js
@@ -468,6 +468,110 @@ function installedPackagesMatchLock(projectDir, packageNames) {
   });
 }
 
+function currentPythonSysPlatform() {
+  if (process.platform === "win32") {
+    return "win32";
+  }
+  if (process.platform === "darwin") {
+    return "darwin";
+  }
+  return "linux";
+}
+
+function pythonRequirementMarkerApplies(marker) {
+  const normalized = String(marker || "").trim();
+  if (!normalized) {
+    return true;
+  }
+
+  const sysPlatform = currentPythonSysPlatform();
+  const equalityMatch = normalized.match(/^sys_platform\s*==\s*["']([^"']+)["']$/u);
+  if (equalityMatch) {
+    return sysPlatform === equalityMatch[1];
+  }
+
+  const inequalityMatch = normalized.match(/^sys_platform\s*!=\s*["']([^"']+)["']$/u);
+  if (inequalityMatch) {
+    return sysPlatform !== inequalityMatch[1];
+  }
+
+  return true;
+}
+
+function parsePythonRequirements(requirementsFile) {
+  if (!pathExists(requirementsFile)) {
+    return [];
+  }
+
+  const requirements = [];
+  for (const rawLine of fs.readFileSync(requirementsFile, "utf8").split(/\r?\n/u)) {
+    const line = rawLine.trim().split("#")[0].trim();
+    if (!line || line.startsWith("-")) {
+      continue;
+    }
+
+    const [rawRequirement, rawMarker = ""] = line.split(";", 2);
+    if (!pythonRequirementMarkerApplies(rawMarker)) {
+      continue;
+    }
+
+    const requirement = rawRequirement.trim();
+    const pinnedMatch = requirement.match(/^([A-Za-z0-9_.-]+)\s*==\s*([^\s]+)$/u);
+    if (pinnedMatch) {
+      requirements.push({
+        name: pinnedMatch[1],
+        version: pinnedMatch[2],
+      });
+      continue;
+    }
+
+    const packageMatch = requirement.match(/^([A-Za-z0-9_.-]+)/u);
+    if (packageMatch) {
+      requirements.push({
+        name: packageMatch[1],
+        version: null,
+      });
+    }
+  }
+  return requirements;
+}
+
+function buildPythonRequirementsCheckScript(requirements) {
+  return [
+    "import importlib.metadata as metadata, json, sys",
+    `requirements = json.loads(${JSON.stringify(JSON.stringify(requirements))})`,
+    "for requirement in requirements:",
+    "    try:",
+    "        installed_version = metadata.version(requirement['name'])",
+    "    except metadata.PackageNotFoundError:",
+    "        sys.exit(1)",
+    "    expected_version = requirement.get('version')",
+    "    if expected_version is not None and installed_version != expected_version:",
+    "        sys.exit(1)",
+    "sys.exit(0)",
+  ].join("\n");
+}
+
+async function pythonRequirementsSatisfied(pythonPath, requirementsFile) {
+  if (!pythonPath || !pathExists(pythonPath)) {
+    return false;
+  }
+
+  const requirements = parsePythonRequirements(requirementsFile);
+  if (requirements.length === 0) {
+    return true;
+  }
+
+  try {
+    await runCommand(pythonPath, ["-c", buildPythonRequirementsCheckScript(requirements)], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function getNpmCommand() {
   return isWindows() ? "npm.cmd" : "npm";
 }
@@ -874,6 +978,7 @@ module.exports = {
   assertSqliteDatabaseUrl,
   buildScopedSqliteDatabaseUrl,
   buildAnalysisEnvironment,
+  buildPythonRequirementsCheckScript,
   ensureDirectory,
   ensureFileFromExample,
   ensureLocalSqliteConfig,
@@ -896,7 +1001,9 @@ module.exports = {
   parseDotEnv,
   pathExists,
   pidFilePath,
+  parsePythonRequirements,
   pythonModuleExists,
+  pythonRequirementsSatisfied,
   quoteShellArgument,
   readDotEnv,
   readTrackedPid,


### PR DESCRIPTION
## Summary

- Problem: `sclaw doctor` considered the analysis Python venv healthy when a couple of imports existed, so stale pinned pip packages were not refreshed after `requirements.txt` changed.
- Why it matters: users could keep running an outdated `~/.structureclaw/.venv`, producing inconsistent analysis/runtime behavior after dependency updates.
- What changed: the CLI now parses applicable analysis requirements, checks installed package metadata and pinned versions, and reruns `uv pip install -r requirements.txt` when packages are missing or stale.
- What did NOT change (scope boundary): no changes to analysis runtime behavior, dependency versions, frontend, backend API contracts, or the default venv location.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #221
- Related #218
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `ensureAnalysisPython` only checked whether required import modules like `uvicorn` and `yaml` existed, not whether packages from `backend/src/agent-skills/analysis/runtime/requirements.txt` matched the expected pinned versions.
- Missing detection / guardrail: there was no guardrail for requirement-version drift in an existing analysis venv.
- Prior context (`git blame`, prior PR, issue, or refactor if known): tracked from #210 and parent issue #218.
- Why this regressed now: Python dependency updates could change `requirements.txt` while an existing venv still had importable but stale packages.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/tests/analysis-python-setup.test.mjs`.
- Scenario the test should lock in: when imports are present but requirements are not satisfied, `setup-analysis-python` / `doctor` reruns `uv pip install -r` without recreating the venv.
- Why this is the smallest reliable guardrail: it exercises the CLI decision point directly with mocked runtime checks and avoids creating a real Python venv in unit tests.
- Existing test that already covers this (if any): the existing missing-`yaml` test covered missing imports, not stale package versions.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`sclaw doctor` and `sclaw setup-analysis-python` now resync analysis pip requirements when an existing venv has missing or stale packages. No config changes.

## Diagram (if applicable)

```text
Before:
[user action] -> [old state]

After:
[user action] -> [new state] -> [result]
```

```text
Before:
[sclaw doctor] -> [uvicorn/yaml importable] -> [skip pip install even if pinned package is stale]

After:
[sclaw doctor] -> [imports present] -> [requirements metadata check] -> [resync when missing/stale]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: the existing `uv pip install -r` path may now run when stale requirements are detected. The command still uses the existing pinned requirements file and existing target Python venv path.

## Repro + Verification

### Environment

- OS: Windows / PowerShell
- Runtime/container: local Node.js backend test runner, CLI runtime, uv-managed analysis Python venv
- Model/provider: N/A
- Integration/channel (if any): CLI
- Relevant config (redacted): optional isolated `SCLAW_DATA_DIR` for manual verification

### Steps

1. Create or reuse an analysis Python venv.
2. Make a pinned package version stale, for example install `PyYAML==6.0.2` while requirements expects `6.0.3`.
3. Run `sclaw doctor` or `sclaw setup-analysis-python`.

### Expected

- The CLI detects stale requirements and reruns `uv pip install -r backend/src/agent-skills/analysis/runtime/requirements.txt`.

### Actual

- Verified by the new regression test and manual stale-package workflow confirmation.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run locally:

```text
npm test --prefix backend -- --runInBand analysis-python-setup.test.mjs
node tests/runner.mjs validate validate-dev-startup-guards
npm run lint --prefix backend
```

## Human Verification (required)

- Verified scenarios: targeted backend Jest regression, CLI startup guard validation, backend lint. The requester also confirmed the isolated stale-package manual flow worked.
- Edge cases checked: missing import still triggers pip install; present imports with stale requirements now trigger pip install; existing venv is reused rather than recreated.
- What you did **not** verify: full native install smoke and full backend regression suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a malformed or unsupported requirements marker could be interpreted as applicable.
  - Mitigation: the parser supports the current requirements patterns and only uses the check to decide whether to rerun the existing `uv pip install -r` command.