### PR TITLE
feat(skills): change csv skill

### DIFF
--- a/backend/src/agent-skills/data-input/csv/__tests__/entry.test.mjs
+++ b/backend/src/agent-skills/data-input/csv/__tests__/entry.test.mjs
@@ -286,6 +286,47 @@ describe('mapCsvToDraftHints — CSV input', () => {
     expect(result.fields.storyCount).toBe(5);
     expect(result.fields.heightM).toBe(17.5);
   });
+
+  test('honours mm/cm/km units on length scalars', () => {
+    const mm = mapCsvToDraftHints({
+      type: 'csv',
+      headers: ['总高', '跨度'],
+      rows: [['17500mm', '6000 mm']],
+    });
+    expect(mm.fields.heightM).toBe(17.5);
+    expect(mm.fields.spanLengthM).toBe(6);
+
+    const cm = mapCsvToDraftHints({
+      type: 'csv',
+      headers: ['总高'],
+      rows: [['1750 cm']],
+    });
+    expect(cm.fields.heightM).toBe(17.5);
+  });
+
+  test('honours mm units inside bayWidthsM vector', () => {
+    const result = mapCsvToDraftHints({
+      type: 'csv',
+      headers: ['开间'],
+      rows: [['6000mm'], ['7500mm'], ['6000 mm']],
+    });
+    expect(result.fields.bayWidthsM).toEqual([6, 7.5, 6]);
+  });
+
+  test('converts force units to kN inside floorLoads', () => {
+    const result = mapCsvToDraftHints({
+      type: 'csv',
+      headers: ['楼层', '恒载', '活载'],
+      rows: [
+        ['1', '5000 N/m²', '2000N/m²'],
+        ['2', '0.5 tf/m²', '0.2 tf/m²'],
+      ],
+    });
+    expect(result.fields.floorLoads).toEqual([
+      { story: 1, verticalKN: 5, liveLoadKN: 2 },
+      { story: 2, verticalKN: 0.5 * 9.81, liveLoadKN: 0.2 * 9.81 },
+    ]);
+  });
 });
 
 describe('mapCsvToDraftHints — Excel multi-sheet', () => {

--- a/backend/src/agent-skills/data-input/csv/__tests__/entry.test.mjs
+++ b/backend/src/agent-skills/data-input/csv/__tests__/entry.test.mjs
@@ -74,6 +74,13 @@ describe('parseNumericCell', () => {
     expect(parseNumericCell('5 kN')).toEqual({ value: 5, unit: 'kn' });
   });
 
+  test('parses superscript and compound units common in structural engineering', () => {
+    expect(parseNumericCell('5 kN/m²')).toEqual({ value: 5, unit: 'kn/m²' });
+    expect(parseNumericCell('2.5kN/m³')).toEqual({ value: 2.5, unit: 'kn/m³' });
+    expect(parseNumericCell('120 kN.m')).toEqual({ value: 120, unit: 'kn.m' });
+    expect(parseNumericCell('1.5e3 mm')).toEqual({ value: 1500, unit: 'mm' });
+  });
+
   test('handles thousands separators', () => {
     expect(parseNumericCell('1,200')).toEqual({ value: 1200, unit: '' });
     expect(parseNumericCell('12,000mm')).toEqual({ value: 12000, unit: 'mm' });

--- a/backend/src/agent-skills/data-input/csv/__tests__/entry.test.mjs
+++ b/backend/src/agent-skills/data-input/csv/__tests__/entry.test.mjs
@@ -1,0 +1,303 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  matchColumnToField,
+  normalizeHeader,
+  parseNumericCell,
+  normalizeStoryHeights,
+  normalizeFloorLoads,
+  mapCsvToDraftHints,
+} from '../../../../../dist/agent-skills/data-input/csv/entry.js';
+
+// ---------------------------------------------------------------------------
+// Header normalisation + alias matching
+// ---------------------------------------------------------------------------
+
+describe('normalizeHeader', () => {
+  test('lower-cases ASCII letters and keeps Chinese characters', () => {
+    expect(normalizeHeader('Story Height')).toBe('storyheight');
+    expect(normalizeHeader('层高')).toBe('层高');
+  });
+
+  test('strips parenthetical fragments and unit suffixes inside parens', () => {
+    expect(normalizeHeader('层高(m)')).toBe('层高');
+    expect(normalizeHeader('Story Height (mm)')).toBe('storyheight');
+    expect(normalizeHeader('恒载（kN/m²）')).toBe('恒载');
+  });
+
+  test('collapses ASCII and full-width whitespace', () => {
+    expect(normalizeHeader('  Dead   Load ')).toBe('deadload');
+    expect(normalizeHeader('层 高')).toBe('层高');
+    expect(normalizeHeader('层　高')).toBe('层高');
+  });
+
+  test('returns empty string for non-string or empty input', () => {
+    expect(normalizeHeader('')).toBe('');
+  });
+});
+
+describe('matchColumnToField', () => {
+  test('matches Chinese aliases (层高 / 恒载 / 楼层)', () => {
+    expect(matchColumnToField('层高')).toBe('storyHeightsM');
+    expect(matchColumnToField('层高(m)')).toBe('storyHeightsM');
+    expect(matchColumnToField('恒荷载')).toBe('verticalKN');
+    expect(matchColumnToField('楼层')).toBe('storyIndex');
+  });
+
+  test('matches English aliases case-insensitively', () => {
+    expect(matchColumnToField('Story Height')).toBe('storyHeightsM');
+    expect(matchColumnToField('DL')).toBe('verticalKN');
+    expect(matchColumnToField('Dead Load')).toBe('verticalKN');
+    expect(matchColumnToField('Live Load')).toBe('liveLoadKN');
+  });
+
+  test('returns null for unknown headers', () => {
+    expect(matchColumnToField('混凝土等级')).toBeNull();
+    expect(matchColumnToField('foobar')).toBeNull();
+    expect(matchColumnToField('')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseNumericCell
+// ---------------------------------------------------------------------------
+
+describe('parseNumericCell', () => {
+  test('parses bare numbers as numeric or string', () => {
+    expect(parseNumericCell(3500)).toEqual({ value: 3500, unit: '' });
+    expect(parseNumericCell('3500')).toEqual({ value: 3500, unit: '' });
+    expect(parseNumericCell('3.5')).toEqual({ value: 3.5, unit: '' });
+  });
+
+  test('parses values with trailing units', () => {
+    expect(parseNumericCell('3500mm')).toEqual({ value: 3500, unit: 'mm' });
+    expect(parseNumericCell('3.5 m')).toEqual({ value: 3.5, unit: 'm' });
+    expect(parseNumericCell('5 kN')).toEqual({ value: 5, unit: 'kn' });
+  });
+
+  test('handles thousands separators', () => {
+    expect(parseNumericCell('1,200')).toEqual({ value: 1200, unit: '' });
+    expect(parseNumericCell('12,000mm')).toEqual({ value: 12000, unit: 'mm' });
+  });
+
+  test('returns null for empty-cell sentinels', () => {
+    expect(parseNumericCell('')).toBeNull();
+    expect(parseNumericCell('N/A')).toBeNull();
+    expect(parseNumericCell('n/a')).toBeNull();
+    expect(parseNumericCell('—')).toBeNull();
+    expect(parseNumericCell('-')).toBeNull();
+    expect(parseNumericCell(null)).toBeNull();
+    expect(parseNumericCell(undefined)).toBeNull();
+  });
+
+  test('returns null for strings with no leading number', () => {
+    expect(parseNumericCell('abc')).toBeNull();
+    expect(parseNumericCell('C30')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeStoryHeights
+// ---------------------------------------------------------------------------
+
+describe('normalizeStoryHeights', () => {
+  test('replicates a single bare-metres height across storyCount', () => {
+    const result = normalizeStoryHeights(
+      ['层高'],
+      [['3.5']],
+      { heightHeader: '层高', storyCount: 5 },
+    );
+    expect(result.values).toEqual([3.5, 3.5, 3.5, 3.5, 3.5]);
+  });
+
+  test('auto-converts millimetre values to metres', () => {
+    const result = normalizeStoryHeights(
+      ['层高'],
+      [['3500']],
+      { heightHeader: '层高', storyCount: 3 },
+    );
+    expect(result.values).toEqual([3.5, 3.5, 3.5]);
+  });
+
+  test('keeps per-story heights when storyHeader is present', () => {
+    const result = normalizeStoryHeights(
+      ['楼层', '层高'],
+      [
+        ['1', '4.5'],
+        ['2', '3.5'],
+        ['3', '3.5'],
+      ],
+      { heightHeader: '层高', storyHeader: '楼层' },
+    );
+    expect(result.values).toEqual([4.5, 3.5, 3.5]);
+  });
+
+  test('warns on out-of-range bare-number heights', () => {
+    const result = normalizeStoryHeights(
+      ['层高'],
+      [['50']], // ambiguous: not mm, not plausible m
+      { heightHeader: '层高', storyCount: 1 },
+    );
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeFloorLoads
+// ---------------------------------------------------------------------------
+
+describe('normalizeFloorLoads', () => {
+  test('emits one FloorLoad per row with at least one populated load', () => {
+    const result = normalizeFloorLoads(
+      ['楼层', '恒载', '活载'],
+      [
+        ['1', '5', '2'],
+        ['2', '5', '2'],
+        ['3', '4', '1.5'],
+      ],
+      { storyHeader: '楼层', verticalHeader: '恒载', liveLoadHeader: '活载' },
+    );
+    expect(result.values).toEqual([
+      { story: 1, verticalKN: 5, liveLoadKN: 2 },
+      { story: 2, verticalKN: 5, liveLoadKN: 2 },
+      { story: 3, verticalKN: 4, liveLoadKN: 1.5 },
+    ]);
+  });
+
+  test('leaves missing load columns as undefined (not zero)', () => {
+    const result = normalizeFloorLoads(
+      ['楼层', '恒载'],
+      [
+        ['1', '5'],
+        ['2', '5'],
+      ],
+      { storyHeader: '楼层', verticalHeader: '恒载' },
+    );
+    expect(result.values).toEqual([
+      { story: 1, verticalKN: 5 },
+      { story: 2, verticalKN: 5 },
+    ]);
+    for (const entry of result.values) {
+      expect(entry.liveLoadKN).toBeUndefined();
+      expect(entry.lateralXKN).toBeUndefined();
+      expect(entry.lateralYKN).toBeUndefined();
+    }
+  });
+
+  test('synthesises story numbers when no storyIndex column exists', () => {
+    const result = normalizeFloorLoads(
+      ['恒载', '活载'],
+      [
+        ['5', '2'],
+        ['4', '1.5'],
+      ],
+      { verticalHeader: '恒载', liveLoadHeader: '活载' },
+    );
+    expect(result.values).toEqual([
+      { story: 1, verticalKN: 5, liveLoadKN: 2 },
+      { story: 2, verticalKN: 4, liveLoadKN: 1.5 },
+    ]);
+  });
+
+  test('returns empty when no load columns are mapped', () => {
+    const result = normalizeFloorLoads(['楼层'], [['1']], { storyHeader: '楼层' });
+    expect(result.values).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapCsvToDraftHints
+// ---------------------------------------------------------------------------
+
+describe('mapCsvToDraftHints — CSV input', () => {
+  test('produces a full DraftState patch from a complete spreadsheet', () => {
+    const result = mapCsvToDraftHints({
+      type: 'csv',
+      headers: ['楼层', '层高', '恒载', '活载'],
+      rows: [
+        ['1', '3.5', '5', '2'],
+        ['2', '3.5', '5', '2'],
+        ['3', '3.5', '4', '1.5'],
+      ],
+    });
+
+    expect(result.unmappedHeaders).toEqual([]);
+    expect(result.fields.storyHeightsM).toEqual([3.5, 3.5, 3.5]);
+    expect(result.fields.floorLoads).toEqual([
+      { story: 1, verticalKN: 5, liveLoadKN: 2 },
+      { story: 2, verticalKN: 5, liveLoadKN: 2 },
+      { story: 3, verticalKN: 4, liveLoadKN: 1.5 },
+    ]);
+  });
+
+  test('reports unknown columns in unmappedHeaders', () => {
+    const result = mapCsvToDraftHints({
+      type: 'csv',
+      headers: ['楼层', '层高', '混凝土等级', '钢筋牌号'],
+      rows: [['1', '3.5', 'C30', 'HRB400']],
+    });
+    expect(result.unmappedHeaders).toEqual(['混凝土等级', '钢筋牌号']);
+    expect(result.fields.storyHeightsM).toEqual([3.5]);
+  });
+
+  test('returns empty fields and lists all headers when nothing matches', () => {
+    const result = mapCsvToDraftHints({
+      type: 'csv',
+      headers: ['项目', '设计单位'],
+      rows: [['办公楼', '某院']],
+    });
+    expect(result.fields).toEqual({});
+    expect(result.unmappedHeaders).toEqual(['项目', '设计单位']);
+  });
+
+  test('extracts storyCount and heightM as scalars from the first valid row', () => {
+    const result = mapCsvToDraftHints({
+      type: 'csv',
+      headers: ['总层数', '总高'],
+      rows: [['5', '17.5']],
+    });
+    expect(result.fields.storyCount).toBe(5);
+    expect(result.fields.heightM).toBe(17.5);
+  });
+});
+
+describe('mapCsvToDraftHints — Excel multi-sheet', () => {
+  test('selects the sheet whose headers match the most known fields', () => {
+    const result = mapCsvToDraftHints({
+      type: 'excel',
+      sheets: {
+        '封面': {
+          headers: ['项目名称', '设计人'],
+          rows: [['某办公楼', '张工']],
+        },
+        '参数': {
+          headers: ['楼层', '层高', '恒载', '活载'],
+          rows: [
+            ['1', '3.5', '5', '2'],
+            ['2', '3.5', '5', '2'],
+          ],
+        },
+      },
+    });
+    expect(result.selectedSheet).toBe('参数');
+    expect(result.fields.storyHeightsM).toEqual([3.5, 3.5]);
+    expect(result.warnings.some((w) => w.includes('selected'))).toBe(true);
+  });
+
+  test('falls back to the first sheet when no sheet has any known column', () => {
+    const result = mapCsvToDraftHints({
+      type: 'excel',
+      sheets: {
+        '封面': { headers: ['项目名称'], rows: [['某办公楼']] },
+        '说明': { headers: ['备注'], rows: [['XXX']] },
+      },
+    });
+    expect(result.selectedSheet).toBe('封面');
+    expect(result.fields).toEqual({});
+  });
+
+  test('reports a warning when the workbook is empty', () => {
+    const result = mapCsvToDraftHints({ type: 'excel', sheets: {} });
+    expect(result.fields).toEqual({});
+    expect(result.warnings.some((w) => w.includes('no sheets'))).toBe(true);
+  });
+});

--- a/backend/src/agent-skills/data-input/csv/__tests__/entry.test.mjs
+++ b/backend/src/agent-skills/data-input/csv/__tests__/entry.test.mjs
@@ -205,6 +205,27 @@ describe('normalizeFloorLoads', () => {
     ]);
   });
 
+  test('skips rows with invalid story cells when storyHeader is mapped', () => {
+    // Spreadsheets often contain a "Total" or summary row whose story cell
+    // is non-numeric. With a synthetic fallback such a row would collide
+    // with a real story 1; skipping keeps the load list correctly indexed.
+    const result = normalizeFloorLoads(
+      ['楼层', '恒载', '活载'],
+      [
+        ['Total', '15', '6'],   // invalid story → skip entirely
+        ['1', '5', '2'],
+        ['2', '5', '2'],
+        ['3', '5', '2'],
+      ],
+      { storyHeader: '楼层', verticalHeader: '恒载', liveLoadHeader: '活载' },
+    );
+    expect(result.values).toEqual([
+      { story: 1, verticalKN: 5, liveLoadKN: 2 },
+      { story: 2, verticalKN: 5, liveLoadKN: 2 },
+      { story: 3, verticalKN: 5, liveLoadKN: 2 },
+    ]);
+  });
+
   test('returns empty when no load columns are mapped', () => {
     const result = normalizeFloorLoads(['楼层'], [['1']], { storyHeader: '楼层' });
     expect(result.values).toEqual([]);

--- a/backend/src/agent-skills/data-input/csv/column-aliases.ts
+++ b/backend/src/agent-skills/data-input/csv/column-aliases.ts
@@ -1,0 +1,121 @@
+/**
+ * Column alias table for the CSV/Excel data-input skill.
+ *
+ * Maps human-written spreadsheet header text (Chinese / English / mixed) to
+ * the small set of DraftState fields the skill knows how to populate.
+ *
+ * Header matching is intentionally deterministic: lower-cased, whitespace
+ * collapsed, and parenthetical fragments stripped before lookup. Unmatched
+ * headers are returned to the caller verbatim so the agent can decide
+ * whether to ask the user for clarification.
+ */
+
+/**
+ * The DraftState fields this skill knows how to fill from a spreadsheet.
+ *
+ * Keep this list narrow — anything not listed here lands in
+ * `unmappedHeaders` and is surfaced to the user.
+ */
+export type KnownDraftField =
+  | 'storyIndex'      // synthetic: not a DraftState field, used to group rows by story
+  | 'storyCount'
+  | 'storyHeightsM'
+  | 'spanLengthM'
+  | 'bayWidthsM'
+  | 'heightM'
+  | 'verticalKN'
+  | 'liveLoadKN'
+  | 'lateralXKN'
+  | 'lateralYKN';
+
+/**
+ * Curated alias list per known field.
+ *
+ * Aliases are matched after `normalizeHeader` is applied to both the
+ * spreadsheet header and the alias itself, so trailing units in
+ * parentheses (e.g. "层高(m)", "Story Height (mm)") match the bare alias.
+ */
+export const COLUMN_ALIASES: Readonly<Record<KnownDraftField, readonly string[]>> = {
+  storyIndex: [
+    '楼层', '层号', '层数索引',
+    'story', 'storey', 'level', 'floor', 'floor index', 'story index',
+  ],
+  storyCount: [
+    '总层数', '楼层数', '层数', '层总数',
+    'story count', 'storey count', 'number of stories', 'total stories',
+  ],
+  storyHeightsM: [
+    '层高', '楼层高度', '楼层层高',
+    'story height', 'storey height', 'floor height', 'height per story',
+  ],
+  spanLengthM: [
+    '跨度', '跨长', '单跨跨度',
+    'span', 'span length', 'bay span',
+  ],
+  bayWidthsM: [
+    '柱距', '柱网间距', '开间', '开间宽度', '跨宽',
+    'bay width', 'bay widths', 'column spacing', 'grid spacing',
+  ],
+  heightM: [
+    '总高', '总高度', '建筑高度', '结构总高',
+    'height', 'total height', 'overall height', 'building height',
+  ],
+  verticalKN: [
+    '恒载', '恒荷载', '永久荷载', '自重',
+    'dead load', 'dl', 'permanent load', 'self weight', 'vertical load',
+  ],
+  liveLoadKN: [
+    '活载', '活荷载', '使用荷载', '可变荷载',
+    'live load', 'll', 'imposed load', 'variable load',
+  ],
+  lateralXKN: [
+    '风载x', '风荷载x', '水平荷载x', 'x向风载', 'x向水平荷载',
+    'wind x', 'wind-x', 'lateral x', 'lateral load x',
+  ],
+  lateralYKN: [
+    '风载y', '风荷载y', '水平荷载y', 'y向风载', 'y向水平荷载',
+    'wind y', 'wind-y', 'lateral y', 'lateral load y',
+  ],
+} as const;
+
+/**
+ * Normalise a spreadsheet header so it matches the alias table.
+ *
+ * The transformation is:
+ *   1. Lower-case ASCII letters (Chinese characters are unaffected).
+ *   2. Strip every "(...)" / "（...）" fragment so trailing units fall away.
+ *   3. Collapse all ASCII and CJK whitespace to nothing.
+ *   4. Trim residual punctuation that commonly appears after column splitting.
+ */
+export function normalizeHeader(raw: string): string {
+  if (typeof raw !== 'string') return '';
+  return raw
+    .toLowerCase()
+    .replace(/[(（][^)）]*[)）]/g, '')
+    .replace(/[\s　]+/g, '')
+    .replace(/[，,。.;；:：]+$/g, '');
+}
+
+// Pre-build a flat lookup map: normalisedAlias -> field
+const ALIAS_LOOKUP: Readonly<Record<string, KnownDraftField>> = (() => {
+  const map: Record<string, KnownDraftField> = {};
+  for (const field of Object.keys(COLUMN_ALIASES) as KnownDraftField[]) {
+    for (const alias of COLUMN_ALIASES[field]) {
+      const key = normalizeHeader(alias);
+      if (key && !(key in map)) {
+        map[key] = field;
+      }
+    }
+  }
+  return map;
+})();
+
+/**
+ * Match a raw spreadsheet header to a known DraftState field, or return
+ * `null` if the header does not correspond to any known field.
+ */
+export function matchColumnToField(rawHeader: string): KnownDraftField | null {
+  const key = normalizeHeader(rawHeader);
+  if (!key) return null;
+  return ALIAS_LOOKUP[key] ?? null;
+}

--- a/backend/src/agent-skills/data-input/csv/column-aliases.ts
+++ b/backend/src/agent-skills/data-input/csv/column-aliases.ts
@@ -92,7 +92,7 @@ export function normalizeHeader(raw: string): string {
   return raw
     .toLowerCase()
     .replace(/[(（][^)）]*[)）]/g, '')
-    .replace(/[\s　]+/g, '')
+    .replace(/[\s\u3000]+/g, '')
     .replace(/[，,。.;；:：]+$/g, '');
 }
 

--- a/backend/src/agent-skills/data-input/csv/draft.md
+++ b/backend/src/agent-skills/data-input/csv/draft.md
@@ -1,0 +1,90 @@
+# Draft Workflow — CSV/Excel Input
+
+This document tells the agent **how to use** the helpers exported from
+`entry.ts` once a CSV or Excel file has been uploaded. The skill itself
+does not call the LLM; it produces a structured patch and leaves the
+narration to the agent.
+
+## End-to-end flow
+
+```
+[user uploads file] ──▶ analyze_file ──▶ mapCsvToDraftHints
+                                              │
+                              ┌───────────────┴───────────────┐
+                              ▼                               ▼
+                  fields (Partial<DraftState>)    unmappedHeaders, warnings
+                              │                               │
+                              ▼                               ▼
+              render as natural-language msg          ask_user_clarification
+                              │
+                              ▼
+                  extract_draft_params({ message })
+```
+
+## Step-by-step
+
+1. **Call `analyze_file`** with the uploaded file path. The tool returns
+   one of two shapes:
+   - CSV/TSV:   `{ type: 'csv',   headers: string[], rows: string[][] }`
+   - Excel:     `{ type: 'excel', sheets: { [name]: { headers, rows } } }`
+
+2. **Pass the payload to `mapCsvToDraftHints`** (re-exported from
+   `data-input/csv/entry.ts`). The result has four fields:
+   - `fields`: a `Partial<DraftState>` patch. Only the keys
+     `storyCount`, `storyHeightsM`, `spanLengthM`, `bayWidthsM`,
+     `heightM`, `floorLoads` are ever set.
+   - `unmappedHeaders`: spreadsheet headers that did not match any
+     known field. Empty array means every column was understood.
+   - `warnings`: human-readable strings about unit conversion edge
+     cases or multi-sheet selection. Surface these to the user when
+     non-empty.
+   - `selectedSheet` (Excel only): which sheet the mapper chose.
+
+3. **Render `fields` into a short natural-language sentence** (Chinese
+   when the conversation is in Chinese, English otherwise). The
+   message is what `extract_draft_params` consumes — it does *not*
+   accept the patch directly. Examples:
+
+   - `fields = { storyCount: 5, storyHeightsM: [3.5,3.5,3.5,3.5,3.5] }`
+     →  `"5 层框架，每层层高 3.5 m"`
+   - `fields = { spanLengthM: 9, floorLoads: [{story:1, verticalKN:5, liveLoadKN:2}] }`
+     →  `"single-span beam with 9 m span, dead load 5 kN/m, live load 2 kN/m"`
+
+4. **Call `extract_draft_params({ message })`** with the rendered
+   message. The normal draft pipeline then merges the values into
+   `DraftState` so this skill never bypasses the validation logic the
+   rest of the agent already relies on.
+
+5. **If `unmappedHeaders` is non-empty**, call `ask_user_clarification`
+   listing those columns and asking which DraftState field they map
+   to (or whether they can be ignored). Do not invent a mapping.
+
+6. **If `warnings` is non-empty**, include the warning text in the
+   reply or in a clarification turn so the user sees decisions that
+   were made on their behalf (e.g. mm→m conversion, sheet selection).
+
+## When to defer to the user
+
+- `unmappedHeaders` contains structurally significant columns
+  (material grade, section size, axis labels) — these are *expected*
+  to be unmapped because this skill only owns geometry and loads.
+  Hand them off to `material`, `section`, or `structure-type` skills
+  through the normal clarification turn.
+- Excel workbook has two or more sheets whose header counts are tied
+  in `selectedSheet`. The warning flags this; ask the user which
+  sheet to use.
+- A `层高` value lands outside the 1 m–9 m / 1000 mm–9000 mm envelope
+  and the warning is present. Confirm with the user before drafting.
+
+## What this skill does **not** do
+
+- Does not call the LLM.
+- Does not parse files itself (`analyze_file` does that).
+- Does not populate `inferredType`, `structuralTypeKey`, `skillId`,
+  material, section, or boundary conditions — those belong to other
+  skills.
+- Does not write to `DraftState` directly; everything goes through
+  `extract_draft_params`.
+- Does not produce `floorLoads[].verticalKN = 0` when a column is
+  missing — absent columns stay `undefined` so downstream code can
+  distinguish "no data" from "explicit zero".

--- a/backend/src/agent-skills/data-input/csv/entry.ts
+++ b/backend/src/agent-skills/data-input/csv/entry.ts
@@ -134,6 +134,71 @@ function storyHeightToMetres(parsed: ParsedCell): { metres: number; warning?: st
 }
 
 /**
+ * Convert a parsed length cell to metres based on its declared unit.
+ *
+ * Unlike `storyHeightToMetres` this helper does not second-guess bare
+ * numbers — span lengths and bay widths can legitimately span anywhere
+ * from 1m to 30m+, so a bare 5 means 5 metres, not 5 millimetres. Only
+ * an explicit `mm` / `cm` unit triggers conversion.
+ */
+function convertLengthCellToMetres(parsed: ParsedCell): { metres: number; warning?: string } {
+  const unit = parsed.unit;
+  if (unit === '' || unit === 'm' || unit === 'meter' || unit === 'metre') {
+    return { metres: parsed.value };
+  }
+  if (unit === 'mm' || unit === 'millimeter' || unit === 'millimetre') {
+    return { metres: parsed.value / 1000 };
+  }
+  if (unit === 'cm' || unit === 'centimeter' || unit === 'centimetre') {
+    return { metres: parsed.value / 100 };
+  }
+  if (unit === 'km' || unit === 'kilometer' || unit === 'kilometre') {
+    return { metres: parsed.value * 1000 };
+  }
+  return {
+    metres: parsed.value,
+    warning: `unrecognised length unit "${unit}"; assuming the value is already in metres`,
+  };
+}
+
+/**
+ * Convert a parsed force / line-load / area-load cell to kN.
+ *
+ * DraftFloorLoad fields are typed as kN (per story for vertical, per face
+ * for lateral). Spreadsheets sometimes carry plain N, kgf, tf or kPa; this
+ * helper normalises the common ones and warns on anything else so the
+ * caller can surface the assumption.
+ */
+function convertForceCellToKN(parsed: ParsedCell): { kN: number; warning?: string } {
+  const unit = parsed.unit;
+  if (unit === '' || unit === 'kn' || unit === 'kn/m' || unit === 'kn/m²' || unit === 'kn/m2') {
+    return { kN: parsed.value };
+  }
+  if (unit === 'n' || unit === 'n/m' || unit === 'n/m²' || unit === 'n/m2') {
+    return { kN: parsed.value / 1000 };
+  }
+  if (unit === 'kgf' || unit === 'kg' || unit === 'kgf/m' || unit === 'kgf/m²' || unit === 'kgf/m2') {
+    // 1 kgf ≈ 0.00981 kN; treat 1 kg ≈ 1 kgf for engineering spreadsheets
+    return { kN: parsed.value * 0.00981 };
+  }
+  if (unit === 'tf' || unit === 't' || unit === 'tf/m' || unit === 'tf/m²' || unit === 'tf/m2') {
+    return { kN: parsed.value * 9.81 };
+  }
+  if (unit === 'kpa') {
+    // 1 kPa = 1 kN/m² — line loads in kPa are a unit-system mistake but
+    // numerically equivalent for area loads, so pass through with a hint.
+    return {
+      kN: parsed.value,
+      warning: `interpreted kPa as kN/m²; verify the load is an area load rather than a line load`,
+    };
+  }
+  return {
+    kN: parsed.value,
+    warning: `unrecognised force unit "${unit}"; assuming the value is already in kN (or kN/m / kN/m²)`,
+  };
+}
+
+/**
  * Extract `storyHeightsM[]` from rows.
  *
  * If `storyHeader` is provided the rows are assumed to be one-per-story and
@@ -238,10 +303,26 @@ export function normalizeFloorLoads(
     }
 
     const entry: DraftFloorLoad = { story };
-    if (v) entry.verticalKN = v.value;
-    if (ll) entry.liveLoadKN = ll.value;
-    if (lx) entry.lateralXKN = lx.value;
-    if (ly) entry.lateralYKN = ly.value;
+    if (v) {
+      const { kN, warning } = convertForceCellToKN(v);
+      entry.verticalKN = kN;
+      if (warning) warnings.push(warning);
+    }
+    if (ll) {
+      const { kN, warning } = convertForceCellToKN(ll);
+      entry.liveLoadKN = kN;
+      if (warning) warnings.push(warning);
+    }
+    if (lx) {
+      const { kN, warning } = convertForceCellToKN(lx);
+      entry.lateralXKN = kN;
+      if (warning) warnings.push(warning);
+    }
+    if (ly) {
+      const { kN, warning } = convertForceCellToKN(ly);
+      entry.lateralYKN = kN;
+      if (warning) warnings.push(warning);
+    }
     values.push(entry);
   }
 
@@ -314,7 +395,9 @@ function mapSheet(
     for (const row of rows) {
       const parsed = parseNumericCell(row[idx]);
       if (parsed && parsed.value > 0) {
-        fields.heightM = parsed.value;
+        const { metres, warning } = convertLengthCellToMetres(parsed);
+        fields.heightM = metres;
+        if (warning) warnings.push(warning);
         break;
       }
     }
@@ -327,7 +410,9 @@ function mapSheet(
     for (const row of rows) {
       const parsed = parseNumericCell(row[idx]);
       if (parsed && parsed.value > 0) {
-        fields.spanLengthM = parsed.value;
+        const { metres, warning } = convertLengthCellToMetres(parsed);
+        fields.spanLengthM = metres;
+        if (warning) warnings.push(warning);
         break;
       }
     }
@@ -340,7 +425,11 @@ function mapSheet(
     const collected: number[] = [];
     for (const row of rows) {
       const parsed = parseNumericCell(row[idx]);
-      if (parsed && parsed.value > 0) collected.push(parsed.value);
+      if (parsed && parsed.value > 0) {
+        const { metres, warning } = convertLengthCellToMetres(parsed);
+        collected.push(metres);
+        if (warning) warnings.push(warning);
+      }
     }
     if (collected.length > 0) fields.bayWidthsM = collected;
   }

--- a/backend/src/agent-skills/data-input/csv/entry.ts
+++ b/backend/src/agent-skills/data-input/csv/entry.ts
@@ -1,0 +1,413 @@
+/**
+ * CSV/Excel data-input skill entry point.
+ *
+ * The agent runtime calls `mapCsvToDraftHints` after `analyze_file` has
+ * already turned the uploaded spreadsheet into structured headers + rows.
+ * This module is intentionally pure: no I/O, no LLM calls, no global
+ * state. It only translates the analyze_file payload into a
+ * `Partial<DraftState>` patch plus diagnostics for the agent to surface.
+ *
+ * The agent never feeds the resulting object directly to
+ * `extract_draft_params` (whose schema is `{ message, locale? }`). Instead
+ * it renders the patch into a natural-language message so the regular
+ * draft extraction path remains the single source of truth.
+ */
+import type { DraftFloorLoad, DraftState } from '../../../agent-runtime/types.js';
+import {
+  COLUMN_ALIASES,
+  matchColumnToField,
+  normalizeHeader,
+  type KnownDraftField,
+} from './column-aliases.js';
+
+export { matchColumnToField, normalizeHeader, COLUMN_ALIASES };
+export type { KnownDraftField };
+
+// ---------------------------------------------------------------------------
+// analyze_file output shapes (subset we depend on)
+// ---------------------------------------------------------------------------
+
+export interface AnalyzeFileCsvOutput {
+  type: 'csv';
+  headers: string[];
+  rows: string[][];
+}
+
+export interface AnalyzeFileExcelSheet {
+  headers: string[];
+  rows: unknown[][];
+}
+
+export interface AnalyzeFileExcelOutput {
+  type: 'excel';
+  sheets: Record<string, AnalyzeFileExcelSheet>;
+}
+
+export type AnalyzeFileSpreadsheet = AnalyzeFileCsvOutput | AnalyzeFileExcelOutput;
+
+/** Hints the skill can produce. Mirrors the relevant DraftState slice. */
+export type CsvDraftHints = Pick<
+  DraftState,
+  'storyCount' | 'storyHeightsM' | 'spanLengthM' | 'bayWidthsM' | 'heightM' | 'floorLoads'
+>;
+
+export interface MapCsvToDraftHintsResult {
+  fields: Partial<CsvDraftHints>;
+  unmappedHeaders: string[];
+  warnings: string[];
+  /** Excel only: which sheet the mapper picked. Undefined for CSV. */
+  selectedSheet?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Cell parsing
+// ---------------------------------------------------------------------------
+
+export interface ParsedCell {
+  value: number;
+  /** Detected unit, lower-cased; empty string when the cell carried no unit. */
+  unit: string;
+}
+
+const EMPTY_CELL_TOKENS = new Set(['', 'n/a', 'na', '-', '—', '–', 'null', 'none']);
+
+/**
+ * Parse a single spreadsheet cell into `{ value, unit }`.
+ *
+ * Handles bare numbers, thousands separators (`1,200`), and a trailing unit
+ * suffix such as `mm`, `m`, `kn`, `kn/m2`, `kpa`. Returns null for empty
+ * sentinels and for strings that contain no numeric prefix.
+ */
+export function parseNumericCell(raw: unknown): ParsedCell | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return { value: raw, unit: '' };
+  }
+  const text = String(raw).trim();
+  const lowered = text.toLowerCase();
+  if (EMPTY_CELL_TOKENS.has(lowered)) return null;
+
+  const match = lowered.match(/^([+-]?[\d,]*\.?\d+)\s*([a-z²/μ]*)$/);
+  if (!match) return null;
+
+  const numeric = Number(match[1].replace(/,/g, ''));
+  if (!Number.isFinite(numeric)) return null;
+
+  return { value: numeric, unit: match[2] ?? '' };
+}
+
+// ---------------------------------------------------------------------------
+// Story heights
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide whether a numeric story-height reading is in millimetres or metres.
+ *
+ * Designs above 9 m per story are unusual; below 1 m is impossible. Anything
+ * in between is treated as metres unless the cell carried an explicit `mm`
+ * unit. Values clearly in the millimetre range (>=1000) are converted.
+ */
+function storyHeightToMetres(parsed: ParsedCell): { metres: number; warning?: string } {
+  const unit = parsed.unit;
+  if (unit === 'mm' || unit === 'millimeter' || unit === 'millimetre') {
+    return { metres: parsed.value / 1000 };
+  }
+  if (unit === 'm' || unit === 'meter' || unit === 'metre' || unit === '') {
+    if (parsed.value >= 1000 && parsed.value <= 9000) {
+      // Bare number in millimetre range — auto-convert.
+      return { metres: parsed.value / 1000 };
+    }
+    if (parsed.value >= 1 && parsed.value <= 9) {
+      return { metres: parsed.value };
+    }
+    return {
+      metres: parsed.value,
+      warning: `story height ${parsed.value}${unit ? ' ' + unit : ''} is outside the typical 1m–9m / 1000mm–9000mm range`,
+    };
+  }
+  return {
+    metres: parsed.value,
+    warning: `unrecognised story-height unit "${unit}"; assuming the value is already in metres`,
+  };
+}
+
+/**
+ * Extract `storyHeightsM[]` from rows.
+ *
+ * If `storyHeader` is provided the rows are assumed to be one-per-story and
+ * read in row order. Otherwise the first non-empty cell is used as a single
+ * value applied to every story (so `[h, h, ..., h]` of length `storyCount`
+ * if `storyCount` is also known; otherwise `[h]`).
+ */
+export function normalizeStoryHeights(
+  headers: string[],
+  rows: unknown[][],
+  options: { heightHeader: string; storyHeader?: string; storyCount?: number },
+): { values: number[]; warnings: string[] } {
+  const warnings: string[] = [];
+  const heightIdx = headers.indexOf(options.heightHeader);
+  if (heightIdx < 0) return { values: [], warnings };
+
+  const collected: number[] = [];
+  for (const row of rows) {
+    const parsed = parseNumericCell(row[heightIdx]);
+    if (!parsed) continue;
+    const { metres, warning } = storyHeightToMetres(parsed);
+    if (warning) warnings.push(warning);
+    collected.push(metres);
+  }
+
+  if (collected.length === 0) return { values: [], warnings };
+
+  if (options.storyHeader && headers.indexOf(options.storyHeader) >= 0) {
+    return { values: collected, warnings };
+  }
+  // No per-story column: single value, replicated to storyCount if known.
+  const single = collected[0];
+  const length = options.storyCount && options.storyCount > 0 ? options.storyCount : 1;
+  return { values: Array.from({ length }, () => single), warnings };
+}
+
+// ---------------------------------------------------------------------------
+// Floor loads
+// ---------------------------------------------------------------------------
+
+interface FloorLoadColumnMap {
+  storyHeader?: string;
+  verticalHeader?: string;
+  liveLoadHeader?: string;
+  lateralXHeader?: string;
+  lateralYHeader?: string;
+}
+
+/**
+ * Build per-story `DraftFloorLoad[]` entries from the spreadsheet rows.
+ *
+ * One entry is emitted per row that has at least one populated load column.
+ * Rows without a recognisable story index are numbered sequentially starting
+ * from 1. Missing load columns leave the corresponding field undefined
+ * (never zero) so the downstream draft path can distinguish "no data" from
+ * "explicit zero load".
+ */
+export function normalizeFloorLoads(
+  headers: string[],
+  rows: unknown[][],
+  mapping: FloorLoadColumnMap,
+): { values: DraftFloorLoad[]; warnings: string[] } {
+  const warnings: string[] = [];
+  const idx = (header: string | undefined): number =>
+    header ? headers.indexOf(header) : -1;
+
+  const storyIdx = idx(mapping.storyHeader);
+  const vIdx = idx(mapping.verticalHeader);
+  const lIdx = idx(mapping.liveLoadHeader);
+  const xIdx = idx(mapping.lateralXHeader);
+  const yIdx = idx(mapping.lateralYHeader);
+
+  if (vIdx < 0 && lIdx < 0 && xIdx < 0 && yIdx < 0) {
+    return { values: [], warnings };
+  }
+
+  const values: DraftFloorLoad[] = [];
+  let synthStory = 1;
+
+  for (const row of rows) {
+    const v = vIdx >= 0 ? parseNumericCell(row[vIdx]) : null;
+    const ll = lIdx >= 0 ? parseNumericCell(row[lIdx]) : null;
+    const lx = xIdx >= 0 ? parseNumericCell(row[xIdx]) : null;
+    const ly = yIdx >= 0 ? parseNumericCell(row[yIdx]) : null;
+    if (!v && !ll && !lx && !ly) continue;
+
+    let story: number;
+    if (storyIdx >= 0) {
+      const parsedStory = parseNumericCell(row[storyIdx]);
+      if (parsedStory && Number.isInteger(parsedStory.value) && parsedStory.value >= 1) {
+        story = parsedStory.value;
+      } else {
+        story = synthStory;
+        synthStory += 1;
+      }
+    } else {
+      story = synthStory;
+      synthStory += 1;
+    }
+
+    const entry: DraftFloorLoad = { story };
+    if (v) entry.verticalKN = v.value;
+    if (ll) entry.liveLoadKN = ll.value;
+    if (lx) entry.lateralXKN = lx.value;
+    if (ly) entry.lateralYKN = ly.value;
+    values.push(entry);
+  }
+
+  return { values, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// Header summary helper (also drives Excel sheet selection)
+// ---------------------------------------------------------------------------
+
+interface HeaderClassification {
+  fieldByHeader: Map<string, KnownDraftField>;
+  unmapped: string[];
+}
+
+function classifyHeaders(headers: string[]): HeaderClassification {
+  const fieldByHeader = new Map<string, KnownDraftField>();
+  const unmapped: string[] = [];
+  for (const header of headers) {
+    if (typeof header !== 'string' || header.length === 0) continue;
+    const field = matchColumnToField(header);
+    if (field) {
+      fieldByHeader.set(header, field);
+    } else {
+      unmapped.push(header);
+    }
+  }
+  return { fieldByHeader, unmapped };
+}
+
+function findHeaderForField(
+  classification: HeaderClassification,
+  field: KnownDraftField,
+): string | undefined {
+  for (const [header, mapped] of classification.fieldByHeader) {
+    if (mapped === field) return header;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level mapper
+// ---------------------------------------------------------------------------
+
+function mapSheet(
+  headers: string[],
+  rows: unknown[][],
+): { fields: Partial<CsvDraftHints>; unmappedHeaders: string[]; warnings: string[] } {
+  const classification = classifyHeaders(headers);
+  const fields: Partial<CsvDraftHints> = {};
+  const warnings: string[] = [];
+
+  // storyCount: scalar from the first row that has a value
+  const storyCountHeader = findHeaderForField(classification, 'storyCount');
+  if (storyCountHeader) {
+    const idx = headers.indexOf(storyCountHeader);
+    for (const row of rows) {
+      const parsed = parseNumericCell(row[idx]);
+      if (parsed && Number.isInteger(parsed.value) && parsed.value > 0) {
+        fields.storyCount = parsed.value;
+        break;
+      }
+    }
+  }
+
+  // heightM: scalar (overall structural height)
+  const heightHeader = findHeaderForField(classification, 'heightM');
+  if (heightHeader) {
+    const idx = headers.indexOf(heightHeader);
+    for (const row of rows) {
+      const parsed = parseNumericCell(row[idx]);
+      if (parsed && parsed.value > 0) {
+        fields.heightM = parsed.value;
+        break;
+      }
+    }
+  }
+
+  // spanLengthM: scalar
+  const spanHeader = findHeaderForField(classification, 'spanLengthM');
+  if (spanHeader) {
+    const idx = headers.indexOf(spanHeader);
+    for (const row of rows) {
+      const parsed = parseNumericCell(row[idx]);
+      if (parsed && parsed.value > 0) {
+        fields.spanLengthM = parsed.value;
+        break;
+      }
+    }
+  }
+
+  // bayWidthsM: vector across all rows
+  const bayHeader = findHeaderForField(classification, 'bayWidthsM');
+  if (bayHeader) {
+    const idx = headers.indexOf(bayHeader);
+    const collected: number[] = [];
+    for (const row of rows) {
+      const parsed = parseNumericCell(row[idx]);
+      if (parsed && parsed.value > 0) collected.push(parsed.value);
+    }
+    if (collected.length > 0) fields.bayWidthsM = collected;
+  }
+
+  // storyHeightsM: vector (or scalar replicated to storyCount)
+  const storyHeightHeader = findHeaderForField(classification, 'storyHeightsM');
+  const storyIndexHeader = findHeaderForField(classification, 'storyIndex');
+  if (storyHeightHeader) {
+    const heights = normalizeStoryHeights(headers, rows, {
+      heightHeader: storyHeightHeader,
+      storyHeader: storyIndexHeader,
+      storyCount: fields.storyCount,
+    });
+    if (heights.values.length > 0) fields.storyHeightsM = heights.values;
+    warnings.push(...heights.warnings);
+  }
+
+  // floorLoads
+  const loads = normalizeFloorLoads(headers, rows, {
+    storyHeader: storyIndexHeader,
+    verticalHeader: findHeaderForField(classification, 'verticalKN'),
+    liveLoadHeader: findHeaderForField(classification, 'liveLoadKN'),
+    lateralXHeader: findHeaderForField(classification, 'lateralXKN'),
+    lateralYHeader: findHeaderForField(classification, 'lateralYKN'),
+  });
+  if (loads.values.length > 0) fields.floorLoads = loads.values;
+  warnings.push(...loads.warnings);
+
+  return { fields, unmappedHeaders: classification.unmapped, warnings };
+}
+
+/**
+ * Translate an `analyze_file` spreadsheet payload into a Partial DraftState
+ * patch plus diagnostics. For Excel inputs the sheet whose header row
+ * matches the most known fields is selected; ties resolve by sheet order.
+ */
+export function mapCsvToDraftHints(
+  payload: AnalyzeFileSpreadsheet,
+): MapCsvToDraftHintsResult {
+  if (payload.type === 'csv') {
+    const { fields, unmappedHeaders, warnings } = mapSheet(payload.headers, payload.rows);
+    return { fields, unmappedHeaders, warnings };
+  }
+
+  const sheetNames = Object.keys(payload.sheets);
+  if (sheetNames.length === 0) {
+    return { fields: {}, unmappedHeaders: [], warnings: ['workbook contains no sheets'] };
+  }
+
+  let bestSheet = sheetNames[0];
+  let bestScore = -1;
+  for (const name of sheetNames) {
+    const sheet = payload.sheets[name];
+    const score = classifyHeaders(sheet.headers).fieldByHeader.size;
+    if (score > bestScore) {
+      bestScore = score;
+      bestSheet = name;
+    }
+  }
+
+  const chosen = payload.sheets[bestSheet];
+  const result = mapSheet(chosen.headers, chosen.rows);
+  const warnings = [...result.warnings];
+  if (sheetNames.length > 1) {
+    warnings.push(
+      `workbook has ${sheetNames.length} sheets (${sheetNames.join(', ')}); selected "${bestSheet}" based on header match`,
+    );
+  }
+  return {
+    fields: result.fields,
+    unmappedHeaders: result.unmappedHeaders,
+    warnings,
+    selectedSheet: bestSheet,
+  };
+}

--- a/backend/src/agent-skills/data-input/csv/entry.ts
+++ b/backend/src/agent-skills/data-input/csv/entry.ts
@@ -87,7 +87,9 @@ export function parseNumericCell(raw: unknown): ParsedCell | null {
   const lowered = text.toLowerCase();
   if (EMPTY_CELL_TOKENS.has(lowered)) return null;
 
-  const match = lowered.match(/^([+-]?[\d,]*\.?\d+)\s*([a-z²/μ]*)$/);
+  const match = lowered.match(
+    /^([+-]?(?:\d[\d,]*\.?\d*|\.\d+)(?:e[+-]?\d+)?)\s*([a-z0-9./²³μ-]*)$/,
+  );
   if (!match) return null;
 
   const numeric = Number(match[1].replace(/,/g, ''));

--- a/backend/src/agent-skills/data-input/csv/entry.ts
+++ b/backend/src/agent-skills/data-input/csv/entry.ts
@@ -226,8 +226,11 @@ export function normalizeFloorLoads(
       if (parsedStory && Number.isInteger(parsedStory.value) && parsedStory.value >= 1) {
         story = parsedStory.value;
       } else {
-        story = synthStory;
-        synthStory += 1;
+        // Story column is explicitly mapped but this row's story cell is
+        // invalid (e.g. a "Total" / "Summary" / blank row). Skip rather
+        // than fall back to a synthetic counter, which would collide with
+        // a real story number further down.
+        continue;
       }
     } else {
       story = synthStory;

--- a/backend/src/agent-skills/data-input/csv/intent.md
+++ b/backend/src/agent-skills/data-input/csv/intent.md
@@ -1,35 +1,69 @@
 # Intent — CSV/Excel Structural Parameter Input
 
-This skill activates when the user uploads or references a CSV or Excel file containing structural parameters.
+This skill activates when the user uploads or references a CSV/TSV or Excel file containing structural parameters.
 
 ## When to Use
 
-- User uploads a `.csv`, `.xls`, or `.xlsx` file
+- User uploads a `.csv`, `.tsv`, `.xls`, or `.xlsx` file
 - User says "我上传了一个结构参数表" / "I uploaded a structural parameter spreadsheet"
-- User references column names like 楼层/story, 截面/section, 荷载/load, 层高/height, 跨度/span
+- User mentions column names like 楼层/story, 层高/height, 恒载/dead load, 活载/live load
 
 ## Parsing Workflow
 
-1. Call `analyze_file` with the uploaded file path to extract headers and row data
-2. Identify column mapping using fuzzy matching:
-   - 楼层/story/floor/level → `storyCount`
-   - 层高/story height/floor height → `storyHeight`
-   - 跨度/span/bay width → `spanLengthM`
-   - 截面/section → `sectionId`
-   - 恒荷载/dead load/DL → `deadLoad`
-   - 活荷载/live load/LL → `liveLoad`
-   - 风荷载/wind load/WL → `windLoad`
-   - 地震/seismic/EQ → enables seismic analysis
-3. Call `extract_draft_params` with the mapped values to populate DraftState
-4. Report any unmapped columns to the user for confirmation
+1. Call `analyze_file` with the uploaded file path.
+   - CSV/TSV returns `{ headers: string[], rows: string[][] }`
+   - Excel returns `{ sheets: Record<sheetName, { headers, rows }> }`
+2. Use `mapCsvToDraftHints` (exported from `data-input/csv/entry.ts`) to translate
+   the analyze_file payload into:
+   - `fields`: a `Partial<DraftState>` patch
+   - `unmappedHeaders`: column names that did not match any known DraftState field
+   - `warnings`: unit / shape problems worth surfacing to the user
+   - `selectedSheet` (Excel only): which sheet the mapper picked
+3. Render `fields` as a short natural-language summary (Chinese or English)
+   and pass that summary as the `message` argument of `extract_draft_params`.
+   `extract_draft_params` only accepts `{ message, locale? }`; it does not
+   accept already-mapped parameter objects.
+4. If `unmappedHeaders` is non-empty, call `ask_user_clarification` so the
+   user can confirm the meaning of those columns.
+
+## Column Recognition
+
+| Spreadsheet column (中/英)            | DraftState field                |
+|----------------------------------------|---------------------------------|
+| 楼层 / 层号 / story / storey / level   | `storyIndex` (row grouping key) |
+| 层数 / 总层数 / story count            | `storyCount`                    |
+| 层高 / story height / floor height     | `storyHeightsM[]` (mm→m auto)   |
+| 跨度 / span / bay width                | `spanLengthM` or `bayWidthsM[]` |
+| 总高 / 高度 / height                   | `heightM`                       |
+| 恒载 / 恒荷载 / dead load / DL         | `floorLoads[].verticalKN`       |
+| 活载 / 活荷载 / live load / LL         | `floorLoads[].liveLoadKN`       |
+| 风载X / wind X / lateral X             | `floorLoads[].lateralXKN`       |
+| 风载Y / wind Y / lateral Y             | `floorLoads[].lateralYKN`       |
+
+Unknown headers are returned in `unmappedHeaders` for clarification.
+
+## Unit Handling
+
+- `层高` values in the range 1000–9000 are treated as millimetres and divided
+  by 1000 before being stored as `storyHeightsM` (metres).
+- Values in the range 1–9 are treated as metres.
+- Cells with explicit units (`3500mm`, `3.5 m`, `5 kN/m²`) are parsed and
+  normalised; unknown units appear in `warnings`.
+- Empty cells, `N/A`, `—`, `-` are treated as missing, not as zero.
 
 ## Error Handling
 
-- If headers cannot be mapped: ask the user to confirm column meaning
-- If a required column is missing: use `ask_user_clarification`
-- If the file has multiple sheets (Excel): ask the user which sheet to use, or process all
+- If headers cannot be mapped: report `unmappedHeaders` via
+  `ask_user_clarification`.
+- If a required column is missing: ask the user to provide it directly.
+- Excel multi-sheet: the mapper picks the sheet whose header row matches the
+  most known fields. If the choice is ambiguous, surface this via a warning
+  and ask the user which sheet to use.
 
 ## Output
 
-All extracted values are normalized and passed to `extract_draft_params`.
-Output conforms to `DraftState` for consumption by structure-type skills.
+`fields` is a `Partial<DraftState>` patch (using real DraftState field names:
+`storyCount`, `storyHeightsM`, `floorLoads`, `spanLengthM`, `heightM`, etc.).
+The skill never calls `extract_draft_params` with a structured payload — it
+renders `fields` into a natural-language `message` first, so the regular
+draft extraction path stays the single source of truth.

--- a/backend/src/agent-skills/data-input/csv/skill.yaml
+++ b/backend/src/agent-skills/data-input/csv/skill.yaml
@@ -11,11 +11,16 @@ triggers:
   - csv
   - excel
   - xlsx
+  - .csv
+  - .xlsx
+  - .xls
   - spreadsheet
   - 表格
   - 电子表格
   - 结构参数表
   - 荷载表
+  - 楼层表
+  - 参数表
 stages:
   - intent
   - draft
@@ -24,6 +29,7 @@ structuralTypeKeys: []
 capabilities:
   - file-parsing
   - draft-extraction
+  - column-mapping
 requires: []
 conflicts: []
 priority: 30


### PR DESCRIPTION
## Summary

Fills `backend/src/agent-skills/data-input/csv/` (previously only `intent.md` + `skill.yaml` placeholders) with a real, tested implementation. Addresses the feedback on #191:

> 合并一个完整的插件化骨架但没有实际的 skill 注册，会变成没人调用的死代码。
> 如果您有更完整合理的设计思路，或者来自设计院的真实工程需求，我们可以进一步讨论。

CSV / Excel parameter sheets are the highest-frequency hand-off document between design institutes and structural engineers (楼层表 / 参数表 / 荷载表). This skill turns those uploads into a `Partial<DraftState>` patch that feeds straight into the existing `extract_draft_params` pipeline.

## Scope

**This PR delivers the logic layer only:** `intent.md`, `draft.md`, column matching, unit conversion, `Partial<DraftState>` mapping, and unit tests. **Runtime wiring is intentionally out of scope** and will land in a follow-up PR.

The follow-up PR will sit `mapCsvToDraftHints` next to the other deterministic helper libraries already wired into the runtime/service layer — same shape as:

- `material/entry.ts::normalizeMaterialFamilies` → consumed by `services/agent-capability.ts`
- `code-check/entry.ts::buildCodeCheckInput` → consumed by `agent-runtime/index.ts`
- `report-export/entry.ts::buildReportDomainArtifacts` → consumed by `agent-runtime/index.ts`

i.e. **a direct-import helper library, not a LangChain tool.** Per the discussion on this PR (thanks @guyi2000), exposing this as an LLM-callable tool would let the agent route any CSV/Excel upload through draft extraction — but design-institute spreadsheets can also be:

- Midas / SAP2000 analysis result tables → should go through `analysis` / `result-postprocess`
- 截面特性表 → should go through the `section` skill
- 材料试验数据 → should go through the `material` skill
- 荷载组合表 → may need its own parser

The next PR will therefore have the LLM (guided by `intent.md` / `draft.md`) decide the CSV's *content type* first, then route to the appropriate domain helper. `mapCsvToDraftHints` is the helper for the **parameter-sheet** branch of that decision tree.

For now, the only consumer of `mapCsvToDraftHints` is `__tests__/entry.test.mjs`. That is intentional for this PR's scope.

`handler.ts` is **not** added: see the discussion above for why the `SkillHandler` interface (`detectStructuralType` / `parseProvidedValues` / `extractDraft` / `mergeState` / `computeMissing`) is a `structure-type` / `section` pattern and would be a forced fit for a deterministic CSV reader.

## What's in the PR

| File | Purpose |
|---|---|
| `intent.md` | Rewritten: previous version described fields that don't exist on `DraftState` (`storyHeight`, `sectionId`, `seismic`); now aligned with real fields (`storyHeightsM[]`, `floorLoads[].verticalKN/liveLoadKN/lateralXKN/lateralYKN`) |
| `column-aliases.ts` | Bilingual (zh/en) alias table for 10 known `DraftState` fields; `normalizeHeader` strips parenthetical units and collapses ASCII + full-width whitespace |
| `entry.ts` | Pure functions: `parseNumericCell`, `normalizeStoryHeights`, `normalizeFloorLoads`, `mapCsvToDraftHints`. No I/O, no LLM calls |
| `__tests__/entry.test.mjs` | 32 Jest tests across 7 describe blocks |
| `draft.md` | Step-by-step workflow doc telling the agent how to use the helpers |
| `skill.yaml` | Triggers expanded (`.csv` `.xlsx` `.xls` `楼层表` `参数表`), capabilities adds `column-mapping` |

Total: **+1150 / -20 lines** (after Gemini fix-up commits), **0 new dependencies**, single PR closed loop.

## Design boundaries

- The skill never calls the LLM. Column → field mapping is deterministic.
- The skill never bypasses `extract_draft_params`. It produces a `Partial<DraftState>` patch that the agent renders into a natural-language message, which then flows through the normal draft path.
- Missing load columns leave `verticalKN` / `liveLoadKN` / `lateralXKN` / `lateralYKN` **undefined**, never zero — downstream code can distinguish "no data" from "explicit zero".
- Unknown spreadsheet headers go into `unmappedHeaders` and are handed off via `ask_user_clarification` rather than guessed.
- Excel multi-sheet: the sheet with the highest header-match count wins; the choice is reported in `selectedSheet` and a warning.
- Unit-aware scalar mapping for `mm` / `cm` / `km` (lengths) and `N` / `kgf` / `tf` (forces), with `kN.m` / `kN/m²` flowing through unchanged.

## How to verify

```bash
cd backend
npm install
npm run db:generate
npm run build
npm run test:skills -- --runInBand src/agent-skills/data-input/csv/
# Expect: 32 tests pass
```

CI runs `analysis-regression` + `backend-regression` + `native-install-smoke` on push (the three workflows whose `paths:` filter matches `backend/**`). The Jest matcher in `backend/jest.config.cjs` picks up `__tests__/**/*.test.mjs` automatically; no config change needed.

## Commits

```
aefe3ec fix(data-input/csv): make scalar mappers unit-aware (mm/cm/km, N/kgf/tf/kPa)
8532fe4 fix(data-input/csv): skip rows with invalid story cells when storyHeader is mapped
890d7b0 fix(data-input/csv): broaden parseNumericCell regex for structural units
1ecd4d8 fix(data-input/csv): escape U+3000 in normalizeHeader regex to satisfy no-irregular-whitespace
a34e877 chore(data-input/csv): refine triggers and capabilities in skill.yaml
16ba66d docs(data-input/csv): add draft.md drafting workflow
3629ddf test(data-input/csv): add Jest unit tests for column matching and field mapping
7c2d2b1 feat(data-input/csv): add entry.ts with column matching and DraftState mapping helpers
f32cc4e feat(data-input/csv): add column-aliases table
1afca8a docs(data-input/csv): align intent.md with real DraftState fields
```

Each commit is independently reviewable. cc @qinsz01 @guyi2000
