### PR TITLE
test(e2e): elevate E2E to cover full install verification and structural analysis flow

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -2,8 +2,8 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests/e2e/specs',
-  timeout: 30_000,
-  expect: { timeout: 10_000 },
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
   fullyParallel: false,
   retries: process.env.CI ? 2 : 0,
   workers: 1,

--- a/frontend/tests/e2e/pages/console.page.ts
+++ b/frontend/tests/e2e/pages/console.page.ts
@@ -32,7 +32,7 @@ export class ConsolePage {
     this.expandHistoryButton = page.getByRole('button', { name: /Expand History|展开历史/ }).first();
     this.newConversationButton = page.locator('button:has-text("New"), button:has-text("新建")');
     this.messageInput = page.locator('[data-testid="console-composer"] textarea, textarea[placeholder]');
-    this.sendButton = page.getByRole('button', { name: 'Send' });
+    this.sendButton = page.getByRole('button', { name: /Send|发送/ });
     this.quickPrompts = page.locator('[data-testid="console-chat-panel"] button');
     this.conversationItems = page.locator('[data-testid="console-history-scroll"] > *');
     this.streamingIndicator = page.locator('.animate-pulse, [class*="streaming"]');
@@ -72,7 +72,7 @@ export class ConsolePage {
   }
 
   async openResultDialog(): Promise<void> {
-    await this.showResultsButton.first().click({ force: true });
+    await this.showResultsButton.first().click();
   }
 
   async openVisualization(): Promise<void> {

--- a/frontend/tests/e2e/pages/console.page.ts
+++ b/frontend/tests/e2e/pages/console.page.ts
@@ -65,7 +65,7 @@ export class ConsolePage {
     await this.messageInput.fill(text);
     await this.sendButton.click();
     await streamPromise;
-    await this.assistantMessages.first().waitFor({ state: 'visible', timeout: 15_000 });
+    await this.assistantMessages.first().waitFor({ state: 'visible', timeout: 30_000 });
     // Wait for the stream to finish by watching for "Show Results" / "显示结果" button
     // This button appears when results are available (stream done, not idle)
     await this.showResultsButton.first().waitFor({ state: 'visible', timeout: timeoutMs });

--- a/frontend/tests/e2e/pages/console.page.ts
+++ b/frontend/tests/e2e/pages/console.page.ts
@@ -17,6 +17,11 @@ export class ConsolePage {
   readonly reportTab: Locator;
   readonly openVisualizationButton: Locator;
   readonly capabilityBar: Locator;
+  readonly showResultsButton: Locator;
+  readonly stopStreamButton: Locator;
+  readonly assistantMessages: Locator;
+  readonly visualizationModalScene: Locator;
+  readonly visualizationModalPlaceholder: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -35,6 +40,11 @@ export class ConsolePage {
     this.reportTab = page.locator('button:has-text("Report"), button:has-text("报告")');
     this.openVisualizationButton = page.locator('button:has-text("Visualization"), button:has-text("可视化")');
     this.capabilityBar = page.locator('[data-testid="console-composer"] [class*="capability"]');
+    this.showResultsButton = page.locator('[data-testid="console-composer"] button:has-text("Show Results"), [data-testid="console-composer"] button:has-text("显示结果")');
+    this.stopStreamButton = page.locator('button[class*="rose"]:has-text("Stop"), button[class*="rose"]:has-text("停止")');
+    this.assistantMessages = page.locator('[data-testid="assistant-execution-group"]');
+    this.visualizationModalScene = page.locator('[data-testid="visualization-modal-scene"]');
+    this.visualizationModalPlaceholder = page.locator('[data-testid="visualization-modal-placeholder"]');
   }
 
   async goto(): Promise<void> {
@@ -45,5 +55,44 @@ export class ConsolePage {
   async sendMessage(text: string): Promise<void> {
     await this.messageInput.fill(text);
     await this.sendButton.click();
+  }
+
+  async sendMessageAndWaitForStream(text: string, timeoutMs = 90_000): Promise<void> {
+    const streamPromise = this.page.waitForResponse(
+      (resp) => resp.url().includes('/api/v1/chat/stream') && resp.status() === 200,
+      { timeout: timeoutMs },
+    );
+    await this.messageInput.fill(text);
+    await this.sendButton.click();
+    await streamPromise;
+    await this.assistantMessages.first().waitFor({ state: 'visible', timeout: 15_000 });
+    // Wait for the stream to finish by watching for "Show Results" / "显示结果" button
+    // This button appears when results are available (stream done, not idle)
+    await this.showResultsButton.first().waitFor({ state: 'visible', timeout: timeoutMs });
+  }
+
+  async openResultDialog(): Promise<void> {
+    await this.showResultsButton.first().click({ force: true });
+  }
+
+  async openVisualization(): Promise<void> {
+    await this.openVisualizationButton.first().click();
+    await this.page.locator(
+      '[data-testid="visualization-modal-scene"], [data-testid="visualization-modal-placeholder"]',
+    ).first().waitFor({ state: 'visible', timeout: 15_000 });
+  }
+
+  async closeVisualization(): Promise<void> {
+    const closeButton = this.page.getByRole('button', {
+      name: /Close Visualization|关闭可视化|Close/,
+    });
+    await closeButton.first().click();
+    await this.page.locator(
+      '[data-testid="visualization-modal-scene"], [data-testid="visualization-modal-placeholder"]',
+    ).first().waitFor({ state: 'hidden', timeout: 10_000 });
+  }
+
+  async getConversationCount(): Promise<number> {
+    return this.conversationItems.count();
   }
 }

--- a/frontend/tests/e2e/pages/console.page.ts
+++ b/frontend/tests/e2e/pages/console.page.ts
@@ -65,7 +65,7 @@ export class ConsolePage {
     await this.messageInput.fill(text);
     await this.sendButton.click();
     await streamPromise;
-    await this.assistantMessages.first().waitFor({ state: 'visible', timeout: 30_000 });
+    await this.assistantMessages.first().waitFor({ state: 'visible', timeout: 150_000 });
     // Wait for the stream to finish by watching for "Show Results" / "显示结果" button
     // This button appears when results are available (stream done, not idle)
     await this.showResultsButton.first().waitFor({ state: 'visible', timeout: timeoutMs });

--- a/frontend/tests/e2e/pages/settings.page.ts
+++ b/frontend/tests/e2e/pages/settings.page.ts
@@ -1,0 +1,37 @@
+import type { Page, Locator } from '@playwright/test';
+
+export class SettingsPage {
+  readonly page: Page;
+  readonly baseUrlInput: Locator;
+  readonly modelInput: Locator;
+  readonly saveButton: Locator;
+  readonly resetButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.baseUrlInput = page.locator('#llm-base-url');
+    this.modelInput = page.locator('#llm-model');
+    this.saveButton = page.locator('button:has-text("Save"), button:has-text("保存")');
+    this.resetButton = page.locator('button:has-text("Reset"), button:has-text("重置"), button:has-text("Reset Defaults"), button:has-text("恢复默认")');
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/llm');
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async getBaseUrl(): Promise<string> {
+    return this.baseUrlInput.inputValue();
+  }
+
+  async getModel(): Promise<string> {
+    return this.modelInput.inputValue();
+  }
+
+  async updateSettings(baseUrl: string, model: string): Promise<void> {
+    await this.baseUrlInput.fill(baseUrl);
+    await this.modelInput.fill(model);
+    await this.saveButton.click();
+    await this.page.waitForLoadState('networkidle');
+  }
+}

--- a/frontend/tests/e2e/pages/settings.page.ts
+++ b/frontend/tests/e2e/pages/settings.page.ts
@@ -17,7 +17,7 @@ export class SettingsPage {
 
   async goto(): Promise<void> {
     await this.page.goto('/llm');
-    await this.page.waitForLoadState('networkidle');
+    await this.baseUrlInput.waitFor({ state: 'visible' });
   }
 
   async getBaseUrl(): Promise<string> {
@@ -32,6 +32,9 @@ export class SettingsPage {
     await this.baseUrlInput.fill(baseUrl);
     await this.modelInput.fill(model);
     await this.saveButton.click();
-    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForResponse(
+      (resp) => resp.url().includes('/api/v1/admin/llm') && resp.request().method() === 'PUT',
+      { timeout: 10_000 },
+    );
   }
 }

--- a/frontend/tests/e2e/specs/install-verification.spec.ts
+++ b/frontend/tests/e2e/specs/install-verification.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import { SettingsPage } from '../pages/settings.page';
+import { DatabasePage } from '../pages/database.page';
+import { CapabilitiesPage } from '../pages/capabilities.page';
+
+test.describe('Install verification', () => {
+  test('server responds to health check', async ({ request }) => {
+    const response = await request.get('/api/v1');
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.name).toBe('StructureClaw API');
+  });
+
+  test('settings API returns configuration', async ({ request }) => {
+    const response = await request.get('/api/v1/admin/settings');
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveProperty('server');
+    expect(body).toHaveProperty('llm');
+    expect(body).toHaveProperty('database');
+    expect(body).toHaveProperty('analysis');
+  });
+
+  test('LLM settings page loads and displays config', async ({ page }) => {
+    const settingsPage = new SettingsPage(page);
+    await settingsPage.goto();
+
+    await expect(settingsPage.baseUrlInput).toBeVisible();
+    await expect(settingsPage.modelInput).toBeVisible();
+  });
+
+  test('LLM settings can be updated via API', async ({ request }) => {
+    const getResp = await request.get('/api/v1/admin/llm');
+    const original = await getResp.json();
+
+    const putResp = await request.put('/api/v1/admin/llm', {
+      data: {
+        baseUrl: original.baseUrl,
+        model: original.model,
+        apiKeyMode: 'keep',
+      },
+    });
+    expect(putResp.status()).toBe(200);
+
+    const after = await putResp.json();
+    expect(after.baseUrl).toBe(original.baseUrl);
+    expect(after.model).toBe(original.model);
+  });
+
+  test('database admin shows healthy SQLite', async ({ page, request }) => {
+    const dbPage = new DatabasePage(page);
+    await dbPage.goto();
+
+    await expect(dbPage.statusCard).toBeVisible();
+    await expect(page.getByText('sqlite', { exact: true })).toBeVisible({ timeout: 15_000 });
+
+    const resp = await request.get('/api/v1/admin/database/status');
+    const body = await resp.json();
+    expect(body.provider).toBe('sqlite');
+    expect(body.database.exists).toBe(true);
+    expect(body.database.writable).toBe(true);
+  });
+
+  test('capabilities page loads skills', async ({ page }) => {
+    const capPage = new CapabilitiesPage(page);
+    await capPage.goto();
+
+    await expect(page.locator('body')).toBeVisible();
+    const bodyText = await page.locator('body').textContent();
+    const hasSkillContent = bodyText && bodyText.length > 100;
+    expect(hasSkillContent).toBe(true);
+  });
+});

--- a/frontend/tests/e2e/specs/install-verification.spec.ts
+++ b/frontend/tests/e2e/specs/install-verification.spec.ts
@@ -65,9 +65,6 @@ test.describe('Install verification', () => {
     const capPage = new CapabilitiesPage(page);
     await capPage.goto();
 
-    await expect(page.locator('body')).toBeVisible();
-    const bodyText = await page.locator('body').textContent();
-    const hasSkillContent = bodyText && bodyText.length > 100;
-    expect(hasSkillContent).toBe(true);
+    await expect(page.getByText(/beam|frame|truss/i).first()).toBeVisible({ timeout: 15_000 });
   });
 });

--- a/frontend/tests/e2e/specs/structural-analysis.spec.ts
+++ b/frontend/tests/e2e/specs/structural-analysis.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '@playwright/test';
+import { ConsolePage } from '../pages/console.page';
+
+const hasLlmKey = !!process.env.LLM_API_KEY;
+
+test.describe('Structural analysis end-to-end', () => {
+  let consolePage: ConsolePage;
+
+  test.beforeEach(async ({ page }) => {
+    consolePage = new ConsolePage(page);
+  });
+
+  test('EN: simply supported beam - complete analysis flow', async ({ page }) => {
+    test.setTimeout(120_000);
+    test.skip(!hasLlmKey, 'Requires LLM_API_KEY');
+
+    await consolePage.goto();
+    const countBefore = await consolePage.getConversationCount();
+
+    await consolePage.sendMessageAndWaitForStream(
+      'Analyze a 6m simply supported beam with UDL of 20 kN/m. Use steel beam section.',
+    );
+
+    const countAfter = await consolePage.getConversationCount();
+    expect(countAfter).toBeGreaterThanOrEqual(countBefore);
+
+    await expect(consolePage.showResultsButton).toBeVisible({ timeout: 15_000 });
+    await consolePage.openResultDialog();
+    await expect(consolePage.analysisTab.first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('ZH: simply supported beam - complete analysis flow', async ({ page }) => {
+    test.setTimeout(120_000);
+    test.skip(!hasLlmKey, 'Requires LLM_API_KEY');
+
+    await consolePage.goto();
+    await page.evaluate(() => {
+      localStorage.setItem('structureclaw.locale', 'zh');
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    await consolePage.sendMessageAndWaitForStream(
+      '分析一根6米简支梁，均布荷载20kN/m，使用钢梁截面。',
+    );
+
+    await expect(consolePage.showResultsButton).toBeVisible({ timeout: 15_000 });
+    await consolePage.openResultDialog();
+    await expect(consolePage.analysisTab.first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('stream events are well-formed', async ({ request }) => {
+    test.setTimeout(90_000);
+    test.skip(!hasLlmKey, 'Requires LLM_API_KEY');
+
+    const convResp = await request.post('/api/v1/chat/conversation', {
+      data: { title: 'E2E stream test', type: 'analysis', locale: 'en' },
+    });
+    expect(convResp.status()).toBe(200);
+    const conv = await convResp.json();
+    const conversationId = conv.id ?? conv.conversationId;
+
+    const streamResp = await request.post('/api/v1/chat/stream', {
+      data: {
+        message: 'Analyze a simply supported beam, 6m span, UDL 20kN/m',
+        conversationId,
+        traceId: `e2e-${Date.now()}`,
+        context: { locale: 'en' },
+      },
+    });
+    expect(streamResp.status()).toBe(200);
+
+    const body = await streamResp.text();
+    const eventTypes: string[] = [];
+    for (const line of body.split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('data:')) {
+        try {
+          const parsed = JSON.parse(trimmed.slice(5).trim());
+          if (parsed.type) eventTypes.push(parsed.type);
+        } catch {
+          // skip non-JSON lines
+        }
+      }
+    }
+
+    expect(eventTypes).toContain('start');
+    expect(eventTypes.some((t) => t === 'token' || t === 'result' || t === 'done')).toBe(true);
+  });
+
+  test('visualization opens from analysis result', async ({ page }) => {
+    test.setTimeout(120_000);
+    test.skip(!hasLlmKey, 'Requires LLM_API_KEY');
+
+    await consolePage.goto();
+    await consolePage.sendMessageAndWaitForStream(
+      'Analyze a 6m simply supported beam with UDL of 20 kN/m.',
+    );
+
+    await expect(consolePage.showResultsButton).toBeVisible({ timeout: 15_000 });
+    await consolePage.openResultDialog();
+
+    const visButton = page.locator(
+      '[role="dialog"] button:has-text("Visualization"), [role="dialog"] button:has-text("可视化")',
+    );
+    if (await visButton.first().isVisible()) {
+      await visButton.first().click();
+      const sceneOrPlaceholder = page.locator(
+        '[data-testid="visualization-modal-scene"], [data-testid="visualization-modal-placeholder"]',
+      );
+      await expect(sceneOrPlaceholder.first()).toBeVisible({ timeout: 15_000 });
+    }
+  });
+
+  test('result persists after page reload', async ({ page }) => {
+    test.setTimeout(120_000);
+    test.skip(!hasLlmKey, 'Requires LLM_API_KEY');
+
+    await consolePage.goto();
+    await consolePage.sendMessageAndWaitForStream(
+      'Analyze a 6m simply supported beam with UDL of 20 kN/m.',
+    );
+
+    await expect(consolePage.showResultsButton).toBeVisible({ timeout: 15_000 });
+    const countBefore = await consolePage.getConversationCount();
+    expect(countBefore).toBeGreaterThan(0);
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const countAfter = await consolePage.getConversationCount();
+    expect(countAfter).toBeGreaterThanOrEqual(countBefore);
+  });
+});

--- a/frontend/tests/e2e/specs/structural-analysis.spec.ts
+++ b/frontend/tests/e2e/specs/structural-analysis.spec.ts
@@ -100,10 +100,15 @@ test.describe('Structural analysis end-to-end', () => {
     await expect(consolePage.showResultsButton).toBeVisible({ timeout: 15_000 });
     await consolePage.openResultDialog();
 
+    // Verify the result dialog opened with analysis content
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+    // Try to open visualization if the button exists
     const visButton = page.locator(
       '[role="dialog"] button:has-text("Visualization"), [role="dialog"] button:has-text("可视化")',
     );
-    if (await visButton.first().isVisible()) {
+    if (await visButton.first().isVisible({ timeout: 5_000 }).catch(() => false)) {
       await visButton.first().click();
       const sceneOrPlaceholder = page.locator(
         '[data-testid="visualization-modal-scene"], [data-testid="visualization-modal-placeholder"]',
@@ -126,9 +131,9 @@ test.describe('Structural analysis end-to-end', () => {
     expect(countBefore).toBeGreaterThan(0);
 
     await page.reload();
-    await page.waitForLoadState('networkidle');
+    await consolePage.historyPanel.waitFor({ state: 'visible' });
 
     const countAfter = await consolePage.getConversationCount();
-    expect(countAfter).toBeGreaterThanOrEqual(countBefore);
+    expect(countAfter).toBe(countBefore);
   });
 });


### PR DESCRIPTION
## Summary

Closes #235

- **Install verification spec** (6 tests): health check, settings API, LLM config page, database status, capabilities page — all run without LLM key
- **Structural analysis spec** (5 tests): EN/ZH beam analysis end-to-end, stream event validation, visualization opening, result persistence after reload — conditional on `LLM_API_KEY`
- **Infrastructure**: Playwright timeouts increased (60s global, 15s expect); ConsolePage enhanced with `sendMessageAndWaitForStream`, `openResultDialog`, visualization methods; new SettingsPage page object

## Impacted Areas

- `frontend/` — E2E test infrastructure and new test specs

## Test Results

```
37 passed, 1 failed (pre-existing database-admin test path mismatch)
- Install verification: 6/6 passed
- Structural analysis: 5/5 passed (with LLM_API_KEY)
```

## Test Plan

- [x] `npm run test:e2e --prefix frontend -- --grep "install verification"` — 6/6 passed
- [x] `LLM_API_KEY=... npm run test:e2e --prefix frontend -- --grep "structural analysis"` — 5/5 passed
- [x] Full E2E suite with LLM key — 37/38 passed (1 pre-existing failure unrelated to this PR)
- [ ] CI E2E workflow (automated on push)