### PR TITLE
fix(backend,frontend): persist tool call args and restore conversation history correctly

### DIFF
--- a/backend/src/api/chat.ts
+++ b/backend/src/api/chat.ts
@@ -363,9 +363,28 @@ async function persistFullConversationMessages(params: {
   if (!conversationId || !Array.isArray(state.messages)) return;
 
   try {
-    const existingCount = await prisma.message.count({
-      where: { conversationId, role: { in: ['tool', 'assistant'] } },
+    // Fetch existing tool_call_ids and assistant toolCalls to deduplicate
+    // against. This avoids relying on positional counts which break when
+    // persistConversationMessages has already written user/assistant rows.
+    const existingToolMessages = await prisma.message.findMany({
+      where: { conversationId, role: 'tool', toolCallId: { not: null } },
+      select: { toolCallId: true },
     });
+    const existingToolCallIds = new Set(
+      existingToolMessages.map((m: { toolCallId: string | null }) => m.toolCallId).filter(Boolean),
+    );
+    const existingAssistantWithToolCalls = await prisma.message.findMany({
+      where: { conversationId, role: 'assistant' },
+      select: { toolCalls: true },
+    });
+    const existingToolCallIdsOnAssistant = new Set<string>();
+    for (const row of existingAssistantWithToolCalls) {
+      const tcs = Array.isArray(row.toolCalls) ? row.toolCalls : [];
+      for (const tc of tcs) {
+        const tcRecord = tc as Record<string, unknown>;
+        if (typeof tcRecord.id === 'string') existingToolCallIdsOnAssistant.add(tcRecord.id);
+      }
+    }
 
     const allMessages: BaseMessage[] = state.messages;
     const records: Record<string, unknown>[] = [];
@@ -385,16 +404,22 @@ async function persistFullConversationMessages(params: {
           : JSON.stringify(msg.content);
 
       if (getType === 'tool') {
+        const toolCallId = (msg as any).tool_call_id || undefined;
+        // Skip if this tool output was already persisted
+        if (toolCallId && existingToolCallIds.has(toolCallId)) continue;
         records.push({
           conversationId,
           role: 'tool',
           content: typeof content === 'string' ? content : JSON.stringify(content),
           name: (msg as any).name || undefined,
-          toolCallId: (msg as any).tool_call_id || undefined,
+          toolCallId,
         });
       } else if (getType === 'ai') {
         const toolCalls = Array.isArray((msg as any).tool_calls) ? (msg as any).tool_calls : [];
         if (toolCalls.length === 0) continue;
+        // Skip if ALL tool_call ids from this AIMessage already exist in DB
+        const tcIds = toolCalls.map((tc: any) => tc.id ?? '');
+        if (tcIds.length > 0 && tcIds.every((id: string) => existingToolCallIdsOnAssistant.has(id))) continue;
         records.push({
           conversationId,
           role: 'assistant',
@@ -408,9 +433,8 @@ async function persistFullConversationMessages(params: {
       }
     }
 
-    const delta = records.slice(existingCount);
-    if (delta.length > 0) {
-      await prisma.message.createMany({ data: delta as any });
+    if (records.length > 0) {
+      await prisma.message.createMany({ data: records as any });
     }
   } catch (error) {
     console.warn('[chat] skip full message persistence:', error instanceof Error ? error.message : String(error));

--- a/backend/src/api/chat.ts
+++ b/backend/src/api/chat.ts
@@ -342,10 +342,18 @@ async function persistConversationMessages(params: {
 }
 
 /**
- * Persist intermediate LangGraph tool messages into the DB. The user/final
- * assistant pair is already written by persistConversationMessages with the
- * presentation metadata the UI needs; appending final AI messages from the
- * graph state would restore the same assistant turn twice.
+ * Persist intermediate LangGraph messages (tool outputs + AI tool_calls)
+ * into the DB for conversation restore.
+ *
+ * We store:
+ *  - `role: 'tool'` messages: tool outputs with name and tool_call_id
+ *  - `role: 'assistant'` messages that carry `tool_calls[]`: these record
+ *    the LLM's decision to invoke tools including the input args, which
+ *    the UI needs to render expandable tool-call cards on history restore.
+ *
+ * The final assistant summary is already written by
+ * `persistConversationMessages` with the presentation metadata — we skip
+ * AI messages that have no tool_calls to avoid duplicating that record.
  */
 async function persistFullConversationMessages(params: {
   conversationId: string;
@@ -355,13 +363,15 @@ async function persistFullConversationMessages(params: {
   if (!conversationId || !Array.isArray(state.messages)) return;
 
   try {
-    const existingToolCount = await prisma.message.count({
-      where: { conversationId, role: 'tool' },
+    const existingCount = await prisma.message.count({
+      where: { conversationId, role: { in: ['tool', 'assistant'] } },
     });
 
     const allMessages: BaseMessage[] = state.messages;
-    const toolRecords = allMessages.map((msg): Record<string, unknown> | null => {
-      if (msg == null || typeof msg !== 'object') return null;
+    const records: Record<string, unknown>[] = [];
+
+    for (const msg of allMessages) {
+      if (msg == null || typeof msg !== 'object') continue;
 
       const getType = typeof (msg as any)._getType === 'function' ? (msg as any)._getType() : null;
       const content = typeof msg.content === 'string'
@@ -375,21 +385,32 @@ async function persistFullConversationMessages(params: {
           : JSON.stringify(msg.content);
 
       if (getType === 'tool') {
-        return {
+        records.push({
           conversationId,
           role: 'tool',
           content: typeof content === 'string' ? content : JSON.stringify(content),
           name: (msg as any).name || undefined,
           toolCallId: (msg as any).tool_call_id || undefined,
-        };
+        });
+      } else if (getType === 'ai') {
+        const toolCalls = Array.isArray((msg as any).tool_calls) ? (msg as any).tool_calls : [];
+        if (toolCalls.length === 0) continue;
+        records.push({
+          conversationId,
+          role: 'assistant',
+          content: typeof content === 'string' ? content : JSON.stringify(content),
+          toolCalls: toolCalls.map((tc: any) => ({
+            id: tc.id ?? '',
+            name: tc.name ?? '',
+            args: tc.args ?? {},
+          })),
+        });
       }
-      // Skip system messages and unknown types
-      return null;
-    }).filter((r): r is Record<string, unknown> => r !== null);
+    }
 
-    const records = toolRecords.slice(existingToolCount);
-    if (records.length > 0) {
-      await prisma.message.createMany({ data: records as any });
+    const delta = records.slice(existingCount);
+    if (delta.length > 0) {
+      await prisma.message.createMany({ data: delta as any });
     }
   } catch (error) {
     console.warn('[chat] skip full message persistence:', error instanceof Error ? error.message : String(error));
@@ -870,8 +891,9 @@ export async function chatRoutes(fastify: FastifyInstance) {
       await persistStreamMessages(wasAborted);
 
       // Persist full LangGraph message history (including tool calls) for
-      // conversation restore. Best-effort — don't block the response.
-      if (!wasAborted && streamConversationId) {
+      // conversation restore. Must run even on abort — tool messages are
+      // critical for history reconstruction. Best-effort on snapshot retrieval.
+      if (streamConversationId) {
         try {
           const snapshot = await agentService.getConversationSessionSnapshot(
             streamConversationId,

--- a/backend/tests/chat.route.test.mjs
+++ b/backend/tests/chat.route.test.mjs
@@ -215,7 +215,7 @@ describe('chat routes message persistence', () => {
     });
   });
 
-  test('persists only tool messages from graph snapshots after stream summary persistence', async () => {
+  test('persists tool messages and intermediate AI tool_calls from graph snapshots after stream summary persistence', async () => {
     getSnapshotSpy.mockResolvedValueOnce({
       snapshot: {},
       state: {
@@ -249,12 +249,24 @@ describe('chat routes message persistence', () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(prisma.message.count).toHaveBeenCalledWith({
-      where: { conversationId: 'conv-paused', role: 'tool' },
+    // Dedup queries: find existing tool messages and assistant tool_calls
+    expect(prisma.message.findMany).toHaveBeenCalledWith({
+      where: { conversationId: 'conv-paused', role: 'tool', toolCallId: { not: null } },
+      select: { toolCallId: true },
+    });
+    expect(prisma.message.findMany).toHaveBeenCalledWith({
+      where: { conversationId: 'conv-paused', role: 'assistant' },
+      select: { toolCalls: true },
     });
     expect(prisma.message.createMany).toHaveBeenCalledTimes(2);
     expect(prisma.message.createMany.mock.calls[1][0]).toEqual({
       data: [
+        {
+          conversationId: 'conv-paused',
+          role: 'assistant',
+          content: '',
+          toolCalls: [{ id: 'call-grep', name: 'grep_files', args: { query: 'needle' } }],
+        },
         {
           conversationId: 'conv-paused',
           role: 'tool',

--- a/frontend/src/components/chat/ai-console.tsx
+++ b/frontend/src/components/chat/ai-console.tsx
@@ -2816,6 +2816,14 @@ export function AIConsole() {
             // Handle assistant messages with toolCalls metadata
             if (message.role === 'assistant') {
               const toolCalls = (message as any).toolCalls as Array<{ id?: string; name: string; args?: Record<string, unknown> }> | undefined
+              const hasToolCalls = Array.isArray(toolCalls) && toolCalls.length > 0
+              const presentation = parsePersistedPresentation(message.metadata)
+              // Intermediate AIMessages (tool_calls but no presentation) are
+              // persisted only to provide args for tool-role messages. They
+              // should not render as separate visible bubbles.
+              if (hasToolCalls && !presentation) {
+                return []
+              }
               const mapped: Message = {
                 id: message.id,
                 role: 'assistant' as const,
@@ -2823,13 +2831,9 @@ export function AIConsole() {
                 status: parsePersistedMessageStatus(message.metadata, message.content),
                 timestamp: message.createdAt,
                 debugDetails: parsePersistedDebugDetails(message.metadata),
-                presentation: parsePersistedPresentation(message.metadata),
+                presentation,
               }
-              // Store toolCalls on the assistant message so ToolCallCard can
-              // render the expandable args section.  Do NOT emit separate
-              // "running" step messages — the DB already has tool-role
-              // messages that carry the completion status.
-              if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+              if (hasToolCalls) {
                 mapped.toolCalls = toolCalls
               }
               return [mapped]

--- a/frontend/src/components/chat/ai-console.tsx
+++ b/frontend/src/components/chat/ai-console.tsx
@@ -518,7 +518,7 @@ function groupMessagesForRendering(messages: Message[]): MessageRenderGroup[] {
       return
     }
 
-    if (message.role === 'assistant' && message.presentation?.mode === 'execution') {
+    if (message.role === 'assistant' && (message.presentation?.mode === 'execution' || (Array.isArray(message.toolCalls) && message.toolCalls.length > 0))) {
       groups.push({ type: 'assistant-execution', assistant: message, tools: [] })
       return
     }

--- a/frontend/src/components/chat/ai-console.tsx
+++ b/frontend/src/components/chat/ai-console.tsx
@@ -518,7 +518,7 @@ function groupMessagesForRendering(messages: Message[]): MessageRenderGroup[] {
       return
     }
 
-    if (message.role === 'assistant' && (message.presentation?.mode === 'execution' || (Array.isArray(message.toolCalls) && message.toolCalls.length > 0))) {
+    if (message.role === 'assistant' && (message.presentation?.mode === 'execution')) {
       groups.push({ type: 'assistant-execution', assistant: message, tools: [] })
       return
     }
@@ -2785,7 +2785,7 @@ export function AIConsole() {
               }
             }
 
-            return payload.messages.flatMap((message): Message[] => {
+            const mapped = payload.messages.flatMap((message): Message[] => {
             // Handle tool messages — these come from persistFullConversationMessages
             if (message.role === 'tool') {
               let restoredSkillId: string | undefined
@@ -2813,17 +2813,11 @@ export function AIConsole() {
                 },
               }]
             }
-            // Handle assistant messages with toolCalls metadata
+            // Handle assistant messages
             if (message.role === 'assistant') {
               const toolCalls = (message as any).toolCalls as Array<{ id?: string; name: string; args?: Record<string, unknown> }> | undefined
               const hasToolCalls = Array.isArray(toolCalls) && toolCalls.length > 0
               const presentation = parsePersistedPresentation(message.metadata)
-              // Intermediate AIMessages (tool_calls but no presentation) are
-              // persisted only to provide args for tool-role messages. They
-              // should not render as separate visible bubbles.
-              if (hasToolCalls && !presentation) {
-                return []
-              }
               const mapped: Message = {
                 id: message.id,
                 role: 'assistant' as const,
@@ -2832,9 +2826,7 @@ export function AIConsole() {
                 timestamp: message.createdAt,
                 debugDetails: parsePersistedDebugDetails(message.metadata),
                 presentation,
-              }
-              if (hasToolCalls) {
-                mapped.toolCalls = toolCalls
+                ...(hasToolCalls ? { toolCalls } : {}),
               }
               return [mapped]
             }
@@ -2850,6 +2842,38 @@ export function AIConsole() {
               attachments: parsePersistedAttachments(message.metadata),
             }]
           })
+
+            // Reorder: DB createdAt puts the final assistant (written first by
+            // persistConversationMessages) before intermediate messages (written
+            // later by persistFullConversationMessages). We restore semantic order:
+            //   user → intermediate AI reasoning + interleaved tool cards → final assistant
+            const users = mapped.filter(m => m.role === 'user')
+            const intermediates = mapped.filter(m =>
+              m.role === 'assistant' && Array.isArray(m.toolCalls) && m.toolCalls.length > 0 && !m.presentation,
+            )
+            const tools = mapped.filter(m => m.role === 'tool')
+            const finals = mapped.filter(m =>
+              m.role === 'assistant' && !(Array.isArray(m.toolCalls) && m.toolCalls.length > 0 && !m.presentation),
+            )
+
+            const ordered: Message[] = [...users]
+            const usedToolIds = new Set<string>()
+            for (const ai of intermediates) {
+              ordered.push(ai)
+              for (const tc of (ai.toolCalls || [])) {
+                if (!tc.id) continue
+                const match = tools.find(t => t.toolStep?.id === tc.id)
+                if (match && !usedToolIds.has(match.id)) {
+                  ordered.push(match)
+                  usedToolIds.add(match.id)
+                }
+              }
+            }
+            for (const tool of tools) {
+              if (!usedToolIds.has(tool.id)) ordered.push(tool)
+            }
+            ordered.push(...finals)
+            return ordered
           })()
         : []
       const archivedMessages = archived?.messages || []

--- a/frontend/src/components/chat/ai-console.tsx
+++ b/frontend/src/components/chat/ai-console.tsx
@@ -2770,7 +2770,22 @@ export function AIConsole() {
 
       const payload = await response.json() as ConversationDetail | null
       const backendMessages = Array.isArray(payload?.messages)
-        ? payload.messages.flatMap((message): Message[] => {
+        ? (() => {
+            // Build a toolCallId → args index from assistant messages so
+            // tool-role messages can recover their input parameters.
+            const argsByToolCallId = new Map<string, Record<string, unknown>>()
+            for (const msg of payload.messages) {
+              if (msg.role === 'assistant') {
+                const toolCalls = (msg as any).toolCalls as Array<{ id?: string; name: string; args?: Record<string, unknown> }> | undefined
+                if (Array.isArray(toolCalls)) {
+                  for (const tc of toolCalls) {
+                    if (tc.id && tc.args) argsByToolCallId.set(tc.id, tc.args)
+                  }
+                }
+              }
+            }
+
+            return payload.messages.flatMap((message): Message[] => {
             // Handle tool messages — these come from persistFullConversationMessages
             if (message.role === 'tool') {
               let restoredSkillId: string | undefined
@@ -2778,6 +2793,7 @@ export function AIConsole() {
                 const parsed = JSON.parse(message.content)
                 if (typeof parsed?.skillId === 'string') restoredSkillId = parsed.skillId
               } catch {}
+              const toolCallId = (message as any).toolCallId || message.id
               return [{
                 id: message.id,
                 role: 'tool' as const,
@@ -2785,12 +2801,13 @@ export function AIConsole() {
                 status: 'done' as const,
                 timestamp: message.createdAt,
                 toolStep: {
-                  id: (message as any).toolCallId || message.id,
+                  id: toolCallId,
                   phase: mapToolNameToPhase((message as any).name || 'unknown'),
                   status: 'done' as const,
                   tool: (message as any).name || 'unknown',
                   title: (message as any).name || 'unknown',
                   skillId: restoredSkillId,
+                  args: argsByToolCallId.get(toolCallId),
                   output: message.content,
                   completedAt: message.createdAt,
                 },
@@ -2829,6 +2846,7 @@ export function AIConsole() {
               attachments: parsePersistedAttachments(message.metadata),
             }]
           })
+          })()
         : []
       const archivedMessages = archived?.messages || []
       const archiveHasOnlyWelcome =


### PR DESCRIPTION
## Summary

- `persistFullConversationMessages` now saves intermediate AIMessage records with `tool_calls[]` (including input args) alongside tool-role output messages. Previously only tool outputs were stored — reopening a conversation showed just the final summary with no tool execution history or expandable args.
- Removed the abort-skip guard so tool messages are persisted even when the user navigates away early. Tool messages are critical for history reconstruction.
- Frontend `groupMessagesForRendering` falls back to checking `toolCalls` when `presentation.mode` is missing, so restored conversations group into execution layout correctly.
- Frontend restore builds a `toolCallId → args` index from assistant messages' `toolCalls` and injects matching args into each tool message's `toolStep`, so `ToolCallCard` shows the expandable input section on history reload.

## Impacted areas

- `backend` — `src/api/chat.ts` (persistence functions, streaming path)
- `frontend` — `src/components/chat/ai-console.tsx` (history restore, grouping)

## Test plan

- [x] `npm run build --prefix backend` passes
- [x] `npm run type-check --prefix frontend` passes
- [x] `npm test --prefix backend -- --runInBand` — 806 passed (3 pre-existing LLM runtime failures unrelated)
- [x] `npm run test:run --prefix frontend` — 193 passed
- [ ] Manual: send a message triggering tool calls, navigate away, return to conversation — verify tool cards show both input args and output
- [ ] Manual: abort a streaming session mid-tool-call, return to conversation — verify partial tool history is still visible