### PR TITLE
feat(#220): tool tests, engineering calculator, skill-creation meta-skill

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,6 +21,7 @@
         "@prisma/client": "^7.8.0",
         "better-sqlite3": "^12.9.0",
         "fastify": "^5.8.5",
+        "mathjs": "^15.2.0",
         "pdf-parse": "^1.1.1",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
@@ -505,6 +506,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -4307,6 +4317,19 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
+    "node_modules/complex.js": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.3.tgz",
+      "integrity": "sha512-UrQVSUur14tNX6tiP4y8T4w4FeJAX3bi2cIv0pu/DTLFNxoq7z2Yh83Vfzztj6Px3X/lubqQ9IrPp7Bpn6p4MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4441,6 +4464,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -4725,6 +4754,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==",
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -5325,6 +5360,19 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -5848,6 +5896,12 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "license": "MIT"
     },
     "node_modules/jest": {
       "version": "30.3.0",
@@ -6896,6 +6950,29 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/mathjs": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+      "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/merge-stream": {
@@ -8180,6 +8257,12 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -8653,6 +8736,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -8782,6 +8871,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-function": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+      "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/typescript": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,9 +25,9 @@
   },
   "dependencies": {
     "@fastify/cors": "^11.2.0",
+    "@fastify/multipart": "^9.0.3",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.1.3",
-    "@fastify/multipart": "^9.0.3",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.6",
     "@langchain/core": "^1.1.40",
@@ -37,6 +37,7 @@
     "@prisma/client": "^7.8.0",
     "better-sqlite3": "^12.9.0",
     "fastify": "^5.8.5",
+    "mathjs": "^15.2.0",
     "pdf-parse": "^1.1.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",

--- a/backend/src/agent-langgraph/__tests__/calc-tool.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/calc-tool.test.mjs
@@ -1,0 +1,191 @@
+import { describe, expect, test } from '@jest/globals';
+
+describe('createCalculateTool', () => {
+  test('basic arithmetic: addition', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: '2 + 3' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(5);
+  });
+
+  test('basic arithmetic: multiplication', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: '6 * 7' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(42);
+  });
+
+  test('basic arithmetic: division', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: '15 / 4' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(3.75);
+  });
+
+  test('basic arithmetic: power', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: '2 ^ 10' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(1024);
+  });
+
+  test('basic arithmetic: modulo', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: '17 % 5' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(2);
+  });
+
+  test('operator precedence: multiplication before addition', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: '2 + 3 * 4' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(14);
+  });
+
+  test('parentheses override precedence', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: '(2 + 3) * 4' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(20);
+  });
+
+  test('sqrt function', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: 'sqrt(144)' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(12);
+  });
+
+  test('trigonometric: sin(pi/2)', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: 'sin(pi / 2)' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBeCloseTo(1);
+  });
+
+  test('abs function', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: 'abs(-5)' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(5);
+  });
+
+  test('log(e) equals 1', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: 'log(e)' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBeCloseTo(1);
+  });
+
+  test('pow function', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: 'pow(2, 10)' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(1024);
+  });
+
+  test('engineering formula: simply supported beam max moment', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    // M = wL²/8 for UDL: w=20kN/m, L=6m
+    const raw = await tool.invoke({ expression: '20e3 * 6^2 / 8' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(90000);
+  });
+
+  test('unit label passes through to output', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: '100 * 5', unit: 'kN·m' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(500);
+    expect(result.unit).toBe('kN·m');
+  });
+
+  test('error on empty expression', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: '' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Empty/);
+  });
+
+  test('error on division by zero', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: '1 / 0' });
+    const result = JSON.parse(raw);
+    // mathjs may return Infinity, null, or an error depending on config
+    expect(typeof result.success === 'boolean').toBe(true);
+  });
+
+  test('error on unknown function', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: 'unknownFunc(5)' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+  });
+
+  test('error on unmatched parentheses', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: '(2 + 3' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+  });
+
+  test('error on expression exceeding length limit', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const longExpr = '1 + '.repeat(200) + '1';
+    const raw = await tool.invoke({ expression: longExpr });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/limit/);
+  });
+
+  test('injection attempt: import is disabled', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: 'import("fs")' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+  });
+
+  test('injection attempt: evaluate is disabled', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: 'evaluate("1+2")' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/agent-langgraph/__tests__/calc-tool.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/calc-tool.test.mjs
@@ -138,13 +138,13 @@ describe('createCalculateTool', () => {
     expect(result.error).toMatch(/Empty/);
   });
 
-  test('error on division by zero', async () => {
+  test('division by zero returns error (Infinity rejected)', async () => {
     const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
     const tool = createCalculateTool();
     const raw = await tool.invoke({ expression: '1 / 0' });
     const result = JSON.parse(raw);
-    // mathjs may return Infinity, null, or an error depending on config
-    expect(typeof result.success === 'boolean').toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not a finite number/);
   });
 
   test('error on unknown function', async () => {
@@ -179,12 +179,52 @@ describe('createCalculateTool', () => {
     const raw = await tool.invoke({ expression: 'import("fs")' });
     const result = JSON.parse(raw);
     expect(result.success).toBe(false);
+    expect(result.error).toMatch(/disabled/);
   });
 
   test('injection attempt: evaluate is disabled', async () => {
     const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
     const tool = createCalculateTool();
     const raw = await tool.invoke({ expression: 'evaluate("1+2")' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/disabled/);
+  });
+
+  test('injection attempt: parse is disabled', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: 'parse("1+2")' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/disabled/);
+  });
+
+  test('injection attempt: config is disabled', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: 'config({number: "BigNumber"})' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/disabled/);
+  });
+
+  test('injection attempt: createUnit is disabled', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    const raw = await tool.invoke({ expression: 'createUnit("fakeunit", "1 m")' });
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/disabled/);
+  });
+
+  test('scope isolation: variable assignment does not leak', async () => {
+    const { createCalculateTool } = await import('../../../dist/agent-langgraph/calc-tool.js');
+    const tool = createCalculateTool();
+    // Assign a variable
+    await tool.invoke({ expression: 'a = 42' });
+    // Verify the variable does not persist
+    const raw = await tool.invoke({ expression: 'a' });
     const result = JSON.parse(raw);
     expect(result.success).toBe(false);
   });

--- a/backend/src/agent-langgraph/__tests__/file-tools.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/file-tools.test.mjs
@@ -1,0 +1,178 @@
+import { describe, expect, test, beforeEach, afterEach } from '@jest/globals';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+describe('file-tools helpers', () => {
+  describe('isPathWithinRoot', () => {
+    test('exact root match returns true', async () => {
+      const { isPathWithinRoot } = await import('../../../dist/agent-langgraph/file-tools.js');
+      const root = path.resolve('/tmp/test-root');
+      expect(isPathWithinRoot(root, root)).toBe(true);
+    });
+
+    test('strict descendant returns true', async () => {
+      const { isPathWithinRoot } = await import('../../../dist/agent-langgraph/file-tools.js');
+      const root = path.resolve('/tmp/test-root');
+      expect(isPathWithinRoot(path.join(root, 'sub', 'file.txt'), root)).toBe(true);
+    });
+
+    test('sibling directory returns false', async () => {
+      const { isPathWithinRoot } = await import('../../../dist/agent-langgraph/file-tools.js');
+      const root = path.resolve('/tmp/test-root');
+      expect(isPathWithinRoot(path.resolve('/tmp/test-other/file.txt'), root)).toBe(false);
+    });
+
+    test('traversal via ../ returns false', async () => {
+      const { isPathWithinRoot } = await import('../../../dist/agent-langgraph/file-tools.js');
+      const root = path.resolve('/tmp/test-root');
+      const traversal = path.normalize(path.join(root, '..', 'outside.txt'));
+      expect(isPathWithinRoot(traversal, root)).toBe(false);
+    });
+  });
+
+  describe('parseCsv', () => {
+    test('empty input returns empty headers and rows', async () => {
+      const { parseCsv } = await import('../../../dist/agent-langgraph/file-tools.js');
+      const result = parseCsv('', 100);
+      expect(result.headers).toEqual([]);
+      expect(result.rows).toEqual([]);
+    });
+
+    test('single row returns headers only', async () => {
+      const { parseCsv } = await import('../../../dist/agent-langgraph/file-tools.js');
+      const result = parseCsv('a,b,c', 100);
+      expect(result.headers).toEqual(['a', 'b', 'c']);
+      expect(result.rows).toEqual([]);
+    });
+
+    test('quoted fields with commas are preserved', async () => {
+      const { parseCsv } = await import('../../../dist/agent-langgraph/file-tools.js');
+      const result = parseCsv('name,value\n"Smith, John",100', 100);
+      expect(result.headers).toEqual(['name', 'value']);
+      expect(result.rows[0][0]).toBe('Smith, John');
+      expect(result.rows[0][1]).toBe('100');
+    });
+
+    test('tab-separated input splits on tabs', async () => {
+      const { parseCsv } = await import('../../../dist/agent-langgraph/file-tools.js');
+      const result = parseCsv('a\tb\tc\n1\t2\t3', 100);
+      expect(result.headers).toEqual(['a', 'b', 'c']);
+      expect(result.rows[0]).toEqual(['1', '2', '3']);
+    });
+
+    test('rows are truncated at maxRows', async () => {
+      const { parseCsv } = await import('../../../dist/agent-langgraph/file-tools.js');
+      const lines = ['h'].concat(Array.from({ length: 20 }, (_, i) => `${i}`));
+      const result = parseCsv(lines.join('\n'), 5);
+      expect(result.rows).toHaveLength(5);
+    });
+  });
+
+  describe('parseDxf', () => {
+    test('extracts LINE entities with coordinates', async () => {
+      const { parseDxf } = await import('../../../dist/agent-langgraph/file-tools.js');
+      const dxf = [
+        '0', 'LINE',
+        '10', '1.0', '20', '2.0',
+        '11', '3.0', '21', '4.0',
+        '0', 'EOF',
+      ].join('\n');
+      const result = parseDxf(dxf);
+      expect(result.lines).toHaveLength(1);
+      expect(result.lines[0]).toEqual({ x1: 1, y1: 2, x2: 3, y2: 4 });
+    });
+
+    test('extracts TEXT and MTEXT content', async () => {
+      const { parseDxf } = await import('../../../dist/agent-langgraph/file-tools.js');
+      const dxf = [
+        '0', 'TEXT',
+        '1', 'Hello World',
+        '0', 'MTEXT',
+        '1', 'Beam Label',
+        '0', 'EOF',
+      ].join('\n');
+      const result = parseDxf(dxf);
+      expect(result.entityCount).toBeGreaterThanOrEqual(2);
+      expect(result.texts).toEqual(['Hello World', 'Beam Label']);
+    });
+
+    test('empty DXF returns zero entities', async () => {
+      const { parseDxf } = await import('../../../dist/agent-langgraph/file-tools.js');
+      const result = parseDxf('');
+      expect(result.entityCount).toBe(0);
+      expect(result.lines).toEqual([]);
+      expect(result.texts).toEqual([]);
+    });
+  });
+});
+
+describe('createAnalyzeFileTool', () => {
+  let tmpDir;
+  let uploadsDir;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sclaw-file-tools-'));
+    uploadsDir = path.join(tmpDir, '.uploads');
+    await fs.mkdir(uploadsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('analyzes a CSV file', async () => {
+    const { createAnalyzeFileTool } = await import('../../../dist/agent-langgraph/file-tools.js');
+    const csvPath = path.join(uploadsDir, 'data.csv');
+    await fs.writeFile(csvPath, 'name,value\nA,1\nB,2\n', 'utf8');
+    const tool = createAnalyzeFileTool();
+    const raw = await tool.invoke(
+      { filePath: csvPath },
+      { configurable: { workspaceRoot: tmpDir } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.type).toBe('csv');
+    expect(result.headers).toEqual(['name', 'value']);
+    expect(result.rows).toEqual([['A', '1'], ['B', '2']]);
+  });
+
+  test('analyzes a plain text file', async () => {
+    const { createAnalyzeFileTool } = await import('../../../dist/agent-langgraph/file-tools.js');
+    const txtPath = path.join(uploadsDir, 'notes.txt');
+    await fs.writeFile(txtPath, 'Hello structural engineering', 'utf8');
+    const tool = createAnalyzeFileTool();
+    const raw = await tool.invoke(
+      { filePath: txtPath },
+      { configurable: { workspaceRoot: tmpDir } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.type).toBe('text');
+    expect(result.content).toContain('Hello structural engineering');
+  });
+
+  test('rejects path traversal', async () => {
+    const { createAnalyzeFileTool } = await import('../../../dist/agent-langgraph/file-tools.js');
+    const tool = createAnalyzeFileTool();
+    const raw = await tool.invoke(
+      { filePath: '../../etc/passwd' },
+      { configurable: { workspaceRoot: tmpDir } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/traversal|denied/);
+  });
+
+  test('returns FILE_NOT_FOUND for missing file', async () => {
+    const { createAnalyzeFileTool } = await import('../../../dist/agent-langgraph/file-tools.js');
+    const tool = createAnalyzeFileTool();
+    const raw = await tool.invoke(
+      { filePath: path.join(uploadsDir, 'missing.csv') },
+      { configurable: { workspaceRoot: tmpDir } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('FILE_NOT_FOUND');
+  });
+});

--- a/backend/src/agent-langgraph/__tests__/shell-tool.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/shell-tool.test.mjs
@@ -1,0 +1,82 @@
+import { describe, expect, test } from '@jest/globals';
+
+describe('shell-tool helpers', () => {
+  describe('isCommandAllowed', () => {
+    test('allowlisted commands pass', async () => {
+      const { isCommandAllowed } = await import('../../../dist/agent-langgraph/shell-tool.js');
+      // Default allowlist includes node, python, python3
+      expect(isCommandAllowed('node')).toBe(true);
+      expect(isCommandAllowed('python')).toBe(true);
+      expect(isCommandAllowed('python3')).toBe(true);
+    });
+
+    test('non-allowlisted commands are denied', async () => {
+      const { isCommandAllowed } = await import('../../../dist/agent-langgraph/shell-tool.js');
+      expect(isCommandAllowed('rm')).toBe(false);
+      expect(isCommandAllowed('bash')).toBe(false);
+      expect(isCommandAllowed('curl')).toBe(false);
+      expect(isCommandAllowed('sh')).toBe(false);
+    });
+
+    test('exact match required (no partial match)', async () => {
+      const { isCommandAllowed } = await import('../../../dist/agent-langgraph/shell-tool.js');
+      // "nodes" is not "node"
+      expect(isCommandAllowed('nodes')).toBe(false);
+    });
+  });
+
+  describe('truncateByBytes', () => {
+    test('short string is not truncated', async () => {
+      const { truncateByBytes } = await import('../../../dist/agent-langgraph/shell-tool.js');
+      const result = truncateByBytes('hello', 100);
+      expect(result.output).toBe('hello');
+      expect(result.truncated).toBe(false);
+    });
+
+    test('string exceeding limit is truncated', async () => {
+      const { truncateByBytes } = await import('../../../dist/agent-langgraph/shell-tool.js');
+      const result = truncateByBytes('abcdefghij', 5);
+      expect(result.truncated).toBe(true);
+      expect(result.output.length).toBeLessThanOrEqual(5);
+    });
+
+    test('CJK characters preserve valid UTF-8 boundaries', async () => {
+      const { truncateByBytes } = await import('../../../dist/agent-langgraph/shell-tool.js');
+      // Each CJK char is 3 bytes in UTF-8
+      const input = '你好世界';
+      const result = truncateByBytes(input, 6);
+      expect(result.truncated).toBe(true);
+      // Should contain at least one valid CJK character
+      expect(result.output.length).toBeGreaterThan(0);
+      // Should not contain garbled partial bytes
+      expect(() => Buffer.from(result.output, 'utf-8')).not.toThrow();
+    });
+  });
+});
+
+describe('createShellTool', () => {
+  test('returns SHELL_DISABLED when allowShell is false', async () => {
+    const { createShellTool } = await import('../../../dist/agent-langgraph/shell-tool.js');
+    const tool = createShellTool();
+    const raw = await tool.invoke(
+      { command: 'node', args: ['-e', 'console.log(1)'] },
+      { configurable: { allowShell: false } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('SHELL_DISABLED');
+  });
+
+  test('returns COMMAND_DENIED for non-allowlisted command', async () => {
+    const { createShellTool } = await import('../../../dist/agent-langgraph/shell-tool.js');
+    const tool = createShellTool();
+    const raw = await tool.invoke(
+      { command: 'rm', args: ['-rf', '/'] },
+      { configurable: { allowShell: true } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('COMMAND_DENIED');
+    expect(result.command).toBe('rm');
+  });
+});

--- a/backend/src/agent-langgraph/__tests__/tool-policy.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/tool-policy.test.mjs
@@ -28,6 +28,7 @@ describe("LangGraph tool policy", () => {
       "analyze_file",
       "ask_user_clarification",
       "build_model",
+      "calculate",
       "delete_path",
       "detect_structure_type",
       "extract_draft_params",

--- a/backend/src/agent-langgraph/__tests__/tool-registry.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/tool-registry.test.mjs
@@ -8,6 +8,7 @@ const EXPECTED_TOOL_IDS = [
   'run_analysis',
   'run_code_check',
   'generate_report',
+  'calculate',
   'ask_user_clarification',
   'set_session_config',
   'memory',
@@ -65,6 +66,7 @@ describe('tool registry: AGENT_TOOL_DEFINITIONS structure', () => {
     const engineeringIds = [
       'detect_structure_type', 'extract_draft_params', 'build_model',
       'validate_model', 'run_analysis', 'run_code_check', 'generate_report',
+      'calculate',
     ];
     for (const id of engineeringIds) {
       const def = AGENT_TOOL_DEFINITIONS.find((d) => d.id === id);

--- a/backend/src/agent-langgraph/__tests__/user-tool-loader.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/user-tool-loader.test.mjs
@@ -1,0 +1,137 @@
+import { describe, expect, test, beforeEach, afterEach } from '@jest/globals';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+describe('jsonSchemaToZod', () => {
+  test('converts string property', async () => {
+    const { jsonSchemaToZod } = await import('../../../dist/agent-langgraph/user-tool-loader.js');
+    const schema = jsonSchemaToZod({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    });
+    expect(schema.safeParse({ name: 'test' }).success).toBe(true);
+    expect(schema.safeParse({ name: 123 }).success).toBe(false);
+  });
+
+  test('converts number and integer properties', async () => {
+    const { jsonSchemaToZod } = await import('../../../dist/agent-langgraph/user-tool-loader.js');
+    const schema = jsonSchemaToZod({
+      type: 'object',
+      properties: {
+        count: { type: 'integer' },
+        ratio: { type: 'number' },
+      },
+      required: ['count', 'ratio'],
+    });
+    expect(schema.safeParse({ count: 5, ratio: 3.14 }).success).toBe(true);
+    expect(schema.safeParse({ count: 5.5, ratio: 3.14 }).success).toBe(false);
+  });
+
+  test('converts boolean property', async () => {
+    const { jsonSchemaToZod } = await import('../../../dist/agent-langgraph/user-tool-loader.js');
+    const schema = jsonSchemaToZod({
+      type: 'object',
+      properties: { active: { type: 'boolean' } },
+      required: ['active'],
+    });
+    expect(schema.safeParse({ active: true }).success).toBe(true);
+    expect(schema.safeParse({ active: 'yes' }).success).toBe(false);
+  });
+
+  test('converts array of strings', async () => {
+    const { jsonSchemaToZod } = await import('../../../dist/agent-langgraph/user-tool-loader.js');
+    const schema = jsonSchemaToZod({
+      type: 'object',
+      properties: { items: { type: 'array', items: { type: 'string' } } },
+      required: ['items'],
+    });
+    expect(schema.safeParse({ items: ['a', 'b'] }).success).toBe(true);
+    expect(schema.safeParse({ items: [1, 2] }).success).toBe(false);
+  });
+
+  test('optional fields are not required', async () => {
+    const { jsonSchemaToZod } = await import('../../../dist/agent-langgraph/user-tool-loader.js');
+    const schema = jsonSchemaToZod({
+      type: 'object',
+      properties: {
+        required_field: { type: 'string' },
+        optional_field: { type: 'string' },
+      },
+      required: ['required_field'],
+    });
+    expect(schema.safeParse({ required_field: 'hello' }).success).toBe(true);
+  });
+
+  test('unknown type falls back to z.unknown()', async () => {
+    const { jsonSchemaToZod } = await import('../../../dist/agent-langgraph/user-tool-loader.js');
+    const schema = jsonSchemaToZod({
+      type: 'object',
+      properties: { data: { type: 'custom_unknown' } },
+      required: ['data'],
+    });
+    expect(schema.safeParse({ data: 'anything' }).success).toBe(true);
+    expect(schema.safeParse({ data: 42 }).success).toBe(true);
+  });
+});
+
+describe('loadUserTools', () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sclaw-user-tools-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('nonexistent directory returns empty result', async () => {
+    const { loadUserTools } = await import('../../../dist/agent-langgraph/user-tool-loader.js');
+    const result = await loadUserTools(path.join(tmpDir, 'no-such-dir'));
+    expect(result.tools).toEqual([]);
+    expect(result.failures).toEqual([]);
+  });
+
+  test('missing tool.yaml reports missing_yaml', async () => {
+    const { loadUserTools } = await import('../../../dist/agent-langgraph/user-tool-loader.js');
+    const toolDir = path.join(tmpDir, 'my-tool');
+    await fs.mkdir(toolDir, { recursive: true });
+    const result = await loadUserTools(tmpDir);
+    expect(result.tools).toHaveLength(0);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].reason).toBe('missing_yaml');
+  });
+
+  test('invalid YAML reports invalid_yaml', async () => {
+    const { loadUserTools } = await import('../../../dist/agent-langgraph/user-tool-loader.js');
+    const toolDir = path.join(tmpDir, 'bad-tool');
+    await fs.mkdir(toolDir, { recursive: true });
+    await fs.writeFile(path.join(toolDir, 'tool.yaml'), 'invalid: [yaml: content', 'utf8');
+    const result = await loadUserTools(tmpDir);
+    expect(result.failures[0].reason).toBe('invalid_yaml');
+  });
+
+  test('missing tool.js reports missing_js', async () => {
+    const { loadUserTools } = await import('../../../dist/agent-langgraph/user-tool-loader.js');
+    const toolDir = path.join(tmpDir, 'no-js-tool');
+    await fs.mkdir(toolDir, { recursive: true });
+    await fs.writeFile(path.join(toolDir, 'tool.yaml'), [
+      'id: test_tool',
+      'category: engineering',
+      'risk: low',
+      'defaultEnabled: true',
+      'displayName: { zh: "测试", en: "Test" }',
+      'description: { zh: "测试工具", en: "Test tool" }',
+      'parameters:',
+      '  type: object',
+      '  properties:',
+      '    input:',
+      '      type: string',
+      '  required: [input]',
+    ].join('\n'), 'utf8');
+    const result = await loadUserTools(tmpDir);
+    expect(result.failures[0].reason).toBe('missing_js');
+  });
+});

--- a/backend/src/agent-langgraph/__tests__/workspace-tools.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/workspace-tools.test.mjs
@@ -161,4 +161,176 @@ describe("workspace tools", () => {
     expect(result.success).toBe(true);
     expect(content).toContain("updated");
   });
+
+  // ── read_file ──────────────────────────────────────────────────────────────
+
+  test("read_file reads a text file", async () => {
+    const { createReadFileTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    const tool = createReadFileTool();
+    const raw = await tool.invoke(
+      { filePath: "src/agent.ts" },
+      { configurable: { workspaceRoot: root } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.type).toBe("text");
+    expect(result.content).toContain("needle");
+  });
+
+  test("read_file detects binary content", async () => {
+    await fs.writeFile(path.join(root, "src", "data.bin"), Buffer.from([0, 1, 2, 3]));
+    const { createReadFileTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    const tool = createReadFileTool();
+    const raw = await tool.invoke(
+      { filePath: "src/data.bin" },
+      { configurable: { workspaceRoot: root } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    expect(result.type).toBe("binary");
+  });
+
+  test("read_file blocks traversal", async () => {
+    const { createReadFileTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    const tool = createReadFileTool();
+    const raw = await tool.invoke(
+      { filePath: "../outside.txt" },
+      { configurable: { workspaceRoot: root } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+  });
+
+  test("read_file returns FILE_NOT_FOUND for missing file", async () => {
+    const { createReadFileTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    const tool = createReadFileTool();
+    const raw = await tool.invoke(
+      { filePath: "src/missing.ts" },
+      { configurable: { workspaceRoot: root } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("FILE_NOT_FOUND");
+  });
+
+  // ── write_file ─────────────────────────────────────────────────────────────
+
+  test("write_file creates new file with parent dirs", async () => {
+    const { createWriteFileTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    const tool = createWriteFileTool();
+    const raw = await tool.invoke(
+      { filePath: "src/deep/new-file.ts", content: "export const x = 1;\n" },
+      { configurable: { workspaceRoot: root } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    const content = await fs.readFile(path.join(root, "src", "deep", "new-file.ts"), "utf8");
+    expect(content).toBe("export const x = 1;\n");
+  });
+
+  test("write_file blocks traversal", async () => {
+    const { createWriteFileTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    const tool = createWriteFileTool();
+    await expect(
+      tool.invoke(
+        { filePath: "../outside.ts", content: "evil" },
+        { configurable: { workspaceRoot: root } },
+      ),
+    ).rejects.toThrow(/Path traversal/);
+  });
+
+  test("write_file rejects disallowed extension", async () => {
+    const { createWriteFileTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    const tool = createWriteFileTool();
+    await expect(
+      tool.invoke(
+        { filePath: "evil.exe", content: "binary" },
+        { configurable: { workspaceRoot: root } },
+      ),
+    ).rejects.toThrow(/denied/);
+  });
+
+  // ── move_path ──────────────────────────────────────────────────────────────
+
+  test("move_path renames a file", async () => {
+    const { createMovePathTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    const tool = createMovePathTool();
+    const raw = await tool.invoke(
+      { fromPath: "src/agent.ts", toPath: "src/renamed.ts" },
+      { configurable: { workspaceRoot: root } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    const content = await fs.readFile(path.join(root, "src", "renamed.ts"), "utf8");
+    expect(content).toContain("needle");
+  });
+
+  test("move_path blocks traversal", async () => {
+    const { createMovePathTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    const tool = createMovePathTool();
+    await expect(
+      tool.invoke(
+        { fromPath: "src/agent.ts", toPath: "../outside.ts" },
+        { configurable: { workspaceRoot: root } },
+      ),
+    ).rejects.toThrow(/Path traversal/);
+  });
+
+  // ── delete_path ────────────────────────────────────────────────────────────
+
+  test("delete_path removes a file", async () => {
+    await fs.writeFile(path.join(root, "src", "to-delete.ts"), "temp", "utf8");
+    const { createDeletePathTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    const tool = createDeletePathTool();
+    const raw = await tool.invoke(
+      { filePath: "src/to-delete.ts" },
+      { configurable: { workspaceRoot: root } },
+    );
+    const result = JSON.parse(raw);
+    expect(result.success).toBe(true);
+    await expect(fs.stat(path.join(root, "src", "to-delete.ts"))).rejects.toThrow();
+  });
+
+  test("delete_path blocks traversal", async () => {
+    const { createDeletePathTool } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    const tool = createDeletePathTool();
+    await expect(
+      tool.invoke(
+        { filePath: "../outside.ts" },
+        { configurable: { workspaceRoot: root } },
+      ),
+    ).rejects.toThrow(/Path traversal/);
+  });
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  test("isProbablyBinary returns true for buffer with null byte", async () => {
+    const { isProbablyBinary } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    expect(isProbablyBinary(Buffer.from([0, 1, 2]))).toBe(true);
+  });
+
+  test("isProbablyBinary returns false for text buffer", async () => {
+    const { isProbablyBinary } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    expect(isProbablyBinary(Buffer.from("hello world"))).toBe(false);
+  });
+
+  test("isAllowedFile accepts .ts extension", async () => {
+    const { isAllowedFile } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    expect(isAllowedFile("test.ts")).toBe(true);
+  });
+
+  test("isAllowedFile rejects .exe extension", async () => {
+    const { isAllowedFile } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    expect(isAllowedFile("program.exe")).toBe(false);
+  });
+
+  test("isAllowedFile rejects no extension", async () => {
+    const { isAllowedFile } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    expect(isAllowedFile("Makefile")).toBe(false);
+  });
+
+  test("assertAllowedFile throws for denied extension", async () => {
+    const { assertAllowedFile } = await import("../../../dist/agent-langgraph/workspace-tools.js");
+    expect(() => assertAllowedFile("evil.exe")).toThrow(/denied/);
+  });
 });

--- a/backend/src/agent-langgraph/calc-tool.ts
+++ b/backend/src/agent-langgraph/calc-tool.ts
@@ -1,0 +1,87 @@
+/**
+ * Engineering calculator tool: safe math expression evaluation via mathjs.
+ *
+ * Uses a locked-down mathjs instance that disables import/evaluate/parse
+ * to prevent expression injection attacks.
+ */
+import { tool } from '@langchain/core/tools';
+import { create, all } from 'mathjs';
+import { z } from 'zod';
+
+const MAX_EXPRESSION_LENGTH = 500;
+
+const math = create(all);
+
+// Save the safe evaluate reference BEFORE disabling it
+const safeEvaluate = math.evaluate;
+
+// Disable dangerous functions to prevent injection
+math.import(
+  {
+    import: function () { throw new Error('Function import is disabled'); },
+    createUnit: function () { throw new Error('Function createUnit is disabled'); },
+    evaluate: function () { throw new Error('Function evaluate is disabled'); },
+    parse: function () { throw new Error('Function parse is disabled'); },
+  },
+  { override: true },
+);
+
+export function createCalculateTool() {
+  return tool(
+    async (input: { expression: string; unit?: string }) => {
+      const { expression, unit } = input;
+
+      if (!expression || expression.trim().length === 0) {
+        return JSON.stringify({ success: false, error: 'Empty expression' });
+      }
+      if (expression.length > MAX_EXPRESSION_LENGTH) {
+        return JSON.stringify({ success: false, error: `Expression exceeds ${MAX_EXPRESSION_LENGTH} character limit` });
+      }
+
+      try {
+        const result = safeEvaluate(expression);
+
+        if (typeof result === 'undefined') {
+          return JSON.stringify({ success: false, error: 'Expression produced no result' });
+        }
+
+        // Convert mathjs result types to plain number
+        let numericResult: number;
+        if (typeof result === 'number') {
+          numericResult = result;
+        } else if (typeof result === 'object' && typeof result.toNumber === 'function') {
+          numericResult = result.toNumber();
+        } else if (typeof result === 'object' && typeof result.valueOf === 'function') {
+          numericResult = result.valueOf() as number;
+        } else {
+          return JSON.stringify({ success: false, error: `Unsupported result type: ${typeof result}` });
+        }
+
+        const response: Record<string, unknown> = {
+          success: true,
+          result: numericResult,
+          expression,
+        };
+        if (unit) {
+          response.unit = unit;
+        }
+        return JSON.stringify(response);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return JSON.stringify({ success: false, error: msg, expression });
+      }
+    },
+    {
+      name: 'calculate',
+      description:
+        'Execute engineering math calculations with guaranteed precision. ' +
+        'Supports arithmetic (+, -, *, /, ^, %), trigonometric functions (sin, cos, tan, asin, acos, atan), ' +
+        'logarithms (log, log10, exp), utilities (sqrt, abs, ceil, floor, round, max, min, pow), ' +
+        'and constants (pi, e). Does NOT rely on LLM text generation — results are deterministic.',
+      schema: z.object({
+        expression: z.string().describe('Math expression to evaluate, e.g. "sqrt(3^2 + 4^2)" or "20e3 * 6^2 / 8"'),
+        unit: z.string().optional().describe('Optional unit label for display (e.g. "kN·m", "mm²"). Does not affect calculation.'),
+      }),
+    },
+  );
+}

--- a/backend/src/agent-langgraph/calc-tool.ts
+++ b/backend/src/agent-langgraph/calc-tool.ts
@@ -1,8 +1,10 @@
 /**
  * Engineering calculator tool: safe math expression evaluation via mathjs.
  *
- * Uses a locked-down mathjs instance that disables import/evaluate/parse
- * to prevent expression injection attacks.
+ * Uses a locked-down mathjs instance that disables import/evaluate/parse/config
+ * to prevent expression injection and global state manipulation.
+ * The math instance and its overrides are created once at module load time
+ * (intentional — process-wide lockdown ensures no circumvention).
  */
 import { tool } from '@langchain/core/tools';
 import { create, all } from 'mathjs';
@@ -15,13 +17,14 @@ const math = create(all);
 // Save the safe evaluate reference BEFORE disabling it
 const safeEvaluate = math.evaluate;
 
-// Disable dangerous functions to prevent injection
+// Disable dangerous functions to prevent injection and state manipulation
 math.import(
   {
     import: function () { throw new Error('Function import is disabled'); },
     createUnit: function () { throw new Error('Function createUnit is disabled'); },
     evaluate: function () { throw new Error('Function evaluate is disabled'); },
     parse: function () { throw new Error('Function parse is disabled'); },
+    config: function () { throw new Error('Function config is disabled'); },
   },
   { override: true },
 );
@@ -39,22 +42,32 @@ export function createCalculateTool() {
       }
 
       try {
-        const result = safeEvaluate(expression);
+        // Pass empty scope to prevent state leakage between invocations
+        const result = safeEvaluate(expression, {});
 
-        if (typeof result === 'undefined') {
+        if (result === null || typeof result === 'undefined') {
           return JSON.stringify({ success: false, error: 'Expression produced no result' });
         }
 
-        // Convert mathjs result types to plain number
+        // Convert mathjs result types to a finite number
         let numericResult: number;
         if (typeof result === 'number') {
           numericResult = result;
         } else if (typeof result === 'object' && typeof result.toNumber === 'function') {
           numericResult = result.toNumber();
         } else if (typeof result === 'object' && typeof result.valueOf === 'function') {
-          numericResult = result.valueOf() as number;
+          const val = result.valueOf();
+          if (typeof val !== 'number') {
+            return JSON.stringify({ success: false, error: `Unsupported result value type: ${typeof val}`, expression });
+          }
+          numericResult = val;
         } else {
-          return JSON.stringify({ success: false, error: `Unsupported result type: ${typeof result}` });
+          return JSON.stringify({ success: false, error: `Unsupported result type: ${typeof result}`, expression });
+        }
+
+        // Reject Infinity and NaN — not useful for engineering calculations
+        if (!Number.isFinite(numericResult)) {
+          return JSON.stringify({ success: false, error: `Result is not a finite number: ${numericResult}`, expression });
         }
 
         const response: Record<string, unknown> = {
@@ -75,9 +88,10 @@ export function createCalculateTool() {
       name: 'calculate',
       description:
         'Execute engineering math calculations with guaranteed precision. ' +
-        'Supports arithmetic (+, -, *, /, ^, %), trigonometric functions (sin, cos, tan, asin, acos, atan), ' +
+        'Supports arithmetic (+, -, *, /, ^, mod), trigonometric functions (sin, cos, tan, asin, acos, atan), ' +
         'logarithms (log, log10, exp), utilities (sqrt, abs, ceil, floor, round, max, min, pow), ' +
-        'and constants (pi, e). Does NOT rely on LLM text generation — results are deterministic.',
+        'and constants (pi, e). The % operator is modulo (remainder). ' +
+        'Does NOT rely on LLM text generation — results are deterministic.',
       schema: z.object({
         expression: z.string().describe('Math expression to evaluate, e.g. "sqrt(3^2 + 4^2)" or "20e3 * 6^2 / 8"'),
         unit: z.string().optional().describe('Optional unit label for display (e.g. "kN·m", "mm²"). Does not affect calculation.'),

--- a/backend/src/agent-langgraph/file-tools.ts
+++ b/backend/src/agent-langgraph/file-tools.ts
@@ -42,7 +42,7 @@ const IMAGE_MIME: Record<string, string> = {
 // ---------------------------------------------------------------------------
 
 /** Returns true only when candidatePath is exactly root or a strict descendant. */
-function isPathWithinRoot(candidatePath: string, root: string): boolean {
+export function isPathWithinRoot(candidatePath: string, root: string): boolean {
   const c = path.normalize(candidatePath);
   const r = path.normalize(root);
   return c === r || c.startsWith(r + path.sep);
@@ -82,7 +82,7 @@ export function resolveUploadPath(
 }
 
 /** Parse CSV text into rows (header + data). */
-function parseCsv(text: string, maxRows: number): { headers: string[]; rows: string[][] } {
+export function parseCsv(text: string, maxRows: number): { headers: string[]; rows: string[][] } {
   const lines = text
     .split(/\r?\n/)
     .map((line) => line.trim())
@@ -114,7 +114,7 @@ function parseCsv(text: string, maxRows: number): { headers: string[]; rows: str
 }
 
 /** Extract DXF entities as structural hints. */
-function parseDxf(text: string): {
+export function parseDxf(text: string): {
   lines: Array<{ x1: number; y1: number; x2: number; y2: number }>;
   texts: string[];
   entityCount: number;

--- a/backend/src/agent-langgraph/shell-tool.ts
+++ b/backend/src/agent-langgraph/shell-tool.ts
@@ -7,11 +7,11 @@ import { getAllowedShellCommands, getShellTimeoutMs } from './config.js';
 
 const MAX_OUTPUT_BYTES = 1024 * 1024;
 
-function isCommandAllowed(command: string): boolean {
+export function isCommandAllowed(command: string): boolean {
   return getAllowedShellCommands().includes(command);
 }
 
-function truncateByBytes(value: string, maxBytes: number): { output: string; truncated: boolean } {
+export function truncateByBytes(value: string, maxBytes: number): { output: string; truncated: boolean } {
   const buf = Buffer.from(value, 'utf-8');
   if (buf.length <= maxBytes) return { output: value, truncated: false };
   return { output: buf.subarray(0, maxBytes).toString('utf-8'), truncated: true };

--- a/backend/src/agent-langgraph/tool-registry.ts
+++ b/backend/src/agent-langgraph/tool-registry.ts
@@ -24,6 +24,7 @@ import {
 } from './workspace-tools.js';
 import { createAnalyzeFileTool } from './file-tools.js';
 import { createShellTool } from './shell-tool.js';
+import { createCalculateTool } from './calc-tool.js';
 
 export type AgentToolRisk = 'low' | 'workspace-read' | 'workspace-write' | 'destructive' | 'shell';
 export type AgentToolCategory = 'engineering' | 'interaction' | 'session' | 'workspace' | 'memory' | 'shell';
@@ -128,6 +129,18 @@ export const AGENT_TOOL_DEFINITIONS: readonly AgentToolDefinition[] = [
       en: 'Generate structural analysis and code-check reports.',
     },
     create: ({ skillRuntime }) => createGenerateReportTool(skillRuntime),
+  },
+  {
+    id: 'calculate',
+    category: 'engineering',
+    risk: 'low',
+    defaultEnabled: true,
+    displayName: { zh: '工程计算', en: 'Engineering Calculator' },
+    description: {
+      zh: '执行工程数学计算（算术、三角函数、对数、幂运算）。不依赖 LLM，保证精确结果。',
+      en: 'Execute engineering math calculations (arithmetic, trigonometry, logarithms, power). Precise results without LLM.',
+    },
+    create: () => createCalculateTool(),
   },
   {
     id: 'ask_user_clarification',

--- a/backend/src/agent-langgraph/user-tool-loader.ts
+++ b/backend/src/agent-langgraph/user-tool-loader.ts
@@ -17,7 +17,7 @@ type UserToolModule = {
   execute: (params: Record<string, unknown>, context: { workspaceRoot: string }) => Promise<unknown>;
 };
 
-function jsonSchemaToZod(schema: Record<string, unknown>): z.ZodType {
+export function jsonSchemaToZod(schema: Record<string, unknown>): z.ZodType {
   // Convert a JSON Schema object to a Zod object schema.
   // Supports: string, number, integer, boolean, array, object (recursive).
   const properties = (schema.properties ?? {}) as Record<string, Record<string, unknown>>;

--- a/backend/src/agent-langgraph/workspace-tools.ts
+++ b/backend/src/agent-langgraph/workspace-tools.ts
@@ -43,7 +43,7 @@ export function safeResolve(workspaceRoot: string, requestedPath: string): strin
   return resolved;
 }
 
-function assertAllowedFile(filePath: string): void {
+export function assertAllowedFile(filePath: string): void {
   if (isAllowedFile(filePath)) {
     return;
   }
@@ -51,7 +51,7 @@ function assertAllowedFile(filePath: string): void {
   throw new Error(`File extension denied: ${ext || '(none)'}`);
 }
 
-function isAllowedFile(filePath: string): boolean {
+export function isAllowedFile(filePath: string): boolean {
   const ext = path.extname(filePath).toLowerCase();
   return ALLOWED_EXTENSIONS.has(ext);
 }
@@ -89,7 +89,7 @@ function createCollectFilesStats(): CollectFilesStats {
   };
 }
 
-function isProbablyBinary(buffer: Buffer): boolean {
+export function isProbablyBinary(buffer: Buffer): boolean {
   return buffer.includes(0);
 }
 

--- a/backend/src/agent-skills/general/skill-creation/draft.md
+++ b/backend/src/agent-skills/general/skill-creation/draft.md
@@ -1,0 +1,116 @@
+# Skill Creation Guide
+
+## Directory structure
+
+Create under `backend/src/agent-skills/<domain>/<skill-name>/`:
+
+```
+<skill-name>/
+├── skill.yaml          # Required — skill manifest
+├── intent.md           # At least one stage markdown is required
+├── draft.md            # Optional
+├── analysis.md         # Optional
+├── design.md           # Optional
+├── handler.ts          # Optional — for interactive skills with custom logic
+└── __tests__/          # Optional — tests for handler
+    └── handler.test.mjs
+```
+
+## skill.yaml template
+
+```yaml
+id: <unique-skill-id>
+domain: <domain-name>
+source: builtin
+name:
+  zh: <中文名称>
+  en: <English Name>
+description:
+  zh: <中文描述>
+  en: <English description>
+triggers:
+  - <keyword1>
+  - <keyword2>
+stages:
+  - intent
+  - draft
+structureType: unknown          # or beam, truss, frame, portal-frame
+structuralTypeKeys: []          # e.g. ["beam", "梁"]
+capabilities:
+  - <capability-name>
+requires: []
+conflicts: []
+priority: 50                    # 0-100, higher = preferred when multiple match
+compatibility:
+  minRuntimeVersion: 0.1.0
+  skillApiVersion: v1
+supportedAnalysisTypes: []
+supportedModelFamilies: []
+materialFamilies: []
+aliases: []
+toolHints: {}
+runtimeContract:
+  role: assistant
+```
+
+## handler.ts template (optional)
+
+For skills that need custom draft extraction, state merging, or model building:
+
+```typescript
+import type { SkillHandler } from '../../agent-runtime/types';
+
+export const handler: SkillHandler = {
+  detectStructuralType(input) {
+    // Return StructuralTypeMatch if user text matches this skill
+    return null;
+  },
+
+  extractDraft(input) {
+    // Extract parameters from user message + LLM output
+    return { parameters: {}, confidence: 0 };
+  },
+
+  mergeState(existing, patch) {
+    // Immutable merge of draft state
+    return { ...existing, ...patch };
+  },
+
+  computeMissing(state, phase) {
+    // Return which fields are still needed
+    return { critical: [], optional: [] };
+  },
+
+  mapLabels(keys, locale) {
+    // Localize field names for display
+    return keys;
+  },
+
+  buildQuestions(keys, criticalMissing, state, locale) {
+    // Generate questions to ask the user
+    return [];
+  },
+
+  buildModel(state) {
+    // Build the final computable model JSON
+    return undefined;
+  },
+};
+```
+
+## Validation rules
+
+1. `skill.yaml` is required and must pass `skillManifestFileSchema` (Zod validation)
+2. At least one stage `.md` file is required for auto-discovery
+3. Skill IDs must be unique across all domains
+4. `domain` must be one of the 14 recognized domains
+5. `structureType` must match a known type or be `unknown`
+6. Priority range: 0–100 (default 50)
+
+## Best practices
+
+- Keep stage markdown focused and under 200 lines each
+- Use deterministic `handler.ts` methods when possible — avoid LLM calls in handlers
+- Reference the `beam` skill (`backend/src/agent-skills/structure-type/beam/`) as a canonical example of a full skill with handler
+- Reference the `memory` skill (`backend/src/agent-skills/general/memory/`) as a minimal skill example (yaml + intent.md only)
+- Skills are auto-discovered by `AgentSkillLoader` — no manual registration needed

--- a/backend/src/agent-skills/general/skill-creation/draft.md
+++ b/backend/src/agent-skills/general/skill-creation/draft.md
@@ -16,6 +16,9 @@ Create under `backend/src/agent-skills/<domain>/<skill-name>/`:
     └── handler.test.mjs
 ```
 
+Stage names must be one of: `intent`, `draft`, `analysis`, `design`
+(defined in `skillManifestFileSchema` in `backend/src/agent-runtime/manifest-schema.ts`).
+
 ## skill.yaml template
 
 ```yaml
@@ -40,7 +43,7 @@ capabilities:
   - <capability-name>
 requires: []
 conflicts: []
-priority: 50                    # 0-100, higher = preferred when multiple match
+priority: 50                    # 0-100, higher = preferred when multiple match; schema default is 0
 compatibility:
   minRuntimeVersion: 0.1.0
   skillApiVersion: v1
@@ -55,7 +58,8 @@ runtimeContract:
 
 ## handler.ts template (optional)
 
-For skills that need custom draft extraction, state merging, or model building:
+For skills that need custom draft extraction, state merging, or model building.
+The full `SkillHandler` interface is defined in `backend/src/agent-runtime/types.ts`.
 
 ```typescript
 import type { SkillHandler } from '../../agent-runtime/types';
@@ -64,6 +68,11 @@ export const handler: SkillHandler = {
   detectStructuralType(input) {
     // Return StructuralTypeMatch if user text matches this skill
     return null;
+  },
+
+  parseProvidedValues(values) {
+    // Normalize explicit user input into DraftExtraction
+    return { parameters: {}, confidence: 0 };
   },
 
   extractDraft(input) {
@@ -91,6 +100,11 @@ export const handler: SkillHandler = {
     return [];
   },
 
+  // Optional methods (omit if not needed):
+  // buildDefaultProposals?(keys, state, locale) → SkillDefaultProposal[]
+  // buildReportNarrative?(input) → string
+  // resolveStage?(missingKeys, state) → pipeline stage
+
   buildModel(state) {
     // Build the final computable model JSON
     return undefined;
@@ -100,12 +114,12 @@ export const handler: SkillHandler = {
 
 ## Validation rules
 
-1. `skill.yaml` is required and must pass `skillManifestFileSchema` (Zod validation)
+1. `skill.yaml` is required and must pass `skillManifestFileSchema` (Zod validation, see `backend/src/agent-runtime/manifest-schema.ts`)
 2. At least one stage `.md` file is required for auto-discovery
 3. Skill IDs must be unique across all domains
 4. `domain` must be one of the 14 recognized domains
 5. `structureType` must match a known type or be `unknown`
-6. Priority range: 0–100 (default 50)
+6. `priority` is an integer (schema default: 0; recommended user value: 50 for equal weighting)
 
 ## Best practices
 

--- a/backend/src/agent-skills/general/skill-creation/intent.md
+++ b/backend/src/agent-skills/general/skill-creation/intent.md
@@ -1,0 +1,21 @@
+# Skill Creation Wizard
+
+- `zh`: 当用户要求创建、定义或编写新的 StructureClaw 技能时激活此技能。
+- `en`: Activate when the user asks to create, define, or author a new StructureClaw skill.
+
+## When to activate
+
+- User says: "create a new skill", "帮我创建技能", "I want to make a custom skill"
+- User provides a skill.yaml or handler.ts snippet and asks for help
+- User asks about skill structure or how skills work
+
+## Information to collect
+
+1. **Skill ID** — unique identifier (lowercase, hyphens allowed)
+2. **Domain** — one of: structure-type, analysis, code-check, data-input, design, drawing, general, load-boundary, material, report-export, result-postprocess, section, validation, visualization
+3. **Name** — bilingual `{ zh, en }`
+4. **Description** — bilingual `{ zh, en }`
+5. **Triggers** — keywords for intent detection
+6. **Stages** — which pipeline stages the skill participates in (intent, draft, analysis, design)
+7. **Structure type** — if applicable (beam, truss, frame, portal-frame, etc.)
+8. **Handler complexity** — does the skill need a `handler.ts` with custom logic, or are stage markdown files sufficient?

--- a/backend/src/agent-skills/general/skill-creation/skill.yaml
+++ b/backend/src/agent-skills/general/skill-creation/skill.yaml
@@ -11,9 +11,10 @@ triggers:
   - create skill
   - new skill
   - custom skill
-  - 技能
   - 创建技能
+  - 新建技能
   - 自定义技能
+  - 编写技能
   - skill.yaml
 stages:
   - intent

--- a/backend/src/agent-skills/general/skill-creation/skill.yaml
+++ b/backend/src/agent-skills/general/skill-creation/skill.yaml
@@ -1,0 +1,41 @@
+id: skill-creation
+domain: general
+source: builtin
+name:
+  zh: 技能创建向导
+  en: Skill Creation Wizard
+description:
+  zh: 指导用户创建新的 StructureClaw 技能，包括 skill.yaml 清单、阶段 Markdown 文件和可选 handler.ts 模块。
+  en: Guide users through creating new StructureClaw skills, including skill.yaml manifest, stage markdown files, and optional handler.ts modules.
+triggers:
+  - create skill
+  - new skill
+  - custom skill
+  - 技能
+  - 创建技能
+  - 自定义技能
+  - skill.yaml
+stages:
+  - intent
+  - draft
+structureType: unknown
+structuralTypeKeys: []
+capabilities:
+  - skill-authoring
+  - manifest-validation
+requires: []
+conflicts: []
+priority: 10
+compatibility:
+  minRuntimeVersion: 0.1.0
+  skillApiVersion: v1
+supportedAnalysisTypes: []
+supportedModelFamilies: []
+materialFamilies: []
+aliases:
+  - skill-wizard
+  - skill-authoring
+toolHints:
+  primary: write_file
+runtimeContract:
+  role: assistant

--- a/backend/tests/utility-tool-registry.test.mjs
+++ b/backend/tests/utility-tool-registry.test.mjs
@@ -3,11 +3,12 @@ import { loadSkillManifestsFromDirectorySync, resolveBuiltinSkillManifestRoot } 
 import { listAgentToolDefinitions } from '../dist/agent-langgraph/tool-registry.js';
 import path from 'node:path';
 
-const REMAINING_GENERAL_SKILL_IDS = ['memory', 'shell'];
+const REMAINING_GENERAL_SKILL_IDS = ['memory', 'shell', 'skill-creation'];
 const CURRENT_TOOL_IDS = [
   'analyze_file',
   'ask_user_clarification',
   'build_model',
+  'calculate',
   'detect_structure_type',
   'extract_draft_params',
   'generate_report',


### PR DESCRIPTION
## Summary

Closes #220 — addresses tooling gaps in the agent runtime.

### 2.1 Test Coverage & Skill-Creation Skill

- **4 new test files** for previously uncovered modules:
  - `file-tools.test.mjs` — isPathWithinRoot, resolveUploadPath, parseCsv, parseDxf, createAnalyzeFileTool
  - `shell-tool.test.mjs` — isCommandAllowed, truncateByBytes, createShellTool
  - `user-tool-loader.test.mjs` — jsonSchemaToZod, loadUserTools failure modes
  - `calc-tool.test.mjs` — arithmetic, trig, engineering formulas, injection prevention
- **Extended** `workspace-tools.test.mjs` with tests for read_file, write_file, move_path, delete_path, isProbablyBinary, isAllowedFile
- **Updated** `tool-registry.test.mjs` and `tool-policy.test.mjs` for the new `calculate` tool
- **New `skill-creation` meta-skill** (`backend/src/agent-skills/general/skill-creation/`) — guides users through creating new StructureClaw skills with skill.yaml + stage markdown + optional handler.ts templates

### 2.2 Engineering Calculator Tool

- New `calculate` tool (`backend/src/agent-langgraph/calc-tool.ts`) using **mathjs** with locked-down security
- Supports: arithmetic, trigonometric functions, logarithms, power, constants (pi, e)
- Safe expression evaluation: `import`, `evaluate`, `parse` functions are disabled to prevent injection
- Optional `unit` parameter for display labeling

## Impacted Areas

- `backend` — new tool, new tests, new skill, dependency addition (mathjs)
- `tests` — updated utility-tool-registry test for new tool + skill IDs

## Test Plan

- [x] `npm run build --prefix backend` — TypeScript compiles clean
- [x] `npm test --prefix backend -- --runInBand` — 803 tests pass (1 skipped)
- [x] Agent-langgraph specific: 168 tests pass (17 suites)
- [x] New `calculate` tool evaluates arithmetic, trig, engineering formulas correctly
- [x] New `calculate` tool rejects injection attempts (import/evaluate/parse disabled)
- [x] New `skill-creation` skill auto-discovered by AgentSkillLoader
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)