### PR TITLE
feat(backend): support multimodal models with image content blocks

### DIFF
--- a/backend/src/agent-langgraph/context-window.ts
+++ b/backend/src/agent-langgraph/context-window.ts
@@ -30,18 +30,40 @@ function messageType(message: BaseMessage): string {
 }
 
 function extractTextContent(content: unknown): string {
-  if (typeof content === 'string') return content;
+  if (typeof content === 'string') {
+    if (content.includes('data:image/') && content.includes(';base64,')) {
+      return estimateBase64ImageChars(content);
+    }
+    return content;
+  }
   if (Array.isArray(content)) {
     return content
       .map((block) => {
         if (block && typeof block === 'object' && 'text' in block) {
           return String((block as { text?: unknown }).text ?? '');
         }
+        if (block && typeof block === 'object' && 'type' in block) {
+          const typed = block as { type: string; url?: string; source_type?: string };
+          if (typed.type === 'image') {
+            const url = typed.url || '';
+            if (url.startsWith('data:image/')) return estimateBase64ImageChars(url);
+            return '[image ~4000 chars]';
+          }
+        }
         return '';
       })
       .join('');
   }
   return content === undefined ? '' : JSON.stringify(content);
+}
+
+function estimateBase64ImageChars(dataUri: string): string {
+  const base64Start = dataUri.indexOf(';base64,');
+  if (base64Start === -1) return '[image ~4000 chars]';
+  const base64Length = dataUri.length - base64Start - 8;
+  const estimatedBytes = base64Length * 0.75;
+  const estimatedTokens = Math.max(85, Math.ceil(estimatedBytes / 750));
+  return `[image ~${estimatedTokens * 4} chars]`;
 }
 
 function truncateText(value: string, limit: number): string {

--- a/backend/src/agent-langgraph/context-window.ts
+++ b/backend/src/agent-langgraph/context-window.ts
@@ -43,9 +43,9 @@ function extractTextContent(content: unknown): string {
           return String((block as { text?: unknown }).text ?? '');
         }
         if (block && typeof block === 'object' && 'type' in block) {
-          const typed = block as { type: string; url?: string; source_type?: string };
-          if (typed.type === 'image') {
-            const url = typed.url || '';
+          const typed = block as { type: string; url?: string; image_url?: { url: string } };
+          if (typed.type === 'image' || typed.type === 'image_url') {
+            const url = typed.url || typed.image_url?.url || '';
             if (url.startsWith('data:image/')) return estimateBase64ImageChars(url);
             return '[image ~4000 chars]';
           }

--- a/backend/src/agent-langgraph/graph.ts
+++ b/backend/src/agent-langgraph/graph.ts
@@ -137,6 +137,51 @@ export function shouldReplaceEmptyFinalResponse(response: BaseMessage, currentTu
 }
 
 // ---------------------------------------------------------------------------
+// Multimodal: transform image ToolMessages into proper content blocks
+// ---------------------------------------------------------------------------
+
+const IMAGE_JSON_REGEX = /"type"\s*:\s*"image"/;
+
+function transformImageToolMessages(messages: BaseMessage[]): BaseMessage[] {
+  const result: BaseMessage[] = [];
+  for (const message of messages) {
+    if (getMessageType(message) !== 'tool') {
+      result.push(message);
+      continue;
+    }
+    const content = typeof message.content === 'string' ? message.content : '';
+    if (!content || !IMAGE_JSON_REGEX.test(content)) {
+      result.push(message);
+      continue;
+    }
+    let parsed: Record<string, unknown>;
+    try { parsed = JSON.parse(content); } catch { result.push(message); continue; }
+    if (parsed.type !== 'image' || typeof parsed.base64DataUri !== 'string') {
+      result.push(message);
+      continue;
+    }
+
+    const { base64DataUri, ...rest } = parsed;
+    const sanitizedContent = JSON.stringify({
+      ...rest,
+      note: 'Image data forwarded to multimodal context (see attached image block).',
+    });
+    result.push(new ToolMessage({
+      content: sanitizedContent,
+      tool_call_id: (message as any).tool_call_id || '',
+      name: (message as any).name,
+    }));
+    result.push(new HumanMessage({
+      content: [
+        { type: 'text', text: `[Image from ${(message as any).name || 'tool'}: ${parsed.mimeType || 'image'}, ${typeof parsed.size === 'number' ? Math.round((parsed.size as number) / 1024) + ' KB' : 'unknown size'}]` },
+        { type: 'image_url', image_url: { url: base64DataUri as string } },
+      ],
+    }));
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
 // Node: agent (LLM reasoning)
 // ---------------------------------------------------------------------------
 
@@ -247,16 +292,20 @@ function createCallModelNode(
       return null;
     }).filter((m): m is BaseMessage => m !== null);
 
+    // Transform ToolMessages with base64 image data into proper multimodal
+    // content blocks (sanitized ToolMessage + synthetic HumanMessage).
+    const effectiveMsgs = transformImageToolMessages(msgs);
+
     // Count prior tool calls in this turn to enforce max iterations.
     let lastHumanIndex = -1;
-    for (let i = msgs.length - 1; i >= 0; i--) {
-      const m = msgs[i];
+    for (let i = effectiveMsgs.length - 1; i >= 0; i--) {
+      const m = effectiveMsgs[i];
       if (typeof m === 'object' && m !== null && '_getType' in m && (m as any)._getType?.() === 'human') {
         lastHumanIndex = i;
         break;
       }
     }
-    const currentTurnMessages = lastHumanIndex === -1 ? msgs : msgs.slice(lastHumanIndex + 1);
+    const currentTurnMessages = lastHumanIndex === -1 ? effectiveMsgs : effectiveMsgs.slice(lastHumanIndex + 1);
     const toolCallCount = currentTurnMessages.reduce((count, m) => {
       if (
         m != null
@@ -286,7 +335,7 @@ function createCallModelNode(
     configurableAny.agentState = state;
 
     const compaction = compactMessagesForContext({
-      messages: msgs,
+      messages: effectiveMsgs,
       locale: state.locale,
       baseCharCount: estimateMessagesCharLength(systemMessages),
     });

--- a/backend/src/agent-langgraph/graph.ts
+++ b/backend/src/agent-langgraph/graph.ts
@@ -292,20 +292,19 @@ function createCallModelNode(
       return null;
     }).filter((m): m is BaseMessage => m !== null);
 
-    // Transform ToolMessages with base64 image data into proper multimodal
-    // content blocks (sanitized ToolMessage + synthetic HumanMessage).
-    const effectiveMsgs = transformImageToolMessages(msgs);
-
     // Count prior tool calls in this turn to enforce max iterations.
+    // Use the original (pre-transform) message array so synthetic
+    // HumanMessages injected by transformImageToolMessages don't
+    // shift the turn boundary or under-count tool calls.
     let lastHumanIndex = -1;
-    for (let i = effectiveMsgs.length - 1; i >= 0; i--) {
-      const m = effectiveMsgs[i];
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const m = msgs[i];
       if (typeof m === 'object' && m !== null && '_getType' in m && (m as any)._getType?.() === 'human') {
         lastHumanIndex = i;
         break;
       }
     }
-    const currentTurnMessages = lastHumanIndex === -1 ? effectiveMsgs : effectiveMsgs.slice(lastHumanIndex + 1);
+    const currentTurnMessages = lastHumanIndex === -1 ? msgs : msgs.slice(lastHumanIndex + 1);
     const toolCallCount = currentTurnMessages.reduce((count, m) => {
       if (
         m != null
@@ -333,6 +332,12 @@ function createCallModelNode(
     // receives the same config object) also sees agentState.
     const configurableAny = config.configurable as Record<string, unknown>;
     configurableAny.agentState = state;
+
+    // Transform ToolMessages with base64 image data into proper multimodal
+    // content blocks (sanitized ToolMessage + synthetic HumanMessage).
+    // Applied after turn-boundary computation so synthetic messages
+    // don't affect tool-call counting or compaction turn detection.
+    const effectiveMsgs = transformImageToolMessages(msgs);
 
     const compaction = compactMessagesForContext({
       messages: effectiveMsgs,

--- a/backend/src/utils/llm-error.ts
+++ b/backend/src/utils/llm-error.ts
@@ -21,6 +21,8 @@ const CONTEXT_OVERFLOW_PATTERNS = [
   'token limit exceeded',
   'reduce the length',
   'exceeds the maximum',
+  'prompt exceeds max length',
+  'exceeds max token',
   '上下文',
   'token 数',
 ];

--- a/backend/src/utils/llm.ts
+++ b/backend/src/utils/llm.ts
@@ -176,18 +176,27 @@ export function createChatModel(
   return wrapWithLlmLogging(model);
 }
 
+function sanitizeBase64ForLogging(text: string): string {
+  return text.replace(
+    /data:image\/[a-zA-Z+]+;base64,[A-Za-z0-9+/=]+/g,
+    (match) => `[base64 image: ${Math.round(match.length / 1024)} KB]`,
+  );
+}
+
 function wrapWithLlmLogging(model: ChatOpenAI): ChatOpenAI {
   const originalInvoke = model.invoke.bind(model);
 
   (model as any).invoke = async function (input: any, options?: any) {
-    const promptStr = typeof input === 'string' ? input : JSON.stringify(input);
+    const promptStr = sanitizeBase64ForLogging(typeof input === 'string' ? input : JSON.stringify(input));
     const start = Date.now();
     const loggedModel = getEffectiveLlmSettings().llmModel;
     try {
       const result = await originalInvoke(input, options);
-      const content = typeof result.content === 'string'
-        ? result.content
-        : JSON.stringify(result.content);
+      const content = sanitizeBase64ForLogging(
+        typeof result.content === 'string'
+          ? result.content
+          : JSON.stringify(result.content),
+      );
       const durationMs = Date.now() - start;
       llmCallLogger.log({
         model: loggedModel,
@@ -206,7 +215,7 @@ function wrapWithLlmLogging(model: ChatOpenAI): ChatOpenAI {
         response: null,
         durationMs,
         success: false,
-        error: String(error),
+        error: sanitizeBase64ForLogging(String(error)),
       });
       logLlmCall(logger, { model: loggedModel, durationMs, success: false });
       throw error;


### PR DESCRIPTION
## Summary
- **Core fix**: Transform ToolMessages containing base64 image data into proper `image_url` content blocks via synthetic `HumanMessage` — the OpenAI API only allows images in user-role messages
- **Context estimation**: Add image-aware character estimation so multi-megabyte base64 strings don't silently bypass the 60K char context budget
- **Error handling**: Add GLM-specific `prompt exceeds max length` and `exceeds max token` patterns to context overflow detection
- **Logging**: Sanitize base64 data URIs from LLM call logs to avoid multi-MB JSONL entries

## Root Cause
`analyze_file` tool returns image data as a base64 JSON string in `ToolMessage.content`. The LLM API receives this as plain text (millions of chars), causing `400 Prompt exceeds max length` on multimodal models like GLM-4.6V.

## Files Changed
- `backend/src/agent-langgraph/graph.ts` — Add `transformImageToolMessages()` to convert image ToolMessages into proper multimodal content blocks
- `backend/src/agent-langgraph/context-window.ts` — Add `estimateBase64ImageChars()` and update `extractTextContent()` for image awareness
- `backend/src/utils/llm-error.ts` — Add GLM error patterns
- `backend/src/utils/llm.ts` — Add `sanitizeBase64ForLogging()` helper

## Test plan
- [x] `npm run build --prefix backend` — compiles clean
- [x] `npm test --prefix backend -- --runInBand` — 874/875 pass (1 skipped, pre-existing)
- [ ] Manual: upload image with GLM-4.6V → verify proper image delivery and no 400 error
- [ ] Manual: verify text-only workflow still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)