### PR TITLE
fix(agent-runtime): stabilize nested draft hashes

### DIFF
--- a/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
+++ b/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
@@ -1,0 +1,123 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  computeDependencyFingerprint,
+  computeDraftStateContentHash,
+} from '../../../dist/agent-runtime/artifact-helpers.js';
+import {
+  stampDraftSemantics,
+  STRUCTURAL_COORDINATE_SEMANTICS,
+} from '../../../dist/agent-runtime/coordinate-semantics.js';
+import { buildElementReferenceVectors } from '../../../dist/agent-runtime/reference-vectors.js';
+import { skillExecutionSchema } from '../../../dist/agent-runtime/schema.js';
+
+describe('agent runtime helper utilities', () => {
+  test('dependency fingerprints are stable regardless of reference insertion order', () => {
+    const left = computeDependencyFingerprint({
+      analysis: { artifactId: 'analysis-1', revision: 3 },
+      model: { artifactId: 'model-1', revision: 2 },
+    });
+    const right = computeDependencyFingerprint({
+      model: { artifactId: 'model-1', revision: 2 },
+      analysis: { artifactId: 'analysis-1', revision: 3 },
+    });
+
+    expect(left).toBe(right);
+    expect(left).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  test('dependency fingerprints include provider bindings and draft state hashes', () => {
+    const refs = {
+      model: { artifactId: 'model-1', revision: 2 },
+    };
+    const base = computeDependencyFingerprint(refs);
+
+    expect(computeDependencyFingerprint(refs, { analysisProviderSkillId: 'analysis-opensees-static' })).not.toBe(base);
+    expect(computeDependencyFingerprint(refs, { codeCheckProviderSkillId: 'code-check-gb50017' })).not.toBe(base);
+    expect(computeDependencyFingerprint(refs, undefined, 'draft-hash-1')).not.toBe(base);
+  });
+
+  test('draft state content hashes ignore updatedAt while tracking real content changes', () => {
+    const first = computeDraftStateContentHash({
+      inferredType: 'beam',
+      lengthM: 6,
+      loadKNPerM: 20,
+      updatedAt: 100,
+    });
+    const second = computeDraftStateContentHash({
+      updatedAt: 200,
+      loadKNPerM: 20,
+      lengthM: 6,
+      inferredType: 'beam',
+    });
+    const changed = computeDraftStateContentHash({
+      inferredType: 'beam',
+      lengthM: 7,
+      loadKNPerM: 20,
+      updatedAt: 100,
+    });
+
+    expect(first).toBe(second);
+    expect(changed).not.toBe(first);
+  });
+
+  test('stampDraftSemantics adds global coordinate semantics without mutating input', () => {
+    const draft = { inferredType: 'frame', storyCount: 2 };
+    const stamped = stampDraftSemantics(draft);
+
+    expect(stamped).toEqual({
+      inferredType: 'frame',
+      storyCount: 2,
+      coordinateSemantics: STRUCTURAL_COORDINATE_SEMANTICS,
+    });
+    expect(stamped).not.toBe(draft);
+    expect(draft).not.toHaveProperty('coordinateSemantics');
+  });
+
+  test('buildElementReferenceVectors assigns columns and beams while skipping invalid elements', () => {
+    const nodes = [
+      { id: 'N1', x: 0, y: 0, z: 0 },
+      { id: 2, x: 0, y: 0, z: 3 },
+      { id: 'N3', x: 5, y: 0, z: 3 },
+      { id: 'bad', x: 'not-a-number', y: 0, z: 0 },
+    ];
+    const elements = [
+      { id: 'C1', nodes: ['N1', 2] },
+      { id: 'B1', nodes: [2, 'N3'] },
+      { id: 'missing-node', nodes: ['N1', 'N404'] },
+      { id: 42, nodes: ['N1', 'N3'] },
+      { id: 'bad-coordinates', nodes: ['N1', 'bad'] },
+    ];
+
+    expect(buildElementReferenceVectors(elements, nodes)).toEqual({
+      C1: [1, 0, 0],
+      B1: [0, 0, 1],
+    });
+  });
+
+  test('skillExecutionSchema accepts valid payloads and rejects invalid stages', () => {
+    const parsed = skillExecutionSchema.parse({
+      inferredType: 'beam',
+      draftPatch: { lengthM: 6 },
+      missingCritical: ['supportType'],
+      questions: [{
+        paramKey: 'supportType',
+        label: 'Support type',
+        question: 'What support type should be used?',
+        required: true,
+        critical: true,
+      }],
+      defaultProposals: [{
+        paramKey: 'supportType',
+        value: 'pinned',
+        reason: 'Common default for simple beams',
+      }],
+      stage: 'model',
+      supportLevel: 'supported',
+      skillId: 'beam',
+    });
+
+    expect(parsed.stage).toBe('model');
+    expect(parsed.questions?.[0].critical).toBe(true);
+    expect(() => skillExecutionSchema.parse({ stage: 'design' })).toThrow();
+  });
+});

--- a/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
+++ b/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
@@ -60,6 +60,33 @@ describe('agent runtime helper utilities', () => {
     expect(changed).not.toBe(first);
   });
 
+  test('draft state content hashes are stable for nested objects while tracking nested changes', () => {
+    const first = computeDraftStateContentHash({
+      nested: {
+        section: { heightM: 0.5, widthM: 0.25 },
+        loads: [{ id: 'L1', value: 20 }],
+      },
+      updatedAt: 100,
+    });
+    const reordered = computeDraftStateContentHash({
+      updatedAt: 200,
+      nested: {
+        loads: [{ value: 20, id: 'L1' }],
+        section: { widthM: 0.25, heightM: 0.5 },
+      },
+    });
+    const changed = computeDraftStateContentHash({
+      nested: {
+        section: { heightM: 0.5, widthM: 0.25 },
+        loads: [{ id: 'L1', value: 25 }],
+      },
+      updatedAt: 100,
+    });
+
+    expect(reordered).toBe(first);
+    expect(changed).not.toBe(first);
+  });
+
   test('stampDraftSemantics adds global coordinate semantics without mutating input', () => {
     const draft = { inferredType: 'frame', storyCount: 2 };
     const stamped = stampDraftSemantics(draft);

--- a/backend/src/agent-runtime/artifact-helpers.ts
+++ b/backend/src/agent-runtime/artifact-helpers.ts
@@ -1,5 +1,20 @@
 import crypto from 'node:crypto';
 
+function stableNormalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableNormalize);
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map((key) => [key, stableNormalize(record[key])]),
+    );
+  }
+  return value;
+}
+
 export function computeDependencyFingerprint(
   refs: Record<string, { artifactId: string; revision: number }>,
   providerBindings?: { analysisProviderSkillId?: string; codeCheckProviderSkillId?: string },
@@ -28,6 +43,6 @@ export function computeDraftStateContentHash(draftState: Record<string, unknown>
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { updatedAt, ...rest } = draftState;
   return crypto.createHash('sha256')
-    .update(JSON.stringify(rest, Object.keys(rest).sort()))
+    .update(JSON.stringify(stableNormalize(rest)))
     .digest('hex').slice(0, 16);
 }


### PR DESCRIPTION
## Summary

- Problem: #229 tracks TypeScript coverage gaps, and review found `computeDraftStateContentHash` did not handle nested draft objects safely.
- Why it matters: draft-state hashes feed artifact dependency fingerprints; nested draft content should be tracked deterministically without false changes from object key order.
- What changed: added recursive stable normalization for draft-state hashing and focused Jest coverage for artifact helpers, coordinate semantics, element reference vectors, and skill execution schema validation.
- What did NOT change (scope boundary): this does not close #229 or attempt to cover the larger runtime/tools/services/API gaps.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #229
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `computeDraftStateContentHash` used `JSON.stringify` with a sorted top-level key-array replacer. That did not recursively normalize nested objects and could miss or destabilize nested draft content.
- Missing detection / guardrail: no unit test covered nested draft-state objects or reordered nested keys.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Found during review of this helper coverage PR.
- Why this regressed now: N/A; this was uncovered while adding tests.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs`
- Scenario the test should lock in: nested draft-state hashes remain stable across nested key order changes, ignore `updatedAt`, and still change when nested values change.
- Why this is the smallest reliable guardrail: the affected behavior is a pure helper function, so isolated unit tests are deterministic and fast.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Microsoft Windows 10.0.19045
- Runtime/container: Node.js v24.14.1, npm 11.11.0, local PowerShell
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `npm test --prefix backend -- --runInBand src/agent-runtime/__tests__/runtime-helpers.test.mjs`
2. `npm test --prefix backend -- --runInBand src/agent-runtime/__tests__`
3. `npm run lint --prefix backend`

### Expected

- New helper tests pass.
- Existing `agent-runtime` tests continue to pass.
- Backend lint passes.

### Actual

- Single file helper test passed: 1 suite, 7 tests.
- Full `agent-runtime/__tests__` passed: 3 suites, 23 tests.
- Backend lint passed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Command outputs are summarized in Repro + Verification.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: deterministic dependency fingerprints, draft-state hashing that ignores `updatedAt`, nested draft hashing stability, nested draft content changes, coordinate semantic stamping, element reference vector defaults/skips, and valid/invalid skill execution schema parsing.
- Edge cases checked: shuffled dependency reference order, provider/draft hash fingerprint changes, reordered nested object keys, changed nested values, invalid element/node records, numeric node IDs, and rejected invalid schema stage.
- What you did **not** verify: LLM integration, browser E2E, or wider #229 coverage outside these helper modules.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.