### PR TITLE
fix(backend): preserve DeepSeek V4 reasoning context

### DIFF
--- a/backend/src/agent-langgraph/graph.ts
+++ b/backend/src/agent-langgraph/graph.ts
@@ -75,6 +75,39 @@ function getToolName(message: BaseMessage): string | undefined {
     : undefined;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function buildAiMessageFields(content: unknown, name: unknown, source: Record<string, unknown>): Record<string, unknown> {
+  const fields: Record<string, unknown> = {
+    content: typeof content === 'string' ? content : content as any[],
+  };
+  if (typeof name === 'string' && name.trim().length > 0) fields.name = name;
+
+  const additionalKwargs = asRecord(source.additional_kwargs);
+  if (additionalKwargs) fields.additional_kwargs = additionalKwargs;
+
+  const responseMetadata = asRecord(source.response_metadata);
+  if (responseMetadata) fields.response_metadata = responseMetadata;
+
+  if (source.usage_metadata !== undefined) fields.usage_metadata = source.usage_metadata;
+  if (Array.isArray(source.tool_calls)) fields.tool_calls = source.tool_calls;
+  if (Array.isArray(source.invalid_tool_calls)) fields.invalid_tool_calls = source.invalid_tool_calls;
+
+  return fields;
+}
+
+function hasRestorableAiMetadata(source: Record<string, unknown>): boolean {
+  const additionalKwargs = asRecord(source.additional_kwargs);
+  return (
+    (Array.isArray(source.tool_calls) && source.tool_calls.length > 0)
+    || (additionalKwargs !== undefined && 'reasoning_content' in additionalKwargs)
+  );
+}
+
 export function buildEmptyFinalResponseFallback(
   locale: 'zh' | 'en',
   toolNames: string[],
@@ -169,8 +202,8 @@ function createCallModelNode(
           const role = (m as any).role;
           if (role === 'assistant' || !role) {
             const content = typeof m.content === 'string' ? m.content : JSON.stringify(m.content ?? '');
-            if (!content) return null;
-            return new AIMessage({ content });
+            if (!content && !hasRestorableAiMetadata(m as unknown as Record<string, unknown>)) return null;
+            return new AIMessage(buildAiMessageFields(content, (m as any).name, m as unknown as Record<string, unknown>) as any);
           }
         }
         // AIMessageChunk is not a proper AIMessage — convert it so the LLM
@@ -181,10 +214,8 @@ function createCallModelNode(
           const content = typeof m.content === 'string' ? m.content : JSON.stringify(m.content ?? '');
           // Skip empty AIMessageChunks — they are streaming artifacts
           // (e.g. the final empty chunk after tool calls) with no value.
-          if (!content) return null;
-          const aiMsg = new AIMessage({ content, name: (m as any).name || undefined });
-          if (Array.isArray((m as any).tool_calls)) (aiMsg as any).tool_calls = (m as any).tool_calls;
-          return aiMsg;
+          if (!content && !hasRestorableAiMetadata(m as unknown as Record<string, unknown>)) return null;
+          return new AIMessage(buildAiMessageFields(content, (m as any).name, m as unknown as Record<string, unknown>) as any);
         }
         return m;
       }
@@ -200,9 +231,7 @@ function createCallModelNode(
         return typeof content === 'string' ? new HumanMessage({ content, name }) : new HumanMessage({ content: content as any[], name });
       }
       if (id.includes('AIMessage') || plain.role === 'assistant' || plain.type === 'ai') {
-        const aiMsg = typeof content === 'string' ? new AIMessage({ content, name }) : new AIMessage({ content: content as any[], name });
-        if (Array.isArray(plain.tool_calls)) (aiMsg as any).tool_calls = plain.tool_calls;
-        return aiMsg;
+        return new AIMessage(buildAiMessageFields(content, name, plain) as any);
       }
       if (id.includes('SystemMessage') || plain.role === 'system' || plain.type === 'system') {
         return new SystemMessage(typeof content === 'string' ? content : JSON.stringify(content));

--- a/backend/src/utils/__tests__/llm-options.test.mjs
+++ b/backend/src/utils/__tests__/llm-options.test.mjs
@@ -72,4 +72,33 @@ describe('LLM model options', () => {
     });
     expect(request.messages[1]).not.toHaveProperty('reasoning_content');
   });
+
+  test('does not attach DeepSeek reasoning content when assistant counts diverge', async () => {
+    const { attachDeepSeekReasoningContent } = await import('../../../dist/utils/llm.js');
+    const request = {
+      model: 'deepseek-v4-pro',
+      messages: [
+        { role: 'user', content: 'Need weather.' },
+        { role: 'assistant', content: 'Cloudy.' },
+      ],
+    };
+    const sourceMessages = [
+      new HumanMessage('Need weather.'),
+      new AIMessage({
+        content: '',
+        additional_kwargs: { reasoning_content: 'Need to call a weather tool.' },
+        tool_calls: [{ id: 'call-1', name: 'get_weather', args: {} }],
+      }),
+      new ToolMessage({ tool_call_id: 'call-1', content: 'Cloudy' }),
+      new AIMessage({
+        content: 'Cloudy.',
+        additional_kwargs: { reasoning_content: 'The tool returned a forecast.' },
+      }),
+    ];
+
+    const patched = attachDeepSeekReasoningContent(request, sourceMessages);
+
+    expect(patched).toBe(request);
+    expect(request.messages[1]).not.toHaveProperty('reasoning_content');
+  });
 });

--- a/backend/src/utils/__tests__/llm-options.test.mjs
+++ b/backend/src/utils/__tests__/llm-options.test.mjs
@@ -1,4 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 
 const baseConfig = {
   llmApiKey: 'test-key',
@@ -27,5 +28,48 @@ describe('LLM model options', () => {
     expect(options.streaming).toBe(false);
     expect(options.modelName).toBe('glm-5-turbo');
     expect(options.configuration.baseURL).toBe('https://example.com/v1');
+  });
+
+  test('passes DeepSeek V4 reasoning content back on assistant messages', async () => {
+    const { attachDeepSeekReasoningContent, isDeepSeekV4Model } = await import('../../../dist/utils/llm.js');
+
+    expect(isDeepSeekV4Model('deepseek-v4-pro')).toBe(true);
+    expect(isDeepSeekV4Model('deepseek-reasoner')).toBe(false);
+
+    const request = {
+      model: 'deepseek-v4-pro',
+      messages: [
+        { role: 'user', content: 'Need weather.' },
+        { role: 'assistant', content: '', tool_calls: [{ id: 'call-1', type: 'function' }] },
+        { role: 'tool', tool_call_id: 'call-1', content: 'Cloudy' },
+        { role: 'assistant', content: 'Cloudy.' },
+      ],
+    };
+    const sourceMessages = [
+      new HumanMessage('Need weather.'),
+      new AIMessage({
+        content: '',
+        additional_kwargs: { reasoning_content: 'Need to call a weather tool.' },
+        tool_calls: [{ id: 'call-1', name: 'get_weather', args: {} }],
+      }),
+      new ToolMessage({ tool_call_id: 'call-1', content: 'Cloudy' }),
+      new AIMessage({
+        content: 'Cloudy.',
+        additional_kwargs: { reasoning_content: 'The tool returned a forecast.' },
+      }),
+    ];
+
+    const patched = attachDeepSeekReasoningContent(request, sourceMessages);
+
+    expect(patched).not.toBe(request);
+    expect(patched.messages[1]).toMatchObject({
+      role: 'assistant',
+      reasoning_content: 'Need to call a weather tool.',
+    });
+    expect(patched.messages[3]).toMatchObject({
+      role: 'assistant',
+      reasoning_content: 'The tool returned a forecast.',
+    });
+    expect(request.messages[1]).not.toHaveProperty('reasoning_content');
   });
 });

--- a/backend/src/utils/llm.ts
+++ b/backend/src/utils/llm.ts
@@ -1,4 +1,4 @@
-import { ChatOpenAI } from '@langchain/openai';
+import { ChatOpenAI, ChatOpenAICompletions } from '@langchain/openai';
 import type { config } from '../config/index.js';
 import { getEffectiveLlmSettings } from '../config/llm-runtime.js';
 import { llmCallLogger } from './llm-logger.js';
@@ -33,6 +33,115 @@ export function buildChatModelOptions(
   };
 }
 
+type ChatCompletionRequestLike = {
+  model?: string;
+  messages?: unknown[];
+  [key: string]: unknown;
+};
+
+type ReasoningValue = string | null;
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+export function isDeepSeekV4Model(modelName: string | undefined): boolean {
+  return typeof modelName === 'string' && modelName.toLowerCase().includes('deepseek-v4');
+}
+
+function getMessageType(message: unknown): string | undefined {
+  if (message && typeof message === 'object' && typeof (message as { _getType?: unknown })._getType === 'function') {
+    return ((message as { _getType: () => string })._getType)();
+  }
+  const plain = message as { role?: unknown; type?: unknown } | null;
+  if (typeof plain?.role === 'string') return plain.role === 'assistant' ? 'ai' : plain.role;
+  if (typeof plain?.type === 'string') return plain.type;
+  return undefined;
+}
+
+function getReasoningContent(message: unknown): ReasoningValue | undefined {
+  const additionalKwargs = (message as { additional_kwargs?: unknown } | null)?.additional_kwargs;
+  if (!additionalKwargs || typeof additionalKwargs !== 'object' || Array.isArray(additionalKwargs)) {
+    return undefined;
+  }
+  const record = additionalKwargs as Record<string, unknown>;
+  if (!hasOwn(record, 'reasoning_content')) return undefined;
+  const reasoningContent = record.reasoning_content;
+  return typeof reasoningContent === 'string' || reasoningContent === null ? reasoningContent : undefined;
+}
+
+export function attachDeepSeekReasoningContent(
+  request: ChatCompletionRequestLike,
+  sourceMessages: unknown[] | null,
+): ChatCompletionRequestLike {
+  if (!sourceMessages || !Array.isArray(request.messages)) return request;
+
+  const reasoningByAssistant = sourceMessages
+    .filter((message) => getMessageType(message) === 'ai')
+    .map((message) => getReasoningContent(message));
+
+  if (!reasoningByAssistant.some((value) => value !== undefined)) return request;
+
+  let assistantIndex = 0;
+  let changed = false;
+  const messages = request.messages.map((message) => {
+    if (!message || typeof message !== 'object' || (message as { role?: unknown }).role !== 'assistant') {
+      return message;
+    }
+
+    const reasoningContent = reasoningByAssistant[assistantIndex];
+    assistantIndex += 1;
+    if (reasoningContent === undefined) return message;
+
+    const record = message as Record<string, unknown>;
+    if (hasOwn(record, 'reasoning_content')) return message;
+
+    changed = true;
+    return { ...record, reasoning_content: reasoningContent };
+  });
+
+  return changed ? { ...request, messages } : request;
+}
+
+class DeepSeekV4CompatibleChatOpenAICompletions extends ChatOpenAICompletions {
+  private activeSourceMessages: unknown[] | null = null;
+
+  async _generate(messages: any[], options: any, runManager?: any) {
+    const previous = this.activeSourceMessages;
+    this.activeSourceMessages = messages;
+    try {
+      return await super._generate(messages, options, runManager);
+    } finally {
+      this.activeSourceMessages = previous;
+    }
+  }
+
+  async *_streamResponseChunks(messages: any[], options: any, runManager?: any) {
+    const previous = this.activeSourceMessages;
+    this.activeSourceMessages = messages;
+    try {
+      yield* super._streamResponseChunks(messages, options, runManager);
+    } finally {
+      this.activeSourceMessages = previous;
+    }
+  }
+
+  completionWithRetry(request: any, requestOptions?: any): Promise<any> {
+    const patchedRequest = attachDeepSeekReasoningContent(request, this.activeSourceMessages);
+    return super.completionWithRetry(patchedRequest as any, requestOptions);
+  }
+}
+
+function withProviderCompatibility(options: ReturnType<typeof buildChatModelOptions>) {
+  if (!isDeepSeekV4Model(options.modelName)) {
+    return options;
+  }
+  return {
+    ...options,
+    completions: new DeepSeekV4CompatibleChatOpenAICompletions(options as any),
+  };
+}
+
 export function createChatModel(
   temperature: number,
   runtimeOptions: ChatModelRuntimeOptions = {},
@@ -42,7 +151,9 @@ export function createChatModel(
     return null;
   }
 
-  const model = new ChatOpenAI(buildChatModelOptions(effectiveSettings, temperature, runtimeOptions));
+  const model = new ChatOpenAI(withProviderCompatibility(
+    buildChatModelOptions(effectiveSettings, temperature, runtimeOptions),
+  ));
 
   return wrapWithLlmLogging(model);
 }

--- a/backend/src/utils/llm.ts
+++ b/backend/src/utils/llm.ts
@@ -40,6 +40,7 @@ type ChatCompletionRequestLike = {
 };
 
 type ReasoningValue = string | null;
+const SOURCE_MESSAGES_OPTION_KEY = '__structureClawSourceMessages';
 
 function hasOwn(record: Record<string, unknown>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(record, key);
@@ -79,6 +80,11 @@ export function attachDeepSeekReasoningContent(
   const reasoningByAssistant = sourceMessages
     .filter((message) => getMessageType(message) === 'ai')
     .map((message) => getReasoningContent(message));
+  const requestAssistantCount = request.messages
+    .filter((message) => message && typeof message === 'object' && (message as { role?: unknown }).role === 'assistant')
+    .length;
+
+  if (requestAssistantCount !== reasoningByAssistant.length) return request;
 
   if (!reasoningByAssistant.some((value) => value !== undefined)) return request;
 
@@ -103,32 +109,44 @@ export function attachDeepSeekReasoningContent(
   return changed ? { ...request, messages } : request;
 }
 
-class DeepSeekV4CompatibleChatOpenAICompletions extends ChatOpenAICompletions {
-  private activeSourceMessages: unknown[] | null = null;
+function withSourceMessages(options: any, sourceMessages: unknown[]) {
+  const requestOptions = options?.options && typeof options.options === 'object'
+    ? options.options
+    : {};
+  return {
+    ...(options ?? {}),
+    [SOURCE_MESSAGES_OPTION_KEY]: sourceMessages,
+    options: {
+      ...requestOptions,
+      [SOURCE_MESSAGES_OPTION_KEY]: sourceMessages,
+    },
+  };
+}
 
+function getSourceMessagesFromOptions(options: any): unknown[] | null {
+  const sourceMessages = options?.[SOURCE_MESSAGES_OPTION_KEY];
+  return Array.isArray(sourceMessages) ? sourceMessages : null;
+}
+
+function withoutSourceMessagesOption(options: any) {
+  if (!options || typeof options !== 'object' || Array.isArray(options)) return options;
+  const { [SOURCE_MESSAGES_OPTION_KEY]: _sourceMessages, ...rest } = options;
+  return rest;
+}
+
+class DeepSeekV4CompatibleChatOpenAICompletions extends ChatOpenAICompletions {
   async _generate(messages: any[], options: any, runManager?: any) {
-    const previous = this.activeSourceMessages;
-    this.activeSourceMessages = messages;
-    try {
-      return await super._generate(messages, options, runManager);
-    } finally {
-      this.activeSourceMessages = previous;
-    }
+    return await super._generate(messages, withSourceMessages(options, messages), runManager);
   }
 
   async *_streamResponseChunks(messages: any[], options: any, runManager?: any) {
-    const previous = this.activeSourceMessages;
-    this.activeSourceMessages = messages;
-    try {
-      yield* super._streamResponseChunks(messages, options, runManager);
-    } finally {
-      this.activeSourceMessages = previous;
-    }
+    yield* super._streamResponseChunks(messages, withSourceMessages(options, messages), runManager);
   }
 
   completionWithRetry(request: any, requestOptions?: any): Promise<any> {
-    const patchedRequest = attachDeepSeekReasoningContent(request, this.activeSourceMessages);
-    return super.completionWithRetry(patchedRequest as any, requestOptions);
+    const sourceMessages = getSourceMessagesFromOptions(requestOptions);
+    const patchedRequest = attachDeepSeekReasoningContent(request, sourceMessages);
+    return super.completionWithRetry(patchedRequest as any, withoutSourceMessagesOption(requestOptions));
   }
 }
 


### PR DESCRIPTION
## Summary
- Problem: DeepSeek V4 Pro thinking mode can return `reasoning_content`, and provider-compatible tool-call turns may reject follow-up requests when that field is dropped.
- Why it matters: StructureClaw routes agent turns through tool calls, so losing provider reasoning metadata can break DeepSeek V4 Pro conversations after a tool result.
- What changed: Preserve AI message metadata during graph message reconstruction and attach DeepSeek V4 `reasoning_content` back onto assistant messages before OpenAI-compatible chat completions requests.
- What did NOT change (scope boundary): Token-level LLM streaming remains disabled in the graph path; this PR does not restore streamed model tokens.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #257
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)
- Root cause: LangChain preserves DeepSeek `reasoning_content` in `additional_kwargs`, but the OpenAI-compatible completions request conversion does not send that provider-specific field back on assistant messages.
- Missing detection / guardrail: There was no unit coverage for provider-specific assistant metadata surviving tool-call round trips.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Issue #257 reported DeepSeek V4 Pro compatibility.
- Why this regressed now: DeepSeek V4 Pro thinking mode makes this field relevant for tool-call follow-up requests.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
- [x] Unit test
- [ ] Seam / integration test
- [ ] End-to-end test
- [ ] Existing coverage already sufficient
- Target test or file: `backend/src/utils/__tests__/llm-options.test.mjs`
- Scenario the test should lock in: Assistant messages with DeepSeek V4 `reasoning_content` keep that field when converted into chat completions request messages.
- Why this is the smallest reliable guardrail: It tests the exact compatibility shim without requiring a live DeepSeek API key.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
DeepSeek V4 Pro provider compatibility is improved for agent/tool-call conversations. No settings or UI changes.

## Diagram (if applicable)
```text
Before: DeepSeek V4 assistant tool call -> tool result -> follow-up request without reasoning_content -> provider may reject
After: DeepSeek V4 assistant tool call -> tool result -> follow-up request with reasoning_content -> provider-compatible continuation
```

## Security Impact (required)
- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification
### Environment
- OS: Windows
- Runtime/container: Node.js backend, local workspace
- Model/provider: DeepSeek V4 Pro compatibility path, tested without live provider call
- Integration/channel (if any): OpenAI-compatible chat completions
- Relevant config (redacted): N/A

### Steps
1. Build backend.
2. Run backend lint.
3. Run targeted Jest tests for LLM options and graph message state.

### Expected
- Backend compiles and lint passes.
- DeepSeek V4 reasoning metadata is attached to assistant chat completion messages.
- Existing graph state and empty response guards continue to pass.

### Actual
- All verification commands passed locally.

## Evidence
- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)
- Verified scenarios: `npm run build --prefix backend`; `npm run lint --prefix backend`; `npm test --prefix backend -- --runInBand src/utils/__tests__/llm-options.test.mjs src/agent-langgraph/__tests__/graph-state.test.mjs src/agent-langgraph/__tests__/graph-empty-response.test.mjs`
- Edge cases checked: Empty AI chunks without restorable metadata are still skipped; AI messages with tool calls or DeepSeek reasoning metadata are preserved.
- What you did **not** verify: Live DeepSeek V4 Pro API call with a real API key; restoring token-level LLM streaming.

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations
- Risk: The compatibility shim is scoped by model name and could miss differently named DeepSeek V4 variants.
- Mitigation: The matcher targets `deepseek-v4` case-insensitively, matching the reported model family while avoiding unrelated providers.