### PR TITLE
feat(backend): add concrete-frame skill core implementation (Part 2/4)

### DIFF
--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/member-generation.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/member-generation.test.mjs
@@ -1,0 +1,476 @@
+import { describe, expect, test } from '@jest/globals';
+import { generateMembers, generateBeams, generateColumns, generateSlabs } from '../../../../../dist/agent-skills/structure-type/concrete-frame/handler.js';
+
+// ============================================================================
+// PR2: 混凝土构件生成器测试
+// ============================================================================
+describe('PR2: concrete-frame member generation', () => {
+  describe('generateBeams', () => {
+    test('generates rectangular beams with proper span-depth ratios', () => {
+      const input = {
+        storyCount: 3,
+        bayCount: 2,
+        storyHeightsM: [3.6, 3.6, 3.6],
+        bayWidthsM: [6, 6],
+        concreteGrade: 'C30',
+        rebarGrade: 'HRB400',
+        beamType: 'rectangular',
+      };
+
+      const beams = generateBeams(input);
+
+      expect(beams).toHaveLength(2);
+      beams.forEach((beam, i) => {
+        expect(beam.id).toBe(`B-${i + 1}`);
+        expect(beam.type).toBe('rectangular');
+        expect(beam.spanM).toBe(6);
+        expect(beam.widthMM).toBeGreaterThanOrEqual(200);
+        expect(beam.heightMM).toBeGreaterThanOrEqual(250);
+        expect(beam.spanDepthRatio).toBeDefined();
+        expect(beam.meetsRequirement).toBeDefined();
+      });
+    });
+
+    test('generates T-shaped beams with proper flange dimensions (middle + edge)', () => {
+      const input = {
+        storyCount: 3,
+        bayCount: 3,
+        storyHeightsM: [3.6, 3.6, 3.6],
+        bayWidthsM: [8, 8, 8],
+        concreteGrade: 'C30',
+        rebarGrade: 'HRB400',
+        beamType: 't-shaped',
+      };
+
+      const beams = generateBeams(input);
+
+      expect(beams).toHaveLength(3);
+      // 边梁 (B-1, B-3) 翼缘宽度应小于中梁 (B-2)
+      const edgeBeam = beams[0];
+      const midBeam = beams[1];
+      expect(edgeBeam.type).toBe('t-shaped');
+      expect(midBeam.type).toBe('t-shaped');
+      // 中梁翼缘更宽 (l0/3 vs l0/6)
+      expect(midBeam.flangeWidthMM).toBeGreaterThan(edgeBeam.flangeWidthMM);
+      // 所有梁满足 bf ≤ bw + 12*hf
+      beams.forEach(beam => {
+        expect(beam.flangeWidthMM).toBeLessThanOrEqual(
+          beam.webWidthMM + 12 * beam.flangeThicknessMM,
+        );
+        expect(beam.webWidthMM).toBeGreaterThanOrEqual(200);
+        expect(beam.flangeThicknessMM).toBeGreaterThan(0);
+        expect(beam.totalHeightMM).toBeGreaterThanOrEqual(250);
+      });
+    });
+
+    test('ensures span-depth ratio for rectangular beams is within 8-16 range', () => {
+      const input = {
+        storyCount: 2,
+        bayCount: 3,
+        storyHeightsM: [3.6, 3.6],
+        bayWidthsM: [4, 8, 12],
+        concreteGrade: 'C30',
+        rebarGrade: 'HRB400',
+        beamType: 'rectangular',
+      };
+
+      const beams = generateBeams(input);
+
+      beams.forEach((beam) => {
+        const sd = beam.spanDepthRatio;
+        expect(sd).toBeGreaterThanOrEqual(8);
+        expect(sd).toBeLessThanOrEqual(16);
+      });
+    });
+
+    test('handles 2m short-span beams', () => {
+      const input = {
+        storyCount: 1,
+        bayCount: 1,
+        storyHeightsM: [3.6],
+        bayWidthsM: [2],
+        concreteGrade: 'C30',
+        rebarGrade: 'HRB400',
+        beamType: 'rectangular',
+      };
+
+      const beams = generateBeams(input);
+      const beam = beams[0];
+      expect(beam.heightMM).toBeGreaterThanOrEqual(250);
+      expect(beam.widthMM).toBeGreaterThanOrEqual(200);
+      expect(beam.meetsRequirement).toBeDefined();
+    });
+  });
+
+  describe('generateColumns', () => {
+    test('generates rectangular columns with proper axial load ratios for C30', () => {
+      const input = {
+        storyCount: 3,
+        bayCount: 2,
+        storyHeightsM: [3.6, 3.6, 3.6],
+        bayWidthsM: [6, 6],
+        concreteGrade: 'C30',
+        rebarGrade: 'HRB400',
+        columnType: 'rectangular',
+        axialLoadKN: 1500,
+      };
+
+      const columns = generateColumns(input);
+
+      expect(columns).toHaveLength(3);
+      columns.forEach((column, i) => {
+        expect(column.id).toBe(`C-S${i + 1}-1`);
+        expect(column.type).toBe('rectangular');
+        expect(column.heightM).toBe(3.6);
+        expect(column.widthMM).toBeGreaterThanOrEqual(400);
+        expect(column.heightMM).toBe(column.widthMM);
+        expect(column.axialLoadRatio).toBeDefined();
+        expect(column.axialLoadRatio).toBeLessThanOrEqual(0.9);
+      });
+    });
+
+    test('generates circular columns', () => {
+      const input = {
+        storyCount: 3,
+        bayCount: 2,
+        storyHeightsM: [3.6, 3.6, 3.6],
+        bayWidthsM: [6, 6],
+        concreteGrade: 'C30',
+        rebarGrade: 'HRB400',
+        columnType: 'circular',
+        axialLoadKN: 1500,
+      };
+
+      const columns = generateColumns(input);
+
+      expect(columns).toHaveLength(3);
+      columns.forEach((column, i) => {
+        expect(column.id).toBe(`C-S${i + 1}-1`);
+        expect(column.type).toBe('circular');
+        expect(column.diameterMM).toBeGreaterThanOrEqual(500);
+        expect(column.axialLoadRatio).toBeDefined();
+        expect(column.axialLoadRatio).toBeLessThanOrEqual(0.9);
+      });
+    });
+
+    test('scales column size with story count', () => {
+      const inputs = [
+        { storyCount: 1, concreteGrade: 'C30', expectedSize: 500 },
+        { storyCount: 6, concreteGrade: 'C30', expectedSize: 600 },
+        { storyCount: 12, concreteGrade: 'C30', expectedSize: 850 },
+      ];
+
+      inputs.forEach(({ storyCount, concreteGrade, expectedSize }) => {
+        const input = {
+          storyCount,
+          bayCount: 2,
+          storyHeightsM: Array(storyCount).fill(3.6),
+          bayWidthsM: [6, 6],
+          concreteGrade,
+          rebarGrade: 'HRB400',
+          columnType: 'rectangular',
+        };
+
+        const columns = generateColumns(input);
+        const bottom = columns[storyCount - 1];
+        expect(bottom.widthMM).toBe(expectedSize);
+      });
+    });
+
+    test('handles 30-story high-rise column sizing', () => {
+      const input = {
+        storyCount: 30,
+        bayCount: 2,
+        storyHeightsM: Array(30).fill(3.6),
+        bayWidthsM: [6, 6],
+        concreteGrade: 'C50',
+        rebarGrade: 'HRB500',
+        columnType: 'rectangular',
+      };
+
+      const columns = generateColumns(input);
+      const bottom = columns[29];
+      expect(bottom.widthMM).toBeGreaterThanOrEqual(900);
+      expect(bottom.axialLoadRatio).toBeLessThanOrEqual(0.9);
+    });
+
+    test('respects axial load ratio limit for different concrete grades', () => {
+      const grades = ['C20', 'C30', 'C40', 'C50', 'C80'];
+
+      grades.forEach(grade => {
+        const input = {
+          storyCount: 3,
+          bayCount: 2,
+          storyHeightsM: [3.6, 3.6, 3.6],
+          bayWidthsM: [6, 6],
+          concreteGrade: grade,
+          rebarGrade: 'HRB400',
+          columnType: 'rectangular',
+          axialLoadKN: 2000,
+        };
+
+        const columns = generateColumns(input);
+        columns.forEach(column => {
+          expect(column.axialLoadRatio).toBeLessThanOrEqual(0.9);
+        });
+      });
+    });
+  });
+
+  describe('generateSlabs', () => {
+    test('generates one-way residential slab with proper thickness', () => {
+      const input = {
+        storyCount: 3,
+        bayCount: 2,
+        storyHeightsM: [3.6, 3.6, 3.6],
+        bayWidthsM: [3, 6],
+        concreteGrade: 'C30',
+        rebarGrade: 'HRB400',
+        slabType: 'one-way',
+        slabUsage: 'residential',
+      };
+
+      const slabs = generateSlabs(input);
+
+      expect(slabs).toHaveLength(2);
+      slabs.forEach((slab, i) => {
+        expect(slab.id).toBe(`SL-${i + 1}`);
+        expect(slab.type).toBe('one-way');
+        expect(slab.usage).toBe('residential');
+        expect(slab.thicknessMM).toBeGreaterThanOrEqual(60);
+        expect(slab.spanDepthRatio).toBeDefined();
+        expect(slab.spanDepthRatio).toBeLessThanOrEqual(30);
+      });
+    });
+
+    test('generates two-way slab with GB/T 50010 minimum thickness (floor 80mm, roof 100mm)', () => {
+      const cases = [
+        { usage: 'residential', minThickness: 80 },
+        { usage: 'commercial', minThickness: 80 },
+        { usage: 'roof', minThickness: 100 },
+      ];
+
+      cases.forEach(({ usage, minThickness }) => {
+        const input = {
+          storyCount: 3,
+          bayCount: 1,
+          storyHeightsM: [3.6, 3.6, 3.6],
+          bayWidthsM: [4],
+          concreteGrade: 'C30',
+          rebarGrade: 'HRB400',
+          slabType: 'two-way',
+          slabUsage: usage,
+        };
+
+        const slabs = generateSlabs(input);
+        const slab = slabs[0];
+        expect(slab.type).toBe('two-way');
+        expect(slab.thicknessMM).toBeGreaterThanOrEqual(minThickness);
+        expect(slab.spanDepthRatio).toBeLessThanOrEqual(40);
+      });
+    });
+
+    test('handles flat slab with proper minimum thickness', () => {
+      const input = {
+        storyCount: 3,
+        bayCount: 1,
+        storyHeightsM: [3.6, 3.6, 3.6],
+        bayWidthsM: [7],
+        concreteGrade: 'C30',
+        rebarGrade: 'HRB400',
+        slabType: 'flat-slab',
+        slabUsage: 'commercial',
+      };
+
+      const slabs = generateSlabs(input);
+      const slab = slabs[0];
+
+      expect(slab.type).toBe('flat-slab');
+      expect(slab.thicknessMM).toBeGreaterThanOrEqual(150);
+      expect(slab.spanDepthRatio).toBeLessThanOrEqual(30);
+    });
+
+    test('applies different minimum thickness based on usage for one-way slabs', () => {
+      const usageCases = [
+        { usage: 'roof', minThickness: 60 },
+        { usage: 'residential', minThickness: 60 },
+        { usage: 'commercial', minThickness: 70 },
+        { usage: 'vehicle', minThickness: 80 },
+      ];
+
+      usageCases.forEach(({ usage, minThickness }) => {
+        const input = {
+          storyCount: 2,
+          bayCount: 1,
+          storyHeightsM: [3.6, 3.6],
+          bayWidthsM: [4],
+          concreteGrade: 'C30',
+          rebarGrade: 'HRB400',
+          slabType: 'one-way',
+          slabUsage: usage,
+        };
+
+        const slabs = generateSlabs(input);
+        const slab = slabs[0];
+        expect(slab.thicknessMM).toBeGreaterThanOrEqual(minThickness);
+      });
+    });
+
+    test('handles 2m short-span slab', () => {
+      const input = {
+        storyCount: 2,
+        bayCount: 1,
+        storyHeightsM: [3.6, 3.6],
+        bayWidthsM: [2],
+        concreteGrade: 'C30',
+        rebarGrade: 'HRB400',
+        slabType: 'one-way',
+        slabUsage: 'residential',
+      };
+
+      const slabs = generateSlabs(input);
+      const slab = slabs[0];
+      expect(slab.thicknessMM).toBe(70);
+      expect(slab.spanDepthRatio).toBeLessThanOrEqual(30);
+    });
+  });
+
+  describe('generateMembers integration', () => {
+    test('generates complete member set for typical 3-story frame', () => {
+      const input = {
+        storyCount: 3,
+        bayCount: 3,
+        storyHeightsM: [3.6, 3.6, 3.6],
+        bayWidthsM: [5, 6, 5],
+        concreteGrade: 'C30',
+        rebarGrade: 'HRB400',
+        beamType: 'rectangular',
+        slabType: 'one-way',
+        slabUsage: 'residential',
+        axialLoadKN: 1200,
+      };
+
+      const output = generateMembers(input);
+
+      expect(output.concreteBeams).toHaveLength(3);
+      expect(output.concreteColumns).toHaveLength(3);
+      expect(output.concreteSlabs).toHaveLength(3);
+      expect(output.warnings).toBeDefined();
+      expect(output.errors).toBeDefined();
+
+      output.concreteBeams.forEach(beam => {
+        expect(beam.spanDepthRatio).toBeGreaterThanOrEqual(8);
+        expect(beam.spanDepthRatio).toBeLessThanOrEqual(16);
+      });
+
+      output.concreteColumns.forEach(column => {
+        expect(column.axialLoadRatio).toBeLessThanOrEqual(0.9);
+      });
+
+      output.concreteSlabs.forEach(slab => {
+        expect(slab.spanDepthRatio).toBeLessThanOrEqual(30);
+      });
+    });
+
+    test('handles edge cases with warnings and errors', () => {
+      const edgeCases = [
+        {
+          description: 'single story, single bay',
+          input: {
+            storyCount: 1,
+            bayCount: 1,
+            storyHeightsM: [3.6],
+            bayWidthsM: [3],
+            concreteGrade: 'C30',
+            rebarGrade: 'HRB400',
+          },
+        },
+        {
+          description: 'long span (12m)',
+          input: {
+            storyCount: 2,
+            bayCount: 1,
+            storyHeightsM: [3.6, 3.6],
+            bayWidthsM: [12],
+            concreteGrade: 'C30',
+            rebarGrade: 'HRB400',
+          },
+        },
+        {
+          description: '2m short span',
+          input: {
+            storyCount: 1,
+            bayCount: 1,
+            storyHeightsM: [3.6],
+            bayWidthsM: [2],
+            concreteGrade: 'C30',
+            rebarGrade: 'HRB400',
+          },
+        },
+        {
+          description: 'C80 + HRB500',
+          input: {
+            storyCount: 3,
+            bayCount: 2,
+            storyHeightsM: [3.6, 3.6, 3.6],
+            bayWidthsM: [6, 6],
+            concreteGrade: 'C80',
+            rebarGrade: 'HRB500',
+          },
+        },
+        {
+          description: '30-story high-rise',
+          input: {
+            storyCount: 30,
+            bayCount: 3,
+            storyHeightsM: Array(30).fill(3.6),
+            bayWidthsM: [6, 6, 6],
+            concreteGrade: 'C50',
+            rebarGrade: 'HRB500',
+          },
+        },
+      ];
+
+      edgeCases.forEach(({ input }) => {
+        const output = generateMembers(input);
+
+        expect(output.concreteBeams).toBeDefined();
+        expect(output.concreteColumns).toBeDefined();
+        expect(output.concreteSlabs).toBeDefined();
+        expect(output.errors).toBeInstanceOf(Array);
+        expect(output.warnings).toBeInstanceOf(Array);
+      });
+    });
+
+    test('validates GB/T 50010-2010 section 9.1.2 requirements', () => {
+      const slabConfigs = [
+        { slabType: 'one-way', slabUsage: 'residential', spanM: 4.5, expectedMaxRatio: 30, expectedMinThickness: 60 },
+        { slabType: 'two-way', slabUsage: 'commercial', spanM: 6.0, expectedMaxRatio: 40, expectedMinThickness: 80 },
+        { slabType: 'two-way', slabUsage: 'roof', spanM: 6.0, expectedMaxRatio: 40, expectedMinThickness: 100 },
+        { slabType: 'flat-slab', slabUsage: 'commercial', spanM: 7.0, expectedMaxRatio: 30, expectedMinThickness: 150 },
+      ];
+
+      slabConfigs.forEach(({ slabType, slabUsage, spanM, expectedMaxRatio, expectedMinThickness }) => {
+        const input = {
+          storyCount: 2,
+          bayCount: 1,
+          storyHeightsM: [3.6, 3.6],
+          bayWidthsM: [spanM],
+          concreteGrade: 'C30',
+          rebarGrade: 'HRB400',
+          slabType,
+          slabUsage,
+        };
+
+        const slabs = generateSlabs(input);
+        const slab = slabs[0];
+
+        expect(slab.spanDepthRatio).toBeLessThanOrEqual(expectedMaxRatio);
+        expect(slab.thicknessMM).toBeGreaterThanOrEqual(expectedMinThickness);
+        expect(slab.meetsRequirement).toBe(
+          slab.spanDepthRatio <= expectedMaxRatio && slab.thicknessMM >= expectedMinThickness,
+        );
+      });
+    });
+  });
+});

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/member-generation.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/member-generation.test.mjs
@@ -51,14 +51,16 @@ describe('PR2: concrete-frame member generation', () => {
       expect(edgeBeam.type).toBe('t-shaped');
       expect(midBeam.type).toBe('t-shaped');
       // 中梁翼缘更宽 (l0/3 vs l0/6)
-      expect(midBeam.flangeWidthMM).toBeGreaterThan(edgeBeam.flangeWidthMM);
-      // 所有梁满足 bf ≤ bw + 12*hf
-      beams.forEach(beam => {
-        expect(beam.flangeWidthMM).toBeLessThanOrEqual(
-          beam.webWidthMM + 12 * beam.flangeThicknessMM,
-        );
+      expect(midBeam.flangeWidthMM_compression).toBeGreaterThan(edgeBeam.flangeWidthMM_compression);
+      // bf' = min(l₀/k, b + n·hf') — 边梁 b + 5hf'，中梁 b + 12hf'
+      beams.forEach((beam, i) => {
+        const isEdge = i === 0 || i === beams.length - 1;
+        const candidateL0 = Math.round(beam.spanM * 1000 / (isEdge ? 6 : 3));
+        const candidateHf = beam.webWidthMM + (isEdge ? 5 : 12) * beam.flangeThicknessMM_compression;
+        const expectedBfMax = Math.min(candidateL0, candidateHf);
+        expect(beam.flangeWidthMM_compression).toBe(expectedBfMax);
         expect(beam.webWidthMM).toBeGreaterThanOrEqual(200);
-        expect(beam.flangeThicknessMM).toBeGreaterThan(0);
+        expect(beam.flangeThicknessMM_compression).toBeGreaterThan(0);
         expect(beam.totalHeightMM).toBeGreaterThanOrEqual(250);
       });
     });

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/member-generation.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/member-generation.test.mjs
@@ -156,8 +156,8 @@ describe('PR2: concrete-frame member generation', () => {
     test('scales column size with story count', () => {
       const inputs = [
         { storyCount: 1, concreteGrade: 'C30', expectedSize: 500 },
-        { storyCount: 6, concreteGrade: 'C30', expectedSize: 600 },
-        { storyCount: 12, concreteGrade: 'C30', expectedSize: 850 },
+        { storyCount: 6, concreteGrade: 'C30', expectedSize: 550 },
+        { storyCount: 12, concreteGrade: 'C30', expectedSize: 750 },
       ];
 
       inputs.forEach(({ storyCount, concreteGrade, expectedSize }) => {

--- a/backend/src/agent-skills/structure-type/concrete-frame/constants.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/constants.ts
@@ -26,3 +26,6 @@ export const REQUIRED_KEYS = [
 ] as const;
 
 export const FRAME_MATERIAL_KEYS = ['frameConcreteGrade', 'frameRebarGrade', 'frameColumnSection', 'frameBeamSection'] as const;
+
+/** 方案阶段柱轴力估算默认单位荷载 (kN/m²)，已含恒载、活载及分项系数 */
+export const DEFAULT_FLOOR_LOAD_KN_PER_M2 = 15;

--- a/backend/src/agent-skills/structure-type/concrete-frame/handler.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/handler.ts
@@ -11,7 +11,7 @@ import {
   resolveConcreteFrameStage,
 } from './interaction.js';
 import { mergeConcreteFrameState } from './merge.js';
-import { buildConcreteFrameModel, getConcreteMaterial, normalizeConcreteGrade, normalizeSectionName } from './model.js';
+import { buildConcreteFrameModel, getConcreteMaterial, isValidConcreteGrade, normalizeConcreteGrade, normalizeSectionName } from './model.js';
 import { DEFAULT_FLOOR_LOAD_KN_PER_M2 } from './constants.js';
 import type {
   ConcreteBeam,
@@ -54,53 +54,88 @@ const MIN_THICKNESS_MAP: Record<string, number> = {
 };
 
 /**
+ * 验证混凝土框架输入参数
+ * @throws Error 如果输入参数无效
+ */
+function validateConcreteFrameInput(input: ConcreteFrameInput): void {
+  if (!input.bayWidthsM?.length) {
+    throw new Error('bayWidthsM must be a non-empty array');
+  }
+  if (input.bayWidthsM.some(w => w <= 0)) {
+    throw new Error('bayWidthsM must contain positive values');
+  }
+  if (input.storyHeightsM?.length !== input.storyCount) {
+    throw new Error(
+      `storyHeightsM length (${input.storyHeightsM?.length ?? 'undefined'}) must match storyCount (${input.storyCount})`,
+    );
+  }
+  if (!isValidConcreteGrade(input.concreteGrade)) {
+    throw new Error(`Invalid concrete grade: ${input.concreteGrade}`);
+  }
+}
+
+/**
  * 生成所有混凝土构件
  * @param input 混凝土框架输入参数
  * @returns 包含梁、柱、板的输出对象
  */
 export function generateMembers(input: ConcreteFrameInput): ConcreteFrameOutput {
-  const warnings: Array<{ code: string; message: string }> = [];
   const errors: Array<{ code: string; message: string }> = [];
+  const warnings: Array<{ code: string; message: string }> = [];
 
   try {
-    const beams = generateBeams(input);
-    const columns = generateColumns(input);
-    const slabs = generateSlabs(input);
-
-    return { concreteBeams: beams, concreteColumns: columns, concreteSlabs: slabs, warnings, errors };
+    validateConcreteFrameInput(input);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
-    errors.push({ code: 'GENERATION_ERROR', message });
-    return {
-      concreteBeams: [],
-      concreteColumns: [],
-      concreteSlabs: [],
-      warnings,
-      errors,
-    };
+    errors.push({ code: 'INPUT_VALIDATION_ERROR', message });
+    return { concreteBeams: [], concreteColumns: [], concreteSlabs: [], warnings, errors };
   }
+
+  let beams: ConcreteBeam[] = [];
+  let columns: ConcreteColumn[] = [];
+  let slabs: ConcreteSlab[] = [];
+
+  try {
+    beams = generateBeams(input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    errors.push({ code: 'BEAM_GENERATION_ERROR', message });
+  }
+
+  try {
+    columns = generateColumns(input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    errors.push({ code: 'COLUMN_GENERATION_ERROR', message });
+  }
+
+  try {
+    slabs = generateSlabs(input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    errors.push({ code: 'SLAB_GENERATION_ERROR', message });
+  }
+
+  return { concreteBeams: beams, concreteColumns: columns, concreteSlabs: slabs, warnings, errors };
 }
 
 /**
  * 生成梁构件
- * 矩形梁: h = span / 10 (主梁) 或 h = span / 14 (次梁)
+ * 矩形梁: h = span / 10
  * 梁宽 b = h / 2
  * T形梁: 根据 GB/T 50010-2010 表 5.2.4 计算翼缘宽度
  */
 export function generateBeams(input: ConcreteFrameInput): ConcreteBeam[] {
   const beams: ConcreteBeam[] = [];
-  const { bayWidthsM, beamType = 'rectangular', storyCount } = input;
+  const { bayWidthsM, beamType = 'rectangular' } = input;
 
-  // 判断是否为主梁（第一层或截面尺寸较大的为默认主梁）
-  const isMainBeam = (index: number) => index === 0 || storyCount <= 3;
+  // 混凝土框架中所有梁均为框架主梁，统一采用 l/10 跨高比
+  const spanDepthRatioTarget = 10;
 
   for (let i = 0; i < bayWidthsM.length; i++) {
     const spanM = bayWidthsM[i]!;
     const spanMM = spanM * 1000;
-    const isMain = isMainBeam(i);
 
-    // 跨高比：主梁 l/10 ~ l/8，次梁 l/15 ~ l/12
-    const spanDepthRatioTarget = isMain ? 10 : 14;
     let heightMM = Math.round((spanMM / spanDepthRatioTarget) / 50) * 50; // 取整到50mm
     heightMM = Math.max(heightMM, 250); // 最小梁高250mm
 
@@ -110,23 +145,27 @@ export function generateBeams(input: ConcreteFrameInput): ConcreteBeam[] {
 
     if (beamType === 't-shaped') {
       // T形梁计算 (GB/T 50010-2010 表 5.2.4)
-      const hf = Math.round(heightMM / 6); // 翼缘厚度取梁高的1/6
-      const bw = widthMM; // 腹板宽度等于梁宽
-      // 边梁 (首跨或末跨): bf = bw + l0/6; 中梁: bf = bw + l0/3
-      // 且 bf ≤ bw + 12*hf
+      // hf' — 受压区翼缘厚度 (带撇)，取板厚；当前用 h/6 近似 (PR3 修正)
+      const flangeThicknessMM_compression = Math.round(heightMM / 6);
+      // b — 腹板宽度
+      const bw = widthMM;
+      // bf' — 受压区翼缘有效宽度 (带撇) = min(l₀/k, b + n·hf')
+      // 边梁: l₀/6,  b + 5hf'
+      // 中梁: l₀/3,  b + 12hf'
       const isEdge = i === 0 || i === bayWidthsM.length - 1;
-      const bfAddend = isEdge ? Math.round(spanMM / 6) : Math.round(spanMM / 3);
-      let bf = bw + bfAddend;
-      const bfMax = bw + 12 * hf;
-      bf = Math.min(bf, bfMax);
+      const candidateL0 = Math.round(spanMM / (isEdge ? 6 : 3));       // ① l₀/k
+      const candidateHf = bw + (isEdge ? 5 : 12) * flangeThicknessMM_compression; // ③ b + n·hf'
+      const flangeWidthMM_compression = Math.min(candidateL0, candidateHf);
+      // TODO(PR4): 补充净距约束 ② b + sₙ
 
       beams.push({
         id: `B-${i + 1}`,
         type: 't-shaped',
         spanM: spanM,
         webWidthMM: bw,
-        flangeWidthMM: bf,
-        flangeThicknessMM: hf,
+        flangeWidthMM_compression,
+        flangeThicknessMM_compression,
+        supportEffectiveWidthMM: bw, // 支座区 bf' = b (翼缘受拉开裂不计)
         totalHeightMM: heightMM,
         spanDepthRatio: spanMM / heightMM,
         meetsRequirement: (spanMM / heightMM) >= 8 && (spanMM / heightMM) <= 16,

--- a/backend/src/agent-skills/structure-type/concrete-frame/handler.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/handler.ts
@@ -11,7 +11,279 @@ import {
   resolveConcreteFrameStage,
 } from './interaction.js';
 import { mergeConcreteFrameState } from './merge.js';
-import { buildConcreteFrameModel, normalizeConcreteGrade, normalizeSectionName } from './model.js';
+import { buildConcreteFrameModel, getConcreteMaterial, normalizeConcreteGrade, normalizeSectionName } from './model.js';
+import type {
+  ConcreteBeam,
+  ConcreteColumn,
+  ConcreteFrameInput,
+  ConcreteFrameOutput,
+  ConcreteSlab,
+} from './types.js';
+
+// ============================================================================
+// PR2: 构件生成器
+// ============================================================================
+
+/**
+ * 生成所有混凝土构件
+ * @param input 混凝土框架输入参数
+ * @returns 包含梁、柱、板的输出对象
+ */
+export function generateMembers(input: ConcreteFrameInput): ConcreteFrameOutput {
+  const warnings: Array<{ code: string; message: string }> = [];
+  const errors: Array<{ code: string; message: string }> = [];
+
+  try {
+    const beams = generateBeams(input);
+    const columns = generateColumns(input);
+    const slabs = generateSlabs(input);
+
+    return { concreteBeams: beams, concreteColumns: columns, concreteSlabs: slabs, warnings, errors };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    errors.push({ code: 'GENERATION_ERROR', message });
+    return {
+      concreteBeams: [],
+      concreteColumns: [],
+      concreteSlabs: [],
+      warnings,
+      errors,
+    };
+  }
+}
+
+/**
+ * 生成梁构件
+ * 矩形梁: h = span / 10 (主梁) 或 h = span / 14 (次梁)
+ * 梁宽 b = h / 2
+ * T形梁: 根据 GB/T 50010-2010 表 5.2.4 计算翼缘宽度
+ */
+export function generateBeams(input: ConcreteFrameInput): ConcreteBeam[] {
+  const beams: ConcreteBeam[] = [];
+  const { bayWidthsM, beamType = 'rectangular', storyCount } = input;
+
+  // 判断是否为主梁（第一层或截面尺寸较大的为默认主梁）
+  const isMainBeam = (index: number) => index === 0 || storyCount <= 3;
+
+  for (let i = 0; i < bayWidthsM.length; i++) {
+    const spanM = bayWidthsM[i]!;
+    const spanMM = spanM * 1000;
+    const isMain = isMainBeam(i);
+
+    // 跨高比：主梁 l/10 ~ l/8，次梁 l/15 ~ l/12
+    const spanDepthRatioTarget = isMain ? 10 : 14;
+    let heightMM = Math.round((spanMM / spanDepthRatioTarget) / 50) * 50; // 取整到50mm
+    heightMM = Math.max(heightMM, 250); // 最小梁高250mm
+
+    // 梁宽 b = h/2，取整到25mm
+    let widthMM = Math.round((heightMM / 2) / 25) * 25;
+    widthMM = Math.max(widthMM, 200); // 最小梁宽200mm
+
+    if (beamType === 't-shaped') {
+      // T形梁计算 (GB/T 50010-2010 表 5.2.4)
+      const hf = Math.round(heightMM / 6); // 翼缘厚度取梁高的1/6
+      const bw = widthMM; // 腹板宽度等于梁宽
+      // 边梁 (首跨或末跨): bf = bw + l0/6; 中梁: bf = bw + l0/3
+      // 且 bf ≤ bw + 12*hf
+      const isEdge = i === 0 || i === bayWidthsM.length - 1;
+      const bfAddend = isEdge ? Math.round(spanMM / 6) : Math.round(spanMM / 3);
+      let bf = bw + bfAddend;
+      const bfMax = bw + 12 * hf;
+      bf = Math.min(bf, bfMax);
+
+      beams.push({
+        id: `B-${i + 1}`,
+        type: 't-shaped',
+        spanM: spanM,
+        webWidthMM: bw,
+        flangeWidthMM: bf,
+        flangeThicknessMM: hf,
+        totalHeightMM: heightMM,
+        spanDepthRatio: spanMM / heightMM,
+        meetsRequirement: (spanMM / heightMM) >= 8 && (spanMM / heightMM) <= 16,
+      });
+    } else {
+      // 矩形梁
+      beams.push({
+        id: `B-${i + 1}`,
+        type: 'rectangular',
+        spanM: spanM,
+        widthMM: widthMM,
+        heightMM: heightMM,
+        spanDepthRatio: spanMM / heightMM,
+        meetsRequirement: (spanMM / heightMM) >= 8 && (spanMM / heightMM) <= 16,
+      });
+    }
+  }
+
+  // TODO(PR3): 梁配筋计算（正截面、斜截面）
+  return beams;
+}
+
+/**
+ * 生成柱构件
+ * 估算公式: N ≤ 0.9 × fc × Ac
+ * Ac ≥ N / (0.9 × fc)
+ */
+export function generateColumns(input: ConcreteFrameInput): ConcreteColumn[] {
+  const columns: ConcreteColumn[] = [];
+  const {
+    storyCount,
+    bayCount,
+    storyHeightsM,
+    bayWidthsM,
+    concreteGrade,
+    axialLoadKN,
+    columnType = 'rectangular',
+  } = input;
+
+  // 获取混凝土抗压强度设计值
+  const concrete = getConcreteMaterial(concreteGrade);
+  const fc = concrete.fc; // N/mm²
+
+  // 轴压比限值 (四级抗震)
+  const axialLoadRatioLimit = 0.9;
+
+  // 每层每柱默认轴力(kN)估算：层面积 × 单位荷载 12kN/m²
+  const avgSpanM = bayWidthsM.reduce((a, b) => a + b, 0) / bayWidthsM.length;
+  const baseLoadKN = axialLoadKN ?? (avgSpanM * storyCount * 120);
+
+  for (let story = 0; story < storyCount; story++) {
+    const heightM = storyHeightsM[story] ?? 3.6;
+
+    // 各层轴力从上到下线性递增：底层=baseLoadKN, 顶层=baseLoadKN/storyCount
+    const storyN = (baseLoadKN * (story + 1) / storyCount) * 1000; // 转换为 N
+    const storyAc = storyN / (axialLoadRatioLimit * fc);
+
+    if (columnType === 'circular') {
+      // 圆形柱：d = sqrt(4*Ac/π)，取整到50mm，最小500mm
+      // TODO(PR3): 配筋计算与圆形柱正截面验算
+      let diameterMM = Math.ceil(Math.sqrt(4 * storyAc / Math.PI) / 50) * 50;
+      diameterMM = Math.max(diameterMM, 500);
+      const Ac_actual = Math.PI * (diameterMM / 2) ** 2;
+      const axialLoadRatio = storyN / (fc * Ac_actual);
+
+      columns.push({
+        id: `C-S${story + 1}-1`,
+        type: 'circular',
+        heightM: heightM,
+        diameterMM: diameterMM,
+        axialLoadRatio: Math.round(axialLoadRatio * 100) / 100,
+        meetsRequirement: axialLoadRatio <= axialLoadRatioLimit,
+      });
+    } else {
+      // 矩形柱截面估算，最小 500mm (GB/T 50010-2010 第 11.4.11 条)
+      // TODO(PR3): 矩形柱配筋计算与轴压比精确验算
+      const commonSizes = [500, 550, 600, 650, 700, 750, 800, 850, 900];
+      let selectedSize = commonSizes[0]!;
+      for (const size of commonSizes) {
+        if (size * size >= storyAc) {
+          selectedSize = size;
+          break;
+        }
+      }
+      // 所有预设不够时取计算值
+      if (selectedSize === commonSizes[0] && commonSizes[0]! ** 2 < storyAc) {
+        selectedSize = Math.ceil(Math.sqrt(storyAc) / 50) * 50;
+      }
+
+      // 验算轴压比
+      const Ac_actual = selectedSize * selectedSize;
+      const axialLoadRatio = storyN / (fc * Ac_actual);
+
+      columns.push({
+        id: `C-S${story + 1}-1`,
+        type: 'rectangular',
+        heightM: heightM,
+        widthMM: selectedSize,
+        heightMM: selectedSize,
+        axialLoadRatio: Math.round(axialLoadRatio * 100) / 100,
+        meetsRequirement: axialLoadRatio <= axialLoadRatioLimit,
+      });
+    }
+  }
+
+  return columns;
+}
+
+/**
+ * 生成板构件
+ * 依据: GB/T 50010-2010 第 9.1.2 条
+ * 跨厚比限值:
+ *   单向板 ≤ 30
+ *   双向板 ≤ 40
+ *   无梁板（有柱帽） ≤ 35
+ *   无梁板（无柱帽） ≤ 30
+ *   悬臂板 ≤ 12
+ */
+export function generateSlabs(input: ConcreteFrameInput): ConcreteSlab[] {
+  const slabs: ConcreteSlab[] = [];
+  const {
+    bayWidthsM,
+    slabType = 'one-way',
+    slabUsage = 'residential',
+  } = input;
+
+  // 跨厚比限值配置
+  const spanDepthRatioLimits: Record<string, number> = {
+    'one-way': 30,
+    'two-way': 40,
+    'flat-slab': 30,
+    'waffle': 35,
+  };
+
+  // 最小厚度配置 (mm) — GB/T 50010-2010 第 9.1.2 条
+  // 键: slabType_slabUsage
+  const minThicknessMap: Record<string, number> = {
+    'one-way_roof': 60,
+    'one-way_residential': 60,
+    'one-way_commercial': 70,
+    'one-way_vehicle': 80,
+    'two-way_roof': 100,
+    'two-way_residential': 80,
+    'two-way_commercial': 80,
+    'two-way_vehicle': 80,
+    'flat-slab_roof': 150,
+    'flat-slab_residential': 150,
+    'flat-slab_commercial': 150,
+    'flat-slab_vehicle': 150,
+    'waffle_roof': 200,
+    'waffle_residential': 200,
+    'waffle_commercial': 200,
+    'waffle_vehicle': 200,
+  };
+
+  const spanDepthRatioLimit = spanDepthRatioLimits[slabType] ?? 30;
+  const minThicknessKey = `${slabType}_${slabUsage}`;
+  const minThickness = minThicknessMap[minThicknessKey] ?? 60;
+
+  for (let i = 0; i < bayWidthsM.length; i++) {
+    const spanM = bayWidthsM[i]!;
+    const spanMM = spanM * 1000;
+
+    // 计算板厚: t = max(span / 跨厚比, 最小厚度)，向上取整保证跨厚比不超限
+    let thicknessMM = Math.ceil((spanMM / spanDepthRatioLimit) / 10) * 10; // 向上取整到10mm
+    thicknessMM = Math.max(thicknessMM, minThickness);
+
+    // 验算跨厚比
+    const actualSpanDepthRatio = spanMM / thicknessMM;
+    const meetsRequirement = actualSpanDepthRatio <= spanDepthRatioLimit;
+
+    slabs.push({
+      id: `SL-${i + 1}`,
+      type: slabType,
+      spanXM: spanM,
+      spanYM: spanM, // 假设板为方形区格
+      thicknessMM: thicknessMM,
+      usage: slabUsage,
+      spanDepthRatio: Math.round(actualSpanDepthRatio * 10) / 10,
+      meetsRequirement,
+    });
+  }
+
+  // TODO(PR3): 板配筋计算（板底/板面钢筋）
+  return slabs;
+}
 
 export const handler: SkillHandler = {
   detectStructuralType(input) {

--- a/backend/src/agent-skills/structure-type/concrete-frame/handler.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/handler.ts
@@ -129,7 +129,6 @@ export function generateColumns(input: ConcreteFrameInput): ConcreteColumn[] {
   const columns: ConcreteColumn[] = [];
   const {
     storyCount,
-    bayCount,
     storyHeightsM,
     bayWidthsM,
     concreteGrade,

--- a/backend/src/agent-skills/structure-type/concrete-frame/handler.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/handler.ts
@@ -12,6 +12,7 @@ import {
 } from './interaction.js';
 import { mergeConcreteFrameState } from './merge.js';
 import { buildConcreteFrameModel, getConcreteMaterial, normalizeConcreteGrade, normalizeSectionName } from './model.js';
+import { DEFAULT_FLOOR_LOAD_KN_PER_M2 } from './constants.js';
 import type {
   ConcreteBeam,
   ConcreteColumn,
@@ -23,6 +24,34 @@ import type {
 // ============================================================================
 // PR2: 构件生成器
 // ============================================================================
+
+/** Span-thickness ratio limits per slab type (GB/T 50010-2010 §9.1.2) */
+const SPAN_DEPTH_RATIO_LIMITS: Record<string, number> = {
+  'one-way': 30,
+  'two-way': 40,
+  'flat-slab': 30,
+  'waffle': 35,
+};
+
+/** Minimum slab thickness by slabType × slabUsage (mm) — GB/T 50010-2010 §9.1.2 */
+const MIN_THICKNESS_MAP: Record<string, number> = {
+  'one-way_roof': 60,
+  'one-way_residential': 60,
+  'one-way_commercial': 70,
+  'one-way_vehicle': 80,
+  'two-way_roof': 100,
+  'two-way_residential': 80,
+  'two-way_commercial': 80,
+  'two-way_vehicle': 80,
+  'flat-slab_roof': 150,
+  'flat-slab_residential': 150,
+  'flat-slab_commercial': 150,
+  'flat-slab_vehicle': 150,
+  'waffle_roof': 200,
+  'waffle_residential': 200,
+  'waffle_commercial': 200,
+  'waffle_vehicle': 200,
+};
 
 /**
  * 生成所有混凝土构件
@@ -143,9 +172,9 @@ export function generateColumns(input: ConcreteFrameInput): ConcreteColumn[] {
   // 轴压比限值 (四级抗震)
   const axialLoadRatioLimit = 0.9;
 
-  // 每层每柱默认轴力(kN)估算：层面积 × 单位荷载 12kN/m²
+  // 每层每柱默认轴力(kN)估算：从属面积 × 15 kN/m²
   const avgSpanM = bayWidthsM.reduce((a, b) => a + b, 0) / bayWidthsM.length;
-  const baseLoadKN = axialLoadKN ?? (avgSpanM * storyCount * 120);
+  const baseLoadKN = axialLoadKN ?? (avgSpanM * avgSpanM * storyCount * DEFAULT_FLOOR_LOAD_KN_PER_M2);
 
   for (let story = 0; story < storyCount; story++) {
     const heightM = storyHeightsM[story] ?? 3.6;
@@ -223,38 +252,9 @@ export function generateSlabs(input: ConcreteFrameInput): ConcreteSlab[] {
     slabUsage = 'residential',
   } = input;
 
-  // 跨厚比限值配置
-  const spanDepthRatioLimits: Record<string, number> = {
-    'one-way': 30,
-    'two-way': 40,
-    'flat-slab': 30,
-    'waffle': 35,
-  };
-
-  // 最小厚度配置 (mm) — GB/T 50010-2010 第 9.1.2 条
-  // 键: slabType_slabUsage
-  const minThicknessMap: Record<string, number> = {
-    'one-way_roof': 60,
-    'one-way_residential': 60,
-    'one-way_commercial': 70,
-    'one-way_vehicle': 80,
-    'two-way_roof': 100,
-    'two-way_residential': 80,
-    'two-way_commercial': 80,
-    'two-way_vehicle': 80,
-    'flat-slab_roof': 150,
-    'flat-slab_residential': 150,
-    'flat-slab_commercial': 150,
-    'flat-slab_vehicle': 150,
-    'waffle_roof': 200,
-    'waffle_residential': 200,
-    'waffle_commercial': 200,
-    'waffle_vehicle': 200,
-  };
-
-  const spanDepthRatioLimit = spanDepthRatioLimits[slabType] ?? 30;
+  const spanDepthRatioLimit = SPAN_DEPTH_RATIO_LIMITS[slabType] ?? 30;
   const minThicknessKey = `${slabType}_${slabUsage}`;
-  const minThickness = minThicknessMap[minThicknessKey] ?? 60;
+  const minThickness = MIN_THICKNESS_MAP[minThicknessKey] ?? 60;
 
   for (let i = 0; i < bayWidthsM.length; i++) {
     const spanM = bayWidthsM[i]!;

--- a/backend/src/agent-skills/structure-type/concrete-frame/types.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/types.ts
@@ -48,17 +48,26 @@ export interface ConcreteFrameInput {
 
 /**
  * 混凝土梁构件
+ *
+ * T形截面符号 (GB/T 50010-2010):
+ *   bf' / hf' — 受压区翼缘宽度/厚度（带撇，跨中正弯矩区有效）
+ *   bf       — 受拉区翼缘宽度（不带撇，正T底面无翼缘 → bf = b）
+ *   b        — 腹板宽度
+ *   h        — 截面总高
+ *
+ * 命名约定: 与 model.ts 一致，用 _compression / _tension 后缀代替规范中的撇号。
  */
 export interface ConcreteBeam {
   id: string;
   type: 'rectangular' | 't-shaped';
   spanM: number;
-  widthMM?: number; // 矩形梁宽度
-  heightMM?: number; // 矩形梁高度
-  webWidthMM?: number; // T形梁腹板宽度
-  flangeWidthMM?: number; // T形梁翼缘宽度
-  flangeThicknessMM?: number; // T形梁翼缘厚度
-  totalHeightMM?: number; // T形梁总高度
+  widthMM?: number; // 矩形梁宽度 (b)
+  heightMM?: number; // 矩形梁高度 (h)
+  webWidthMM?: number; // 腹板宽度 (b)
+  flangeWidthMM_compression?: number; // 受压区翼缘有效宽度 (bf')，仅跨中正弯矩区有效
+  flangeThicknessMM_compression?: number; // 受压区翼缘厚度 (hf')
+  supportEffectiveWidthMM?: number; // 支座有效宽度 (负弯矩区 bf' = b)，等于 webWidthMM
+  totalHeightMM?: number; // 截面总高度 (h)
   spanDepthRatio?: number;
   meetsRequirement?: boolean;
 }

--- a/backend/src/agent-skills/structure-type/concrete-frame/types.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/types.ts
@@ -6,3 +6,111 @@ export interface ConcreteFramePatchSources {
   naturalPatch?: DraftExtraction | null;
   llmPatch?: DraftExtraction | null;
 }
+
+// ============================================================================
+// PR2: 构件生成器接口
+// ============================================================================
+
+/**
+ * 混凝土框架技能输入接口
+ * 用于接收用户提供的混凝土框架结构参数
+ */
+export interface ConcreteFrameInput {
+  // 结构体系
+  structureSystem?: 'moment-frame' | 'frame-shear-wall' | 'shear-wall'; // 默认: moment-frame
+
+  // 几何参数
+  storyCount: number; // 层数（必填）
+  bayCount: number; // 跨数（必填）
+  storyHeightsM: number[]; // 每层层高(m)
+  bayWidthsM: number[]; // 每跨跨度(m)
+
+  // 抗震设计
+  seismicGrade?: '一级' | '二级' | '三级' | '四级'; // 默认: 四级
+
+  // 材料等级
+  concreteGrade: string; // 混凝土等级 (C20-C80)
+  rebarGrade: string; // 钢筋等级 (HRB400, HRB500)
+
+  // 板设计参数
+  slabType?: 'one-way' | 'two-way' | 'flat-slab' | 'waffle'; // 板类型
+  slabUsage?: 'roof' | 'residential' | 'commercial' | 'vehicle'; // 板用途
+
+  // 梁设计参数
+  beamType?: 'rectangular' | 't-shaped'; // 梁类型
+
+  // 柱设计参数
+  columnType?: 'rectangular' | 'circular'; // 柱类型，默认: rectangular
+
+  // 荷载信息（用于柱截面估算）
+  axialLoadKN?: number; // 估算轴力(kN)
+}
+
+/**
+ * 混凝土梁构件
+ */
+export interface ConcreteBeam {
+  id: string;
+  type: 'rectangular' | 't-shaped';
+  spanM: number;
+  widthMM?: number; // 矩形梁宽度
+  heightMM?: number; // 矩形梁高度
+  webWidthMM?: number; // T形梁腹板宽度
+  flangeWidthMM?: number; // T形梁翼缘宽度
+  flangeThicknessMM?: number; // T形梁翼缘厚度
+  totalHeightMM?: number; // T形梁总高度
+  spanDepthRatio?: number;
+  meetsRequirement?: boolean;
+}
+
+/**
+ * 混凝土柱构件
+ */
+export interface ConcreteColumn {
+  id: string;
+  type: 'rectangular' | 'circular';
+  heightM: number;
+  widthMM?: number; // 矩形柱宽度
+  heightMM?: number; // 矩形柱高度
+  diameterMM?: number; // 圆形柱直径
+  axialLoadRatio?: number; // 轴压比
+  meetsRequirement?: boolean;
+}
+
+/**
+ * 混凝土板构件
+ */
+export interface ConcreteSlab {
+  id: string;
+  type: 'one-way' | 'two-way' | 'flat-slab' | 'waffle';
+  spanXM?: number; // X向跨度
+  spanYM?: number; // Y向跨度
+  thicknessMM: number; // 板厚
+  usage: string;
+  spanDepthRatio?: number;
+  meetsRequirement?: boolean;
+}
+
+/**
+ * 混凝土框架技能输出接口
+ */
+export interface ConcreteFrameOutput {
+  concreteBeams: ConcreteBeam[];
+  concreteColumns: ConcreteColumn[];
+  concreteSlabs: ConcreteSlab[];
+  warnings?: Array<{ code: string; message: string }>;
+  errors?: Array<{ code: string; message: string }>;
+}
+
+/**
+ * 混凝土框架特有状态接口
+ */
+export interface ConcreteFrameDraftState extends DraftState {
+  concreteBeams?: ConcreteBeam[];
+  concreteColumns?: ConcreteColumn[];
+  concreteSlabs?: ConcreteSlab[];
+  structureSystem?: 'moment-frame' | 'frame-shear-wall' | 'shear-wall';
+  seismicGrade?: string;
+  slabType?: 'one-way' | 'two-way' | 'flat-slab' | 'waffle';
+  beamType?: 'rectangular' | 't-shaped';
+}


### PR DESCRIPTION
Related to: #238 (concrete frame skill — Part 2 of 4)

## What's in this PR （Part 2/4)

Concrete member geometry generation built on top of PR1's material library. Beam, column, and slab preliminary sizing — **geometry only**, no strength analysis or reinforcement design (deferred to PR3). All calculations based on **GB/T 50010-2010 (2024 edition)**.

| Member | Types | Code Reference |
|--------|-------|----------------|
| Beam | Rectangular (b×h), T-shaped (bw, bf, hf, h) | §8.4 span-depth ratio + Table 5.2.4 flange width |
| Column | Rectangular (b×h), Circular (d) | §8.3 axial load ratio estimation |
| Slab | One-way, two-way, flat, waffle | §9.1.2 span-thickness ratio + minimum thickness |

### New functions

- `generateBeams()` — primary beam l/10, secondary l/14; T-beam middle bf=bw+l0/3, edge bf=bw+l0/6, bounded by bf≤bw+12hf
- `generateColumns()` — rectangular size presets (500–900mm); circular d=sqrt(4·Ac/π), rounded to 50mm, min 500mm
- `generateSlabs()` — span-thickness ratio limits + slabType×slabUsage 2D minimum thickness lookup (16 combinations)
- `generateMembers()` — integration entry point returning `ConcreteFrameOutput`
- `ConcreteFrameInput.columnType` — optional 'rectangular' | 'circular' (default: rectangular)
- 4 `// TODO(PR3): ...` markers at reinforcement design boundaries

## Impacted Areas

- `backend` — `agent-skills/structure-type/concrete-frame/`
- No changes to frontend, scripts, or other skills

## Commands Run and Results

```bash
npm run build --prefix backend
# ✓ TypeScript compilation successful

npm test --prefix backend -- --runInBand
# ✓ 64 concrete-frame tests passing
#   handler.test.mjs:           5 passed
#   member-generation.test.mjs: 17 passed
#   skill-core.test.mjs:       42 passed
```

### Test Coverage

```
generateBeams (4)
  ✓ rectangular beam span-depth ratios
  ✓ T-beam middle + edge flange dimensions
  ✓ span-depth ratio within 8–16
  ✓ 2m short-span beam

generateColumns (5)
  ✓ C30 rectangular column axial load ratio
  ✓ circular column (d ≥ 500mm, μ ≤ 0.9)
  ✓ size scaling with story count (1 / 6 / 12)
  ✓ 30-story high-rise column (≥ 900mm)
  ✓ axial ratio across grades (C20–C80)

generateSlabs (5)
  ✓ one-way residential (ratio ≤ 30, thickness ≥ 60mm)
  ✓ two-way min thickness (floor 80mm / roof 100mm)
  ✓ flat slab (thickness ≥ 150mm)
  ✓ one-way min thickness by usage
  ✓ 2m short-span slab

generateMembers integration (3)
  ✓ complete 3-story frame member set
  ✓ edge cases (single-bay / 12m span / 2m span / C80+HRB500 / 30-story)
  ✓ GB/T 50010 §9.1.2 compliance
```

## Next Steps (issue #238)

- **PR 3**: GB/T 50010-2010 (2024) code-check core — flexural, shear, axial ratio exact verification
- **PR 4**: skill definition finalization, integration tests, documentation
```