### PR TITLE
feat(backend): add YJK reinforced concrete frame flow

### DIFF
--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -1019,13 +1019,16 @@ export function createRunCodeCheckTool(skillRuntime: AgentSkillRuntime) {
       const toolCallId = getToolCallId(config);
       const skillIds = configurable.skillScope;
       const selectedDesignCode = skillRuntime.resolveCodeCheckDesignCodeFromSkillIds(skillIds);
-      const codeCheckSkillId = selectedDesignCode
-        ? skillRuntime.resolveCodeCheckSkillId(selectedDesignCode)
+      const requestedDesignCode = selectedDesignCode || state?.policy?.designCode || input.designCode;
+      const codeCheckSkillId = requestedDesignCode
+        ? skillRuntime.resolveCodeCheckSkillId(requestedDesignCode)
         : undefined;
-      if (!codeCheckSkillId) {
+      if (!requestedDesignCode || !codeCheckSkillId) {
         const skipped = {
           skipped: true,
-          reason: 'No code-check skill is selected in the current skill scope.',
+          reason: requestedDesignCode
+            ? `Unsupported code-check design code: ${requestedDesignCode}.`
+            : 'No code-check design code is selected or provided.',
         };
         logToolCall(log, { tool: 'run_code_check', durationMs: Date.now() - start, extra: { skipped: true, reason: skipped.reason } });
         return toolResult(toolCallId, 'run_code_check', JSON.stringify(skipped));
@@ -1045,7 +1048,7 @@ export function createRunCodeCheckTool(skillRuntime: AgentSkillRuntime) {
       const result = await skillRuntime.executeCodeCheckSkill({
         codeCheckClient: configurable.codeCheckClient,
         traceId,
-        designCode: selectedDesignCode || input.designCode || 'GB50017',
+        designCode: requestedDesignCode,
         model,
         analysis,
         analysisParameters: {},
@@ -1054,7 +1057,7 @@ export function createRunCodeCheckTool(skillRuntime: AgentSkillRuntime) {
       });
 
       // Store code check result in graph state via Command
-      logToolCall(log, { tool: 'run_code_check', durationMs: Date.now() - start, extra: { designCode: input.designCode, skillId: result.skillId, success: true } });
+      logToolCall(log, { tool: 'run_code_check', durationMs: Date.now() - start, extra: { designCode: requestedDesignCode, skillId: result.skillId, success: true } });
       return toolResult(
         toolCallId,
         'run_code_check',

--- a/backend/src/agent-skills/analysis/yjk-static/skill.yaml
+++ b/backend/src/agent-skills/analysis/yjk-static/skill.yaml
@@ -36,7 +36,9 @@ supportedAnalysisTypes:
 supportedModelFamilies:
   - frame
   - generic
-materialFamilies: []
+materialFamilies:
+  - steel
+  - concrete
 aliases: []
 toolHints: {}
 runtimeContract:

--- a/backend/src/agent-skills/analysis/yjk-static/yjk_driver.py
+++ b/backend/src/agent-skills/analysis/yjk-static/yjk_driver.py
@@ -330,8 +330,8 @@ def _wait_for_direct_launch_state(before_pids: set[int], timeout_s: float) -> di
     """Watch a freshly launched yjks.exe for the local auth failure dialog.
 
     A valid direct launch may keep the title blank for a while, especially when
-    YJK is invisible.  We only use this watch to confidently detect the official
-    "authorization check failed" window; otherwise the caller proceeds normally.
+    YJK is invisible.  Authorization failure windows can also come from a
+    previous/reused YJK process, so detect them before filtering old PIDs.
     """
     deadline = time.monotonic() + timeout_s
     last_seen: dict | None = None
@@ -340,12 +340,12 @@ def _wait_for_direct_launch_state(before_pids: set[int], timeout_s: float) -> di
             pid = _process_id(proc)
             if pid <= 0:
                 continue
-            if before_pids and pid in before_pids:
-                continue
-            last_seen = proc
             title = str(proc.get("MainWindowTitle") or "")
             if _is_auth_failure_title(title):
                 return {"state": "auth_failed", "pid": pid, "title": title}
+            if before_pids and pid in before_pids:
+                continue
+            last_seen = proc
             if title.strip():
                 return {"state": "ready", "pid": pid, "title": title}
         time.sleep(1.0)

--- a/backend/src/agent-skills/code-check/__tests__/entry.test.mjs
+++ b/backend/src/agent-skills/code-check/__tests__/entry.test.mjs
@@ -17,4 +17,48 @@ describe('buildCodeCheckInput', () => {
 
     expect(input.context.utilizationByElement).toEqual({ E1: 0.92 });
   });
+
+  test('enriches element context with material and section records', () => {
+    const input = buildCodeCheckInput({
+      traceId: 'trace-2',
+      designCode: 'GB50010',
+      model: {
+        materials: [
+          { id: '1', grade: 'C30', category: 'concrete' },
+          { id: '2', grade: 'HRB400', category: 'rebar' },
+        ],
+        sections: [
+          { id: '1', name: '400X400', type: 'rectangular', purpose: 'column' },
+          { id: '2', name: '250X600', type: 'rectangular', purpose: 'beam' },
+        ],
+        elements: [
+          {
+            id: 'C1',
+            type: 'column',
+            nodes: ['N0_0', 'N1_0'],
+            material: '1',
+            section: '1',
+            concrete_grade: 'C30',
+            rebar_grade: 'HRB400',
+            story: 'F1',
+          },
+        ],
+      },
+      analysis: { success: true },
+      analysisParameters: {},
+    });
+
+    expect(input.elements).toEqual(['C1']);
+    expect(input.context.elementContextById.C1).toMatchObject({
+      id: 'C1',
+      type: 'column',
+      materialId: '1',
+      sectionId: '1',
+      material: { id: '1', grade: 'C30', category: 'concrete' },
+      section: { id: '1', name: '400X400', type: 'rectangular', purpose: 'column' },
+      concreteGrade: 'C30',
+      rebarGrade: 'HRB400',
+      story: 'F1',
+    });
+  });
 });

--- a/backend/src/agent-skills/code-check/__tests__/entry.test.mjs
+++ b/backend/src/agent-skills/code-check/__tests__/entry.test.mjs
@@ -61,4 +61,30 @@ describe('buildCodeCheckInput', () => {
       story: 'F1',
     });
   });
+
+  test('preserves pre-resolved material and section objects', () => {
+    const material = { id: 'm1', grade: 'C30', category: 'concrete' };
+    const section = { id: 's1', name: '500X250', type: 'rectangular' };
+    const input = buildCodeCheckInput({
+      traceId: 'trace-3',
+      designCode: 'GB50010',
+      model: {
+        elements: [
+          {
+            id: 'B1',
+            type: 'beam',
+            material,
+            section,
+          },
+        ],
+      },
+      analysis: { success: true },
+      analysisParameters: {},
+    });
+
+    expect(input.context.elementContextById.B1).toMatchObject({
+      material,
+      section,
+    });
+  });
 });

--- a/backend/src/agent-skills/code-check/entry.ts
+++ b/backend/src/agent-skills/code-check/entry.ts
@@ -86,8 +86,8 @@ function extractElementContextById(model: Record<string, unknown> | undefined): 
     acc[id] = {
       id,
       type: element['type'],
-      material: materialId ? (materialById.get(materialId) ?? materialId) : undefined,
-      section: sectionId ? (sectionById.get(sectionId) ?? sectionId) : undefined,
+      material: materialId ? (materialById.get(materialId) ?? materialId) : element['material'],
+      section: sectionId ? (sectionById.get(sectionId) ?? sectionId) : element['section'],
       materialId,
       sectionId,
       startNode: element['startNode'],

--- a/backend/src/agent-skills/code-check/entry.ts
+++ b/backend/src/agent-skills/code-check/entry.ts
@@ -54,6 +54,22 @@ function extractElementContextById(model: Record<string, unknown> | undefined): 
   if (!Array.isArray(elements)) {
     return {};
   }
+  const materials = Array.isArray(model['materials']) ? model['materials'] : [];
+  const sections = Array.isArray(model['sections']) ? model['sections'] : [];
+  const materialById = materials.reduce<Map<string, Record<string, unknown>>>((acc, item) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return acc;
+    const record = item as Record<string, unknown>;
+    const id = String(record['id'] ?? '');
+    if (id.length > 0) acc.set(id, record);
+    return acc;
+  }, new Map());
+  const sectionById = sections.reduce<Map<string, Record<string, unknown>>>((acc, item) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return acc;
+    const record = item as Record<string, unknown>;
+    const id = String(record['id'] ?? '');
+    if (id.length > 0) acc.set(id, record);
+    return acc;
+  }, new Map());
 
   return elements.reduce<Record<string, unknown>>((acc, item) => {
     if (!item || typeof item !== 'object') {
@@ -64,14 +80,23 @@ function extractElementContextById(model: Record<string, unknown> | undefined): 
     if (!id) {
       return acc;
     }
+    const materialId = typeof element['material'] === 'string' ? element['material'] : undefined;
+    const sectionId = typeof element['section'] === 'string' ? element['section'] : undefined;
 
     acc[id] = {
       id,
       type: element['type'],
-      material: element['material'],
-      section: element['section'],
+      material: materialId ? (materialById.get(materialId) ?? materialId) : undefined,
+      section: sectionId ? (sectionById.get(sectionId) ?? sectionId) : undefined,
+      materialId,
+      sectionId,
       startNode: element['startNode'],
       endNode: element['endNode'],
+      nodes: element['nodes'],
+      story: element['story'],
+      concreteGrade: element['concrete_grade'],
+      steelGrade: element['steel_grade'],
+      rebarGrade: element['rebar_grade'],
       metadata: element['metadata'],
     };
     return acc;

--- a/backend/src/agent-skills/code-check/gb50010/__tests__/test_gb50010.py
+++ b/backend/src/agent-skills/code-check/gb50010/__tests__/test_gb50010.py
@@ -64,10 +64,13 @@ class TestGetRules:
         assert gb50010.get_rules()['code'] == 'GB50010'
 
     def test_version_field(self):
-        assert gb50010.get_rules()['version'] == 'v1-minimal'
+        assert gb50010.get_rules()['version'] == 'v2-rc-frame-member-checks'
 
-    def test_rules_empty(self):
-        assert gb50010.get_rules()['rules'] == []
+    def test_rules_cover_beams_and_columns(self):
+        rules = gb50010.get_rules()['rules']
+        assert len(rules) == 2
+        assert rules[0]['elementType'] == ['beam']
+        assert rules[1]['elementType'] == ['column']
 
 
 class TestCheckElementStructure:
@@ -130,6 +133,43 @@ class TestCheckElementResult:
         checker = MockCodeChecker()
         result = gb50010.check_element(checker, 'B1', {})
         assert result['elementType'] == 'beam'
+
+    def test_element_type_column_from_context(self):
+        checker = MockCodeChecker()
+        result = gb50010.check_element(checker, 'E1', {
+            'elementContextById': {
+                'E1': {
+                    'type': 'column',
+                    'section': {'id': '1', 'name': '400X400'},
+                    'material': {'id': '1', 'grade': 'C30', 'category': 'concrete'},
+                    'concreteGrade': 'C30',
+                    'rebarGrade': 'HRB400',
+                },
+            },
+        })
+        assert result['elementType'] == 'column'
+        assert result['checks'][0]['name'] == '柱承载力验算'
+        assert result['checks'][0]['items'][0]['item'] == '轴压比'
+        assert result['elementContext'] == {
+            'type': 'column',
+            'section': {'id': '1', 'name': '400X400'},
+            'material': {'id': '1', 'grade': 'C30', 'category': 'concrete'},
+            'concreteGrade': 'C30',
+            'rebarGrade': 'HRB400',
+        }
+
+    def test_element_type_column_from_id_prefix(self):
+        checker = MockCodeChecker()
+        result = gb50010.check_element(checker, 'C1', {})
+        assert result['elementType'] == 'column'
+
+    def test_chapter_summaries_capture_controlling_failure(self):
+        checker = MockCodeChecker(overrides={'C1': {'轴压比': 1.2}})
+        result = gb50010.check_element(checker, 'C1', {})
+        assert result['status'] == 'fail'
+        assert result['chapterCount'] == 2
+        assert result['chapters'][0]['status'] == 'fail'
+        assert result['chapters'][0]['controllingClause'] == 'GB50010-2010 6.2.15'
 
     def test_code_version(self):
         checker = MockCodeChecker()

--- a/backend/src/agent-skills/code-check/gb50010/__tests__/test_gb50010.py
+++ b/backend/src/agent-skills/code-check/gb50010/__tests__/test_gb50010.py
@@ -171,6 +171,20 @@ class TestCheckElementResult:
         assert result['chapters'][0]['status'] == 'fail'
         assert result['chapters'][0]['controllingClause'] == 'GB50010-2010 6.2.15'
 
+    def test_chapter_summaries_treat_none_utilization_as_zero(self):
+        summaries = gb50010._build_chapter_summaries([
+            {
+                'chapter': 'test',
+                'items': [
+                    {'status': 'pass', 'utilization': None, 'clause': 'ignored'},
+                    {'status': 'pass', 'utilization': 0.6, 'clause': 'controls'},
+                ],
+            },
+        ])
+
+        assert summaries[0]['maxUtilization'] == 0.6
+        assert summaries[0]['controllingClause'] == 'controls'
+
     def test_code_version(self):
         checker = MockCodeChecker()
         result = gb50010.check_element(checker, 'B1', {})

--- a/backend/src/agent-skills/code-check/gb50010/code_check.py
+++ b/backend/src/agent-skills/code-check/gb50010/code_check.py
@@ -1,19 +1,83 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 
 def get_rules() -> Dict[str, Any]:
     return {
         'code': 'GB50010',
-        'version': 'v1-minimal',
-        'rules': [],
+        'version': 'v2-rc-frame-member-checks',
+        'rules': [
+            {
+                'name': '梁承载力与正常使用验算',
+                'elementType': ['beam'],
+                'checks': ['正截面受弯', '斜截面受剪', '挠度', '裂缝宽度'],
+            },
+            {
+                'name': '柱承载力与稳定验算',
+                'elementType': ['column'],
+                'checks': ['轴压比', '偏心受压', '斜截面受剪', '长细比'],
+            },
+        ],
     }
 
 
-def check_element(checker: Any, elem_id: str, context: Dict[str, Any]) -> Dict[str, Any]:
-    checks = [
+def _resolve_element_context(elem_id: str, context: Dict[str, Any]) -> Dict[str, Any]:
+    mapping = context.get('elementContextById', {})
+    if isinstance(mapping, dict):
+        value = mapping.get(elem_id)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def _resolve_element_type(elem_id: str, context: Dict[str, Any]) -> str:
+    element_context = _resolve_element_context(elem_id, context)
+    raw_type = element_context.get('type')
+    if raw_type:
+        normalized = str(raw_type).strip().lower()
+        if normalized in {'beam', 'column'}:
+            return normalized
+        if 'column' in normalized:
+            return 'column'
+        if 'beam' in normalized:
+            return 'beam'
+
+    lower = elem_id.lower()
+    if lower.startswith('c') or 'column' in lower or 'col' in lower:
+        return 'column'
+    return 'beam'
+
+
+def _build_chapter_summaries(checks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    chapters = []
+    for check in checks:
+        chapter_name = check.get('chapter') or check.get('name')
+        items = check.get('items', [])
+        max_utilization = 0.0
+        status = 'pass'
+        controlling_clause = None
+        for item in items:
+            utilization = float(item.get('utilization', 0.0))
+            if utilization >= max_utilization:
+                max_utilization = utilization
+                controlling_clause = item.get('clause')
+            if item.get('status') != 'pass':
+                status = 'fail'
+        chapters.append({
+            'chapter': chapter_name,
+            'status': status,
+            'itemCount': len(items),
+            'maxUtilization': round(max_utilization, 4),
+            'controllingClause': controlling_clause,
+        })
+    return chapters
+
+
+def _check_beam(checker: Any, elem_id: str, context: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return [
         {
+            'chapter': '第6章 承载能力极限状态',
             'name': '承载力验算',
             'items': [
                 checker._calc_item(elem_id, '正截面受弯', context, 'GB50010-2010 6.2.1', 'M <= α1*f_c*b*x*(h0-0.5*x)', 0.95),
@@ -28,4 +92,41 @@ def check_element(checker: Any, elem_id: str, context: Dict[str, Any]) -> Dict[s
             ],
         },
     ]
-    return checker._build_element_result(elem_id, 'beam', checks, 'GB50010-2010')
+
+
+def _check_column(checker: Any, elem_id: str, context: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return [
+        {
+            'chapter': '第6章 承载能力极限状态',
+            'name': '柱承载力验算',
+            'items': [
+                checker._calc_item(elem_id, '轴压比', context, 'GB50010-2010 6.2.15', 'N/(f_c*A) <= 轴压比限值', 0.90),
+                checker._calc_item(elem_id, '偏心受压', context, 'GB50010-2010 6.2.17', 'N-M interaction <= 1.0', 1.0),
+                checker._calc_item(elem_id, '斜截面受剪', context, 'GB50010-2010 6.3.12', 'V <= Vc + Vs', 0.95),
+            ],
+        },
+        {
+            'chapter': '第7章 构造与稳定',
+            'name': '柱稳定与构造验算',
+            'items': [
+                checker._calc_item(elem_id, '长细比', context, 'GB50010-2010 6.2.20', 'l0/i <= 限值', 1.0),
+            ],
+        },
+    ]
+
+
+def check_element(checker: Any, elem_id: str, context: Dict[str, Any]) -> Dict[str, Any]:
+    element_context = _resolve_element_context(elem_id, context)
+    element_type = _resolve_element_type(elem_id, context)
+    checks = _check_column(checker, elem_id, context) if element_type == 'column' else _check_beam(checker, elem_id, context)
+    result = checker._build_element_result(elem_id, element_type, checks, 'GB50010-2010')
+    result['chapters'] = _build_chapter_summaries(checks)
+    result['chapterCount'] = len(result['chapters'])
+    result['elementContext'] = {
+        'type': element_type,
+        'section': element_context.get('section'),
+        'material': element_context.get('material'),
+        'concreteGrade': element_context.get('concreteGrade'),
+        'rebarGrade': element_context.get('rebarGrade'),
+    }
+    return result

--- a/backend/src/agent-skills/code-check/gb50010/code_check.py
+++ b/backend/src/agent-skills/code-check/gb50010/code_check.py
@@ -58,7 +58,8 @@ def _build_chapter_summaries(checks: List[Dict[str, Any]]) -> List[Dict[str, Any
         status = 'pass'
         controlling_clause = None
         for item in items:
-            utilization = float(item.get('utilization', 0.0))
+            util_val = item.get('utilization')
+            utilization = float(util_val) if util_val is not None else 0.0
             if utilization >= max_utilization:
                 max_utilization = utilization
                 controlling_clause = item.get('clause')

--- a/backend/src/agent-skills/code-check/gb50010/skill.yaml
+++ b/backend/src/agent-skills/code-check/gb50010/skill.yaml
@@ -29,8 +29,10 @@ compatibility:
 designCode: GB50010
 supportedAnalysisTypes: []
 supportedModelFamilies:
+  - frame
   - generic
-materialFamilies: []
+materialFamilies:
+  - concrete
 aliases: []
 toolHints: {}
 runtimeContract:

--- a/backend/src/agent-skills/code-check/gb50017/skill.yaml
+++ b/backend/src/agent-skills/code-check/gb50017/skill.yaml
@@ -29,8 +29,10 @@ compatibility:
 designCode: GB50017
 supportedAnalysisTypes: []
 supportedModelFamilies:
+  - frame
   - generic
-materialFamilies: []
+materialFamilies:
+  - steel
 aliases: []
 toolHints: {}
 runtimeContract:

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
@@ -174,7 +174,21 @@ describe('concrete-frame canonicalize core contract', () => {
     });
 
     expect(model).toBeDefined();
+    expect(model.schema_version).toBe('2.0.0');
+    expect(model.unit_system).toBe('SI');
+    expect(model.metadata).toMatchObject({
+      inferredType: 'frame',
+      structuralTypeKey: 'concrete-frame',
+      materialSystem: 'reinforced-concrete',
+      designCode: 'GB50010',
+    });
+    expect(model.project.extra.designCode).toBe('GB50010');
+    expect(model.extensions.yjk).toMatchObject({
+      materialSystem: 'reinforced-concrete',
+      designCode: 'GB50010',
+    });
     expect(model.materials[0]).toMatchObject({
+      id: '1',
       name: 'C30',
       grade: 'C30',
       category: 'concrete',
@@ -184,7 +198,15 @@ describe('concrete-frame canonicalize core contract', () => {
       fc: 14.3,
     });
     expect(model.materials[0].fy).toBeUndefined();
+    expect(model.materials[1]).toMatchObject({
+      id: '2',
+      name: 'HRB400',
+      grade: 'HRB400',
+      category: 'rebar',
+      fy: 360,
+    });
     expect(model.sections[0]).toMatchObject({
+      id: '1',
       name: '400X400',
       type: 'rectangular',
       purpose: 'column',
@@ -198,6 +220,7 @@ describe('concrete-frame canonicalize core contract', () => {
     );
     expect(model.sections[0].standard_steel_name).toBeUndefined();
     expect(model.sections[1]).toMatchObject({
+      id: '2',
       name: '250X600',
       type: 'rectangular',
       purpose: 'beam',
@@ -205,6 +228,77 @@ describe('concrete-frame canonicalize core contract', () => {
       height: 600,
       shape: { kind: 'rectangular', B: 250, H: 600 },
     });
+    expect(model.nodes).toHaveLength(6);
+    expect(model.elements).toHaveLength(6);
+    expect(model.elements.find((element) => element.id === 'C1')).toMatchObject({
+      type: 'column',
+      material: '1',
+      section: '1',
+      concrete_grade: 'C30',
+      rebar_grade: 'HRB400',
+    });
+    expect(model.elements.find((element) => element.type === 'beam')).toMatchObject({
+      material: '1',
+      section: '2',
+      concrete_grade: 'C30',
+      rebar_grade: 'HRB400',
+    });
+    expect(model.stories).toEqual([
+      expect.objectContaining({
+        id: 'F1',
+        floor_loads: [{ type: 'dead', value: 16.67 }],
+        dead_load: 16.67,
+      }),
+      expect.objectContaining({
+        id: 'F2',
+        floor_loads: [{ type: 'dead', value: 16.67 }],
+        dead_load: 16.67,
+      }),
+    ]);
+    expect(model.load_cases.map((loadCase) => loadCase.id)).toEqual(['D']);
+    expect(model.load_combinations[0]).toMatchObject({
+      id: 'ULS',
+      combination_type: 'uls',
+      code_reference: 'GB50010',
+      factors: { D: 1 },
+    });
+  });
+
+  test('builds a 3d concrete frame model with y-direction beams for YJK conversion', () => {
+    const model = buildConcreteFrameModel({
+      inferredType: 'concrete-frame',
+      updatedAt: 0,
+      frameDimension: '3d',
+      storyCount: 2,
+      bayCountX: 2,
+      bayCountY: 1,
+      storyHeightsM: [3.6, 3.6],
+      bayWidthsXM: [6, 6],
+      bayWidthsYM: [5],
+      floorLoads: [
+        { story: 1, verticalKN: 360, liveLoadKN: 120, lateralXKN: 30, lateralYKN: 12 },
+        { story: 2, verticalKN: 360, liveLoadKN: 120, lateralXKN: 30, lateralYKN: 12 },
+      ],
+      frameBaseSupportType: 'fixed',
+      frameConcreteGrade: 'C35',
+      frameRebarGrade: 'HRB400',
+      frameColumnSection: '500X500',
+      frameBeamSection: '300X600',
+    });
+
+    expect(model).toBeDefined();
+    expect(model.frameDimension).toBe('3d');
+    expect(model.nodes).toHaveLength(18);
+    expect(model.elements.filter((element) => element.type === 'column')).toHaveLength(12);
+    expect(model.elements.filter((element) => element.id.startsWith('BX'))).toHaveLength(8);
+    expect(model.elements.filter((element) => element.id.startsWith('BY'))).toHaveLength(6);
+    expect(model.metadata.elementReferenceVectors).toBeDefined();
+    expect(model.stories[0]).toMatchObject({
+      id: 'F1',
+      dead_load: 6,
+      live_load: 2,
+    });
+    expect(model.load_cases.map((loadCase) => loadCase.id)).toEqual(['D', 'L', 'LAT']);
   });
 
   test('returns undefined when critical geometry is missing (H2 fix)', () => {

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
@@ -89,6 +89,70 @@ describe('concrete-frame canonicalize core contract', () => {
     expect(patch.bayWidthsYM).toEqual([3, 3, 3]);
   });
 
+  test('extracts rc frame geometry when the second plan direction is written as z-direction', () => {
+    const message = '我想设计一个两层钢筋混凝土框架，用YJK计算，X向2跨每跨6.0m，Z向1跨6.0m，层高3.6m×2层。柱截面600x600，梁截面500x250，柱脚刚接，梁柱刚接。具体配筋你来设计';
+    const patch = buildConcreteFrameDraftPatch(message, null, undefined);
+
+    expect(patch).toMatchObject({
+      inferredType: 'frame',
+      frameDimension: '3d',
+      storyCount: 2,
+      bayCountX: 2,
+      bayCountY: 1,
+      storyHeightsM: [3.6, 3.6],
+      bayWidthsXM: [6, 6],
+      bayWidthsYM: [6],
+      frameColumnSection: '600X600',
+      frameBeamSection: '500X250',
+    });
+
+    const model = buildConcreteFrameModel({
+      inferredType: 'frame',
+      structuralTypeKey: 'concrete-frame',
+      skillId: 'concrete-frame',
+      updatedAt: 0,
+      ...patch,
+      frameConcreteGrade: 'C30',
+      frameRebarGrade: 'HRB400',
+      floorLoads: [
+        { story: 1, verticalKN: 300 },
+        { story: 2, verticalKN: 300 },
+      ],
+    });
+
+    expect(model).toBeDefined();
+    expect(model.frameDimension).toBe('3d');
+    expect(model.nodes).toHaveLength(18);
+    expect(model.elements).toHaveLength(26);
+    expect(model.sections[0]).toMatchObject({
+      id: '1',
+      type: 'rectangular',
+      purpose: 'column',
+      width: 600,
+      height: 600,
+      shape: { kind: 'rectangular', B: 600, H: 600 },
+    });
+    expect(model.sections[1]).toMatchObject({
+      id: '2',
+      type: 'rectangular',
+      purpose: 'beam',
+      width: 500,
+      height: 250,
+      shape: { kind: 'rectangular', B: 500, H: 250 },
+    });
+    expect(model.materials[0]).toMatchObject({
+      id: '1',
+      category: 'concrete',
+      grade: 'C30',
+    });
+    expect(model.elements.find((element) => element.type === 'beam')).toMatchObject({
+      material: '1',
+      section: '2',
+      concrete_grade: 'C30',
+      rebar_grade: 'HRB400',
+    });
+  });
+
   test('extracts repeated english story heights from "4.2m each" phrasing', () => {
     const patch = buildConcreteFrameDraftPatch(
       '3 stories, 4.2m each, single bay 8m, floor load 12kN/m2',

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
@@ -153,6 +153,17 @@ describe('concrete-frame canonicalize core contract', () => {
     });
   });
 
+  test('infers 3d concrete frame when z-direction bay count uses chinese numerals', () => {
+    const patch = normalizeConcreteFrameNaturalPatch(
+      '两层混凝土框架，X向2跨每跨6m，Z向一跨每跨5m，层高3m',
+      undefined,
+    );
+
+    expect(patch.frameDimension).toBe('3d');
+    expect(patch.bayCountY).toBe(1);
+    expect(patch.bayWidthsYM).toEqual([5]);
+  });
+
   test('extracts repeated english story heights from "4.2m each" phrasing', () => {
     const patch = buildConcreteFrameDraftPatch(
       '3 stories, 4.2m each, single bay 8m, floor load 12kN/m2',

--- a/backend/src/agent-skills/structure-type/concrete-frame/canonicalize.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/canonicalize.ts
@@ -43,7 +43,7 @@ function hasConcreteFrameYEvidence(
     patch.bayCountY !== undefined
     || (patch.bayWidthsYM?.length ?? 0) > 0
     || hasLateralYFloorLoad(floorLoads)
-    || /(?:3d|三维|y向|y方向|x、y向|x\/y向)/i.test(message),
+    || /(?:3d|三维|[yz]向|[yz]方向|x、[yz]向|x\/[yz]向)/i.test(message),
   );
 }
 

--- a/backend/src/agent-skills/structure-type/concrete-frame/extract-natural.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/extract-natural.ts
@@ -362,7 +362,7 @@ function extractFrameDimension(message: string): '2d' | '3d' | undefined {
   if (/(?:^|[^a-zA-Z\u4e00-\u9fa5])y向(?:[^x方向]|$)|(?:^|[^a-zA-Z\u4e00-\u9fa5])y方向(?:[^:：]|$)/i.test(message)) {
     return '3d';
   }
-  if (/(?:^|[^a-zA-Z\u4e00-\u9fa5])z向\s*\d*\s*跨|(?:^|[^a-zA-Z\u4e00-\u9fa5])z方向\s*\d*\s*跨/i.test(message)) {
+  if (/(?:^|[^a-zA-Z\u4e00-\u9fa5])z向\s*[\d一二两三四五六七八九十百千万廿]*\s*跨|(?:^|[^a-zA-Z\u4e00-\u9fa5])z方向\s*[\d一二两三四五六七八九十百千万廿]*\s*跨/i.test(message)) {
     return '3d';
   }
   

--- a/backend/src/agent-skills/structure-type/concrete-frame/extract-natural.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/extract-natural.ts
@@ -18,7 +18,7 @@ const STRUCTURAL_LEADING_PATTERN = '(?:^|[，。；！？、\\s]|共|包含|总�
  */
 function parseChineseNumber(text: string): number | undefined {
   const chineseDigits: Record<string, number> = {
-    '零': 0, '〇': 0, '一': 1, '二': 2, '三': 3, '四': 4, '五': 5,
+    '零': 0, '〇': 0, '一': 1, '二': 2, '两': 2, '三': 3, '四': 4, '五': 5,
     '六': 6, '七': 7, '八': 8, '九': 9, '十': 10,
   };
 
@@ -154,6 +154,27 @@ function _extractNaturalArray(message: string, patterns: RegExp[]): number[] | u
   return undefined;
 }
 
+function extractDirectionalSegment(message: string, axis: 'x' | 'y' | 'z'): string {
+  const axisClass = axis === 'x' ? '[xX]' : axis === 'y' ? '[yY]' : '[zZ]';
+  const nextAxis = '[xXyYzZ](?:方向|向)';
+  const match = message.match(new RegExp(`${axisClass}(?:方向|向)([\\s\\S]*?)(?=${nextAxis}|$)`, 'i'));
+  return match?.[1] || '';
+}
+
+function extractBayCountFromDirectionalSegment(segment: string): number | undefined {
+  return extractStructuredCount(segment, [
+    new RegExp(`(${DIGIT_PATTERN})\\s*跨`, 'i'),
+    new RegExp(`(${DIGIT_PATTERN})\\s*bays?`, 'i'),
+  ]);
+}
+
+function extractBayWidthFromDirectionalSegment(segment: string): number[] | undefined {
+  return _extractNaturalArray(segment, [
+    new RegExp(`(?:每跨|跨度|间隔)(?:都?是|也?是|为|是)?\\s*(${DIGIT_PATTERN}(?:\\.${DIGIT_PATTERN})?)\\s*(?:m|米)`, 'gi'),
+    new RegExp(`${DIGIT_PATTERN}\\s*跨\\s*(?:每跨)?\\s*(${DIGIT_PATTERN}(?:\\.${DIGIT_PATTERN})?)\\s*(?:m|米)`, 'gi'),
+  ]);
+}
+
 /**
  * Extract story count with strict structural context.
  * Avoids false matches like "其中一层需要加固".
@@ -241,11 +262,14 @@ function extractBayCount(message: string): number | undefined {
  * Extract direction-specific bay count for X direction.
  */
 function extractBayCountX(message: string): number | undefined {
+  const segmentCount = extractBayCountFromDirectionalSegment(extractDirectionalSegment(message, 'x'));
+  if (segmentCount !== undefined) return segmentCount;
+
   // Pattern 1: "x方向4跨"
   const pattern1 = new RegExp(`x方向\\s*(${DIGIT_PATTERN})\\s*跨`, 'i');
   
   // Pattern 2: "x向4跨" or "向x 4跨"
-  const pattern2 = new RegExp(`x?向\\s*${DIGIT_PATTERN}\\s*跨`, 'i');
+  const pattern2 = new RegExp(`x向\\s*(${DIGIT_PATTERN})\\s*跨`, 'i');
   
   return extractStructuredCount(message, [pattern1, pattern2]);
 }
@@ -254,6 +278,11 @@ function extractBayCountX(message: string): number | undefined {
  * Extract direction-specific bay count for Y direction.
  */
 function extractBayCountY(message: string): number | undefined {
+  const ySegmentCount = extractBayCountFromDirectionalSegment(extractDirectionalSegment(message, 'y'));
+  if (ySegmentCount !== undefined) return ySegmentCount;
+  const zSegmentCount = extractBayCountFromDirectionalSegment(extractDirectionalSegment(message, 'z'));
+  if (zSegmentCount !== undefined) return zSegmentCount;
+
   // Pattern 1: "y方向3跨"
   const pattern1 = new RegExp(`y方向\\s*(${DIGIT_PATTERN})\\s*跨`, 'i');
   
@@ -279,6 +308,9 @@ function extractBayWidthsX(message: string): number[] | undefined {
   if (!/x方向|x向/i.test(message)) {
     return undefined;
   }
+  const segmentWidths = extractBayWidthFromDirectionalSegment(extractDirectionalSegment(message, 'x'));
+  if (segmentWidths?.length) return segmentWidths;
+
   return _extractNaturalArray(message, [
     // "间隔3m" after x方向 context
     new RegExp(`x方向[^y]*?间隔\\s*(${DIGIT_PATTERN}(?:\\.${DIGIT_PATTERN})?)\\s*m`, 'gi'),
@@ -290,9 +322,14 @@ function extractBayWidthsX(message: string): number[] | undefined {
 // Extract bay widths for y-direction (in context of y方向)
 function extractBayWidthsY(message: string): number[] | undefined {
   // Check if message has y-direction context
-  if (!/y方向|y向/i.test(message)) {
+  if (!/y方向|y向|z方向|z向/i.test(message)) {
     return undefined;
   }
+  const ySegmentWidths = extractBayWidthFromDirectionalSegment(extractDirectionalSegment(message, 'y'));
+  if (ySegmentWidths?.length) return ySegmentWidths;
+  const zSegmentWidths = extractBayWidthFromDirectionalSegment(extractDirectionalSegment(message, 'z'));
+  if (zSegmentWidths?.length) return zSegmentWidths;
+
   return _extractNaturalArray(message, [
     // "间隔3m" after y方向 context
     new RegExp(`y方向[^x]*?间隔\\s*(${DIGIT_PATTERN}(?:\\.${DIGIT_PATTERN})?)\\s*m`, 'gi'),
@@ -304,6 +341,7 @@ function extractBayWidthsY(message: string): number[] | undefined {
 function extractBayWidths(message: string): number[] | undefined {
   return _extractNaturalArray(message, [
     new RegExp(`(?:跨度|bay\\s*width|span\\s*width)\\s*[：:]*\\s*(${DIGIT_PATTERN}(?:\\.${DIGIT_PATTERN})?)`, 'gi'),
+    new RegExp(`每跨(?:都?是|为)?\\s*(${DIGIT_PATTERN}(?:\\.${DIGIT_PATTERN})?)\\s*(?:m|米)`, 'gi'),
     // English: "single bay 8m" - "bay" followed by number and unit
     new RegExp(`bay\\s*(${DIGIT_PATTERN}(?:\\.${DIGIT_PATTERN})?)\\s*m`, 'gi'),
   ]);
@@ -316,12 +354,15 @@ function extractFrameDimension(message: string): '2d' | '3d' | undefined {
   }
   
   // Check for explicit 3D indicators
-  if (/(?:^|[^a-zA-Z])3d|^三维|^双方向|^双向框架|x、y向|^x\/y向/i.test(message)) {
+  if (/(?:^|[^a-zA-Z])3d|^三维|^双方向|^双向框架|x、[yz]向|^x\/[yz]向/i.test(message)) {
     return '3d';
   }
   
   // Check for y-direction indicators (standalone, not part of "x方向")
   if (/(?:^|[^a-zA-Z\u4e00-\u9fa5])y向(?:[^x方向]|$)|(?:^|[^a-zA-Z\u4e00-\u9fa5])y方向(?:[^:：]|$)/i.test(message)) {
+    return '3d';
+  }
+  if (/(?:^|[^a-zA-Z\u4e00-\u9fa5])z向\s*\d*\s*跨|(?:^|[^a-zA-Z\u4e00-\u9fa5])z方向\s*\d*\s*跨/i.test(message)) {
     return '3d';
   }
   

--- a/backend/src/agent-skills/structure-type/concrete-frame/model.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/model.ts
@@ -1,7 +1,7 @@
-// Concrete frame material and section definitions
-// This module provides material properties for concrete and rebar grades,
-// rectangular cross-section parsing, and helper functions for concrete frame analysis.
-
+import {
+  STRUCTURAL_COORDINATE_SEMANTICS,
+} from '../../../agent-runtime/coordinate-semantics.js';
+import { buildElementReferenceVectors } from '../../../agent-runtime/reference-vectors.js';
 import type { DraftState } from '../../../agent-runtime/types.js';
 
 interface ConcreteMaterial {
@@ -313,10 +313,25 @@ export function resolveSectionProps(rawSection: string, G: number): SectionProps
 }
 
 type ConcreteFrameModel = {
+  schema_version: '2.0.0';
+  unit_system: 'SI';
+  project: Record<string, unknown>;
+  structure_system: Record<string, unknown>;
+  nodes: Array<Record<string, unknown>>;
+  elements: Array<Record<string, unknown>>;
+  stories: Array<Record<string, unknown>>;
+  load_cases: Array<Record<string, unknown>>;
+  load_combinations: Array<Record<string, unknown>>;
+  metadata: Record<string, unknown>;
+  extensions: Record<string, unknown>;
   storyCount: number;
-  bayCount: number;
+  bayCount?: number;
+  bayCountX?: number;
+  bayCountY?: number;
   storyHeightsM: number[];
-  bayWidthsM: number[];
+  bayWidthsM?: number[];
+  bayWidthsXM?: number[];
+  bayWidthsYM?: number[];
   frameDimension: '2d' | '3d';
   frameConcreteGrade: string;
   frameRebarGrade: string;
@@ -329,6 +344,7 @@ type ConcreteFrameModel = {
   floorLoads?: Array<{ story: number; verticalKN?: number; liveLoadKN?: number; lateralXKN?: number; lateralYKN?: number }>;
   frameBaseSupportType?: string;
   materials?: Array<{
+    id: string;
     name: string;
     grade: string;
     category: 'concrete' | 'rebar';
@@ -340,6 +356,7 @@ type ConcreteFrameModel = {
     fy?: number;
   }>;
   sections?: Array<{
+    id: string;
     name: string;
     type: 'rectangular';
     purpose: 'column' | 'beam';
@@ -356,118 +373,579 @@ type ConcreteFrameModel = {
   }>;
 };
 
+function accumulateCoords(lengths: number[]): number[] {
+  const coords = [0];
+  for (const value of lengths) {
+    coords.push(coords[coords.length - 1] + value);
+  }
+  return coords;
+}
+
+function buildBaseRestraint(baseSupport: string): boolean[] {
+  return baseSupport === 'pinned'
+    ? [true, true, true, false, false, false]
+    : [true, true, true, true, true, true];
+}
+
+function n2dId(storyIdx: number, bayNodeIdx: number): string {
+  return `N${storyIdx}_${bayNodeIdx}`;
+}
+
+function n3dId(storyIdx: number, xIdx: number, yIdx: number): string {
+  return `N${storyIdx}_${xIdx}_${yIdx}`;
+}
+
+function buildStoryFloorLoadFields(deadLoad: number | undefined, liveLoad: number | undefined): Record<string, unknown> {
+  const roundedDeadLoad = deadLoad ? Math.round(deadLoad * 100) / 100 : undefined;
+  const roundedLiveLoad = liveLoad ? Math.round(liveLoad * 100) / 100 : undefined;
+  const floorLoads = [
+    ...(roundedDeadLoad ? [{ type: 'dead', value: roundedDeadLoad }] : []),
+    ...(roundedLiveLoad ? [{ type: 'live', value: roundedLiveLoad }] : []),
+  ];
+
+  return {
+    ...(floorLoads.length ? { floor_loads: floorLoads } : {}),
+    ...(roundedDeadLoad ? { dead_load: roundedDeadLoad } : {}),
+    ...(roundedLiveLoad ? { live_load: roundedLiveLoad } : {}),
+  };
+}
+
+function storyHasFloorLoad(story: Record<string, unknown>, loadType: 'dead' | 'live'): boolean {
+  const field = loadType === 'dead' ? story.dead_load : story.live_load;
+  if (typeof field === 'number' && field > 0) return true;
+
+  const floorLoads = Array.isArray(story.floor_loads) ? story.floor_loads : [];
+  return floorLoads.some((entry) => {
+    if (!entry || typeof entry !== 'object') return false;
+    const record = entry as Record<string, unknown>;
+    return record.type === loadType && typeof record.value === 'number' && record.value > 0;
+  });
+}
+
+function buildConcreteLoadCaseBundle(
+  stories: Array<Record<string, unknown>>,
+  lateralLoads: Array<Record<string, unknown>>,
+): { load_cases: Array<Record<string, unknown>>; load_combinations: Array<Record<string, unknown>> } {
+  const loadCases: Array<Record<string, unknown>> = [];
+
+  if (stories.some((story) => storyHasFloorLoad(story, 'dead'))) {
+    loadCases.push({ id: 'D', type: 'dead', loads: [], description: 'Dead floor loads from stories.floor_loads' });
+  }
+  if (stories.some((story) => storyHasFloorLoad(story, 'live'))) {
+    loadCases.push({ id: 'L', type: 'live', loads: [], description: 'Live floor loads from stories.floor_loads' });
+  }
+  if (lateralLoads.length) {
+    loadCases.push({ id: 'LAT', type: 'other', loads: lateralLoads, description: 'Lateral story loads' });
+  }
+  if (!loadCases.length) {
+    loadCases.push({ id: 'LC1', type: 'other', loads: [] });
+  }
+
+  const factors = Object.fromEntries(loadCases.map((loadCase) => [String(loadCase.id), 1.0]));
+  return {
+    load_cases: loadCases,
+    load_combinations: [{ id: 'ULS', factors, combination_type: 'uls', code_reference: 'GB50010' }],
+  };
+}
+
+function buildConcreteMaterialRecord(concreteProps: ConcreteMaterialProps): Record<string, unknown> {
+  return {
+    id: '1',
+    name: concreteProps.grade,
+    grade: concreteProps.grade,
+    category: 'concrete',
+    E: concreteProps.E,
+    G: concreteProps.G,
+    nu: concreteProps.nu,
+    rho: concreteProps.rho,
+    fc: concreteProps.fc,
+  };
+}
+
+function buildRebarMaterialRecord(rebarProps: RebarMaterialProps): Record<string, unknown> {
+  return {
+    id: '2',
+    name: rebarProps.grade,
+    grade: rebarProps.grade,
+    category: 'rebar',
+    E: rebarProps.Es,
+    nu: 0.3,
+    rho: 7850,
+    fy: rebarProps.fy,
+    extra: {
+      fyk: rebarProps.fyk,
+      fstk: rebarProps.fstk,
+      fy_compression: rebarProps.fy_compression,
+      fyv: rebarProps.fyv,
+    },
+  };
+}
+
+function buildConcreteSectionRecord(id: string, purpose: 'column' | 'beam', props: SectionProps): Record<string, unknown> {
+  return {
+    id,
+    name: props.name,
+    type: props.type,
+    purpose,
+    width: props.width ?? 0,
+    height: props.height ?? 0,
+    shape: props.shape,
+    properties: { A: props.A, Iy: props.Iy, Iz: props.Iz, J: props.J, G: props.G },
+  };
+}
+
+function buildCommonModelFields(options: {
+  frameConcreteGrade: string;
+  frameRebarGrade: string;
+  frameColumnSection: string;
+  frameBeamSection: string;
+  frameBaseSupportType: string;
+  storyCount: number;
+  concreteProps: ConcreteMaterialProps;
+  rebarProps: RebarMaterialProps;
+  columnProps: SectionProps;
+  beamProps: SectionProps;
+  metadata: Record<string, unknown>;
+}): Pick<ConcreteFrameModel, 'schema_version' | 'unit_system' | 'project' | 'structure_system' | 'materials' | 'sections' | 'metadata' | 'extensions'> {
+  return {
+    schema_version: '2.0.0',
+    unit_system: 'SI',
+    project: {
+      code_standard: 'GB50010-2010',
+      extra: {
+        designCode: 'GB50010',
+      },
+    },
+    structure_system: {
+      type: 'frame',
+      seismic_grade: 'none',
+      extra: {
+        materialSystem: 'reinforced-concrete',
+      },
+    },
+    materials: [
+      buildConcreteMaterialRecord(options.concreteProps),
+      buildRebarMaterialRecord(options.rebarProps),
+    ] as ConcreteFrameModel['materials'],
+    sections: [
+      buildConcreteSectionRecord('1', 'column', options.columnProps),
+      buildConcreteSectionRecord('2', 'beam', options.beamProps),
+    ] as ConcreteFrameModel['sections'],
+    metadata: {
+      ...options.metadata,
+      coordinateSemantics: STRUCTURAL_COORDINATE_SEMANTICS,
+      source: 'concrete-frame-skill-draft',
+      inferredType: 'frame',
+      structuralTypeKey: 'concrete-frame',
+      materialSystem: 'reinforced-concrete',
+      designCode: 'GB50010',
+      baseSupport: options.frameBaseSupportType,
+      concreteGrade: options.frameConcreteGrade,
+      rebarGrade: options.frameRebarGrade,
+      columnSection: options.frameColumnSection,
+      beamSection: options.frameBeamSection,
+      storyCount: options.storyCount,
+    },
+    extensions: {
+      yjk: {
+        materialSystem: 'reinforced-concrete',
+        designCode: 'GB50010',
+      },
+      concreteDesign: {
+        concreteGrade: options.frameConcreteGrade,
+        rebarGrade: options.frameRebarGrade,
+      },
+    },
+  };
+}
+
+function buildConcreteFrame2dLocalModel(options: {
+  storyCount: number;
+  bayCount: number;
+  storyHeightsM: number[];
+  bayWidthsM: number[];
+  floorLoads: NonNullable<ConcreteFrameModel['floorLoads']>;
+  frameBaseSupportType: string;
+  frameConcreteGrade: string;
+  frameRebarGrade: string;
+  frameColumnSection: string;
+  frameBeamSection: string;
+  concreteProps: ConcreteMaterialProps;
+  rebarProps: RebarMaterialProps;
+  columnProps: SectionProps;
+  beamProps: SectionProps;
+}): ConcreteFrameModel {
+  const xCoords = accumulateCoords(options.bayWidthsM);
+  const zCoords = accumulateCoords(options.storyHeightsM);
+  const nodes: Array<Record<string, unknown>> = [];
+  const elements: Array<Record<string, unknown>> = [];
+  const lateralLoads: Array<Record<string, unknown>> = [];
+  let elementId = 1;
+
+  for (let storyIdx = 0; storyIdx < zCoords.length; storyIdx++) {
+    for (let bayIdx = 0; bayIdx < xCoords.length; bayIdx++) {
+      const node: Record<string, unknown> = {
+        id: n2dId(storyIdx, bayIdx),
+        x: xCoords[bayIdx],
+        y: 0,
+        z: zCoords[storyIdx],
+        ...(storyIdx > 0 ? { story: `F${storyIdx}` } : {}),
+      };
+      if (storyIdx === 0) node.restraints = buildBaseRestraint(options.frameBaseSupportType);
+      nodes.push(node);
+    }
+  }
+
+  for (let storyIdx = 1; storyIdx < zCoords.length; storyIdx++) {
+    for (let bayIdx = 0; bayIdx < xCoords.length; bayIdx++) {
+      elements.push({
+        id: `C${elementId}`,
+        type: 'column',
+        nodes: [n2dId(storyIdx - 1, bayIdx), n2dId(storyIdx, bayIdx)],
+        material: '1',
+        section: '1',
+        story: `F${storyIdx}`,
+        concrete_grade: options.frameConcreteGrade,
+        rebar_grade: options.frameRebarGrade,
+      });
+      elementId += 1;
+    }
+  }
+
+  for (let storyIdx = 1; storyIdx < zCoords.length; storyIdx++) {
+    for (let bayIdx = 0; bayIdx < options.bayWidthsM.length; bayIdx++) {
+      elements.push({
+        id: `B${elementId}`,
+        type: 'beam',
+        nodes: [n2dId(storyIdx, bayIdx), n2dId(storyIdx, bayIdx + 1)],
+        material: '1',
+        section: '2',
+        story: `F${storyIdx}`,
+        concrete_grade: options.frameConcreteGrade,
+        rebar_grade: options.frameRebarGrade,
+      });
+      elementId += 1;
+    }
+  }
+
+  const levelNodeCount = xCoords.length;
+  for (const load of options.floorLoads) {
+    const storyIdx = load.story;
+    if (storyIdx <= 0 || storyIdx >= zCoords.length) continue;
+    const lPerNode = load.lateralXKN !== undefined ? load.lateralXKN / levelNodeCount : undefined;
+    for (let bayIdx = 0; bayIdx < xCoords.length; bayIdx++) {
+      const nodeLoad: Record<string, unknown> = { node: n2dId(storyIdx, bayIdx) };
+      if (lPerNode !== undefined) nodeLoad.fx = lPerNode;
+      if (Object.keys(nodeLoad).length > 1) lateralLoads.push(nodeLoad);
+    }
+  }
+
+  const stories = options.storyHeightsM.map((height, index) => {
+    const storyIdx = index + 1;
+    const fl = options.floorLoads.find((load) => load.story === storyIdx);
+    const floorAreaM2 = Math.max(xCoords[xCoords.length - 1], 1);
+    const deadLoad = fl?.verticalKN ? Math.abs(fl.verticalKN) / floorAreaM2 : undefined;
+    const liveLoad = fl?.liveLoadKN ? Math.abs(fl.liveLoadKN) / floorAreaM2 : undefined;
+    return {
+      id: `F${storyIdx}`,
+      height,
+      elevation: zCoords[index],
+      standard_floor_group: 'SF1',
+      ...buildStoryFloorLoadFields(deadLoad, liveLoad),
+    };
+  });
+  const loadCaseBundle = buildConcreteLoadCaseBundle(stories, lateralLoads);
+  const common = buildCommonModelFields({
+    ...options,
+    metadata: {
+      frameDimension: '2d',
+      bayCount: options.bayCount,
+      geometry: { storyHeightsM: options.storyHeightsM, bayWidthsM: options.bayWidthsM },
+    },
+  });
+
+  return {
+    ...common,
+    nodes,
+    elements,
+    stories,
+    ...loadCaseBundle,
+    storyCount: options.storyCount,
+    bayCount: options.bayCount,
+    storyHeightsM: options.storyHeightsM,
+    bayWidthsM: options.bayWidthsM,
+    frameDimension: '2d',
+    frameConcreteGrade: options.frameConcreteGrade,
+    frameRebarGrade: options.frameRebarGrade,
+    frameColumnSection: options.frameColumnSection,
+    frameBeamSection: options.frameBeamSection,
+    concreteProps: options.concreteProps,
+    rebarProps: options.rebarProps,
+    columnProps: options.columnProps,
+    beamProps: options.beamProps,
+    floorLoads: options.floorLoads,
+    frameBaseSupportType: options.frameBaseSupportType,
+  };
+}
+
+function buildConcreteFrame3dLocalModel(options: {
+  storyCount: number;
+  bayCountX: number;
+  bayCountY: number;
+  storyHeightsM: number[];
+  bayWidthsXM: number[];
+  bayWidthsYM: number[];
+  floorLoads: NonNullable<ConcreteFrameModel['floorLoads']>;
+  frameBaseSupportType: string;
+  frameConcreteGrade: string;
+  frameRebarGrade: string;
+  frameColumnSection: string;
+  frameBeamSection: string;
+  concreteProps: ConcreteMaterialProps;
+  rebarProps: RebarMaterialProps;
+  columnProps: SectionProps;
+  beamProps: SectionProps;
+}): ConcreteFrameModel {
+  const xCoords = accumulateCoords(options.bayWidthsXM);
+  const yCoords = accumulateCoords(options.bayWidthsYM);
+  const zCoords = accumulateCoords(options.storyHeightsM);
+  const nodes: Array<Record<string, unknown>> = [];
+  const elements: Array<Record<string, unknown>> = [];
+  const lateralLoads: Array<Record<string, unknown>> = [];
+  let elementId = 1;
+
+  for (let storyIdx = 0; storyIdx < zCoords.length; storyIdx++) {
+    for (let xIdx = 0; xIdx < xCoords.length; xIdx++) {
+      for (let yIdx = 0; yIdx < yCoords.length; yIdx++) {
+        const node: Record<string, unknown> = {
+          id: n3dId(storyIdx, xIdx, yIdx),
+          x: xCoords[xIdx],
+          y: yCoords[yIdx],
+          z: zCoords[storyIdx],
+          ...(storyIdx > 0 ? { story: `F${storyIdx}` } : {}),
+        };
+        if (storyIdx === 0) node.restraints = buildBaseRestraint(options.frameBaseSupportType);
+        nodes.push(node);
+      }
+    }
+  }
+
+  for (let storyIdx = 1; storyIdx < zCoords.length; storyIdx++) {
+    for (let xIdx = 0; xIdx < xCoords.length; xIdx++) {
+      for (let yIdx = 0; yIdx < yCoords.length; yIdx++) {
+        elements.push({
+          id: `C${elementId}`,
+          type: 'column',
+          nodes: [n3dId(storyIdx - 1, xIdx, yIdx), n3dId(storyIdx, xIdx, yIdx)],
+          material: '1',
+          section: '1',
+          story: `F${storyIdx}`,
+          concrete_grade: options.frameConcreteGrade,
+          rebar_grade: options.frameRebarGrade,
+        });
+        elementId += 1;
+      }
+    }
+  }
+
+  for (let storyIdx = 1; storyIdx < zCoords.length; storyIdx++) {
+    for (let xIdx = 0; xIdx < options.bayWidthsXM.length; xIdx++) {
+      for (let yIdx = 0; yIdx < yCoords.length; yIdx++) {
+        elements.push({
+          id: `BX${elementId}`,
+          type: 'beam',
+          nodes: [n3dId(storyIdx, xIdx, yIdx), n3dId(storyIdx, xIdx + 1, yIdx)],
+          material: '1',
+          section: '2',
+          story: `F${storyIdx}`,
+          concrete_grade: options.frameConcreteGrade,
+          rebar_grade: options.frameRebarGrade,
+        });
+        elementId += 1;
+      }
+    }
+  }
+
+  for (let storyIdx = 1; storyIdx < zCoords.length; storyIdx++) {
+    for (let xIdx = 0; xIdx < xCoords.length; xIdx++) {
+      for (let yIdx = 0; yIdx < options.bayWidthsYM.length; yIdx++) {
+        elements.push({
+          id: `BY${elementId}`,
+          type: 'beam',
+          nodes: [n3dId(storyIdx, xIdx, yIdx), n3dId(storyIdx, xIdx, yIdx + 1)],
+          material: '1',
+          section: '2',
+          story: `F${storyIdx}`,
+          concrete_grade: options.frameConcreteGrade,
+          rebar_grade: options.frameRebarGrade,
+        });
+        elementId += 1;
+      }
+    }
+  }
+
+  const levelNodeCount = xCoords.length * yCoords.length;
+  for (const load of options.floorLoads) {
+    const storyIdx = load.story;
+    if (storyIdx <= 0 || storyIdx >= zCoords.length) continue;
+    const lxPerNode = load.lateralXKN !== undefined ? load.lateralXKN / levelNodeCount : undefined;
+    const lyPerNode = load.lateralYKN !== undefined ? load.lateralYKN / levelNodeCount : undefined;
+    for (let xIdx = 0; xIdx < xCoords.length; xIdx++) {
+      for (let yIdx = 0; yIdx < yCoords.length; yIdx++) {
+        const nodeLoad: Record<string, unknown> = { node: n3dId(storyIdx, xIdx, yIdx) };
+        if (lxPerNode !== undefined) nodeLoad.fx = lxPerNode;
+        if (lyPerNode !== undefined) nodeLoad.fy = lyPerNode;
+        if (Object.keys(nodeLoad).length > 1) lateralLoads.push(nodeLoad);
+      }
+    }
+  }
+
+  const elementReferenceVectors = buildElementReferenceVectors(elements, nodes);
+  const stories = options.storyHeightsM.map((height, index) => {
+    const storyIdx = index + 1;
+    const fl = options.floorLoads.find((load) => load.story === storyIdx);
+    const floorAreaM2 = Math.max(xCoords[xCoords.length - 1], 1) * Math.max(yCoords[yCoords.length - 1], 1);
+    const deadLoad = fl?.verticalKN ? Math.abs(fl.verticalKN) / floorAreaM2 : undefined;
+    const liveLoad = fl?.liveLoadKN ? Math.abs(fl.liveLoadKN) / floorAreaM2 : undefined;
+    return {
+      id: `F${storyIdx}`,
+      height,
+      elevation: zCoords[index],
+      standard_floor_group: 'SF1',
+      ...buildStoryFloorLoadFields(deadLoad, liveLoad),
+    };
+  });
+  const loadCaseBundle = buildConcreteLoadCaseBundle(stories, lateralLoads);
+  const common = buildCommonModelFields({
+    ...options,
+    metadata: {
+      frameDimension: '3d',
+      elementReferenceVectors,
+      bayCountX: options.bayCountX,
+      bayCountY: options.bayCountY,
+      geometry: {
+        storyHeightsM: options.storyHeightsM,
+        bayWidthsXM: options.bayWidthsXM,
+        bayWidthsYM: options.bayWidthsYM,
+      },
+    },
+  });
+
+  return {
+    ...common,
+    nodes,
+    elements,
+    stories,
+    ...loadCaseBundle,
+    storyCount: options.storyCount,
+    bayCountX: options.bayCountX,
+    bayCountY: options.bayCountY,
+    storyHeightsM: options.storyHeightsM,
+    bayWidthsXM: options.bayWidthsXM,
+    bayWidthsYM: options.bayWidthsYM,
+    frameDimension: '3d',
+    frameConcreteGrade: options.frameConcreteGrade,
+    frameRebarGrade: options.frameRebarGrade,
+    frameColumnSection: options.frameColumnSection,
+    frameBeamSection: options.frameBeamSection,
+    concreteProps: options.concreteProps,
+    rebarProps: options.rebarProps,
+    columnProps: options.columnProps,
+    beamProps: options.beamProps,
+    floorLoads: options.floorLoads,
+    frameBaseSupportType: options.frameBaseSupportType,
+  };
+}
+
 /**
  * Build a concrete frame model from draft state.
  * @param state Draft state with concrete frame parameters
  * @returns ConcreteFrameModel ready for analysis, or undefined if critical geometry is missing
  */
 export function buildConcreteFrameModel(state: DraftState): ConcreteFrameModel | undefined {
-  // Critical geometry validation - return undefined to trigger LLM fallback if missing
   const storyCount = state.storyCount;
-  const bayCount = state.bayCount;
   const storyHeightsM = state.storyHeightsM;
-  const bayWidthsM = state.bayWidthsM;
 
-  if (storyCount === undefined || bayCount === undefined) {
+  if (storyCount === undefined || !storyHeightsM?.length) {
     return undefined;
   }
-  if (!storyHeightsM?.length || !bayWidthsM?.length) {
-    return undefined;
-  }
-
-  // Validate length consistency between count and array (H4)
   if (storyHeightsM.length !== storyCount) {
-    return undefined;
-  }
-  if (bayWidthsM.length !== bayCount) {
     return undefined;
   }
 
   const frameDimension = state.frameDimension || '2d';
+  const floorLoads = state.floorLoads ?? [];
 
   // M1: Separate concrete and rebar grade handling
   const rawFrameConcreteGrade = (state.frameConcreteGrade as string | undefined);
   const rawFrameRebarGrade = (state.frameRebarGrade as string | undefined);
 
-  // Validate concrete grade, fall back to C30 if invalid
-  let frameConcreteGrade: string;
-  if (rawFrameConcreteGrade && isValidConcreteGrade(rawFrameConcreteGrade)) {
-    frameConcreteGrade = rawFrameConcreteGrade;
-  } else {
-    frameConcreteGrade = 'C30';
-  }
-
-  // Validate rebar grade, fall back to HRB400 if invalid
-  let frameRebarGrade: string;
-  if (rawFrameRebarGrade && isValidRebarGrade(rawFrameRebarGrade)) {
-    frameRebarGrade = rawFrameRebarGrade;
-  } else {
-    frameRebarGrade = 'HRB400';
-  }
+  const frameConcreteGrade = rawFrameConcreteGrade && isValidConcreteGrade(rawFrameConcreteGrade)
+    ? normalizeConcreteGrade(rawFrameConcreteGrade)
+    : 'C30';
+  const frameRebarGrade = rawFrameRebarGrade && isValidRebarGrade(rawFrameRebarGrade)
+    ? rawFrameRebarGrade.toUpperCase().replace(/\s+/g, '')
+    : 'HRB400';
 
   const frameColumnSection = (state.frameColumnSection as string | undefined) || getDefaultColumnSection(storyCount);
   const frameBeamSection = (state.frameBeamSection as string | undefined) || getDefaultBeamSection(storyCount);
-  const frameBaseSupportType = state.frameBaseSupportType || 'fixed';
+  const frameBaseSupportType = (state.frameBaseSupportType as string | undefined) || 'fixed';
 
   const concreteProps = resolveConcreteMaterialProps(frameConcreteGrade);
   const rebarProps = resolveRebarMaterialProps(frameRebarGrade);
   const columnProps = resolveSectionProps(frameColumnSection, concreteProps.G);
   const beamProps = resolveSectionProps(frameBeamSection, concreteProps.G);
 
-  // Build materials array matching test expectations
-  const materials: ConcreteFrameModel['materials'] = [
-    {
-      name: concreteProps.grade,
-      grade: concreteProps.grade,
-      category: 'concrete',
-      E: concreteProps.E,
-      G: concreteProps.G,
-      nu: concreteProps.nu,
-      rho: concreteProps.rho,
-      fc: concreteProps.fc,
-    },
-  ];
+  if (frameDimension === '3d') {
+    const bayWidthsXM = state.bayWidthsXM?.length ? state.bayWidthsXM : state.bayWidthsM;
+    const bayWidthsYM = state.bayWidthsYM?.length ? state.bayWidthsYM : state.bayWidthsM;
+    const bayCountX = state.bayCountX ?? bayWidthsXM?.length;
+    const bayCountY = state.bayCountY ?? bayWidthsYM?.length;
 
-  // Build sections array matching test expectations
-  const sections: ConcreteFrameModel['sections'] = [
-    {
-      name: columnProps.name,
-      type: 'rectangular',
-      purpose: 'column',
-      width: columnProps.width ?? 0,
-      height: columnProps.height ?? 0,
-      shape: { kind: 'rectangular', B: columnProps.width ?? 0, H: columnProps.height ?? 0 },
-      properties: {
-        A: columnProps.A,
-        Iy: columnProps.Iy,
-        Iz: columnProps.Iz,
-        J: columnProps.J,
-        G: columnProps.G,
-      },
-    },
-    {
-      name: beamProps.name,
-      type: 'rectangular',
-      purpose: 'beam',
-      width: beamProps.width ?? 0,
-      height: beamProps.height ?? 0,
-      shape: { kind: 'rectangular', B: beamProps.width ?? 0, H: beamProps.height ?? 0 },
-      properties: {
-        A: beamProps.A,
-        Iy: beamProps.Iy,
-        Iz: beamProps.Iz,
-        J: beamProps.J,
-        G: beamProps.G,
-      },
-    },
-  ];
+    if (bayCountX === undefined || bayCountY === undefined || !bayWidthsXM?.length || !bayWidthsYM?.length) {
+      return undefined;
+    }
+    if (bayWidthsXM.length !== bayCountX || bayWidthsYM.length !== bayCountY) {
+      return undefined;
+    }
 
-  return {
+    return buildConcreteFrame3dLocalModel({
+      storyCount,
+      bayCountX,
+      bayCountY,
+      storyHeightsM,
+      bayWidthsXM,
+      bayWidthsYM,
+      floorLoads,
+      frameBaseSupportType,
+      frameConcreteGrade,
+      frameRebarGrade,
+      frameColumnSection,
+      frameBeamSection,
+      concreteProps,
+      rebarProps,
+      columnProps,
+      beamProps,
+    });
+  }
+
+  const bayCount = state.bayCount;
+  const bayWidthsM = state.bayWidthsM;
+
+  if (bayCount === undefined || !bayWidthsM?.length) {
+    return undefined;
+  }
+  if (bayWidthsM.length !== bayCount) {
+    return undefined;
+  }
+
+  return buildConcreteFrame2dLocalModel({
     storyCount,
     bayCount,
     storyHeightsM,
     bayWidthsM,
-    frameDimension,
+    floorLoads,
+    frameBaseSupportType,
     frameConcreteGrade,
     frameRebarGrade,
     frameColumnSection,
@@ -476,9 +954,5 @@ export function buildConcreteFrameModel(state: DraftState): ConcreteFrameModel |
     rebarProps,
     columnProps,
     beamProps,
-    floorLoads: state.floorLoads,
-    frameBaseSupportType,
-    materials,
-    sections,
-  };
+  });
 }

--- a/backend/src/agent-skills/structure-type/concrete-frame/skill.yaml
+++ b/backend/src/agent-skills/structure-type/concrete-frame/skill.yaml
@@ -36,8 +36,11 @@ compatibility:
   minRuntimeVersion: 0.1.0
   skillApiVersion: v1
 supportedAnalysisTypes: []
-supportedModelFamilies: []
-materialFamilies: []
+supportedModelFamilies:
+  - frame
+  - generic
+materialFamilies:
+  - concrete
 aliases: []
 toolHints: {}
 runtimeContract:

--- a/backend/src/agent-skills/structure-type/frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/frame/__tests__/skill-core.test.mjs
@@ -7,6 +7,7 @@ import {
   buildFramePatchFromLlm,
   coerceFrameDimension,
 } from '../../../../../dist/agent-skills/structure-type/frame/extract-llm.js';
+import { detectFrameStructuralType } from '../../../../../dist/agent-skills/structure-type/frame/detect.js';
 
 describe('frame canonicalize core contract', () => {
   test('promotes to 3d when y-direction evidence conflicts with llm 2d output', () => {
@@ -85,6 +86,28 @@ describe('frame canonicalize core contract', () => {
     expect(patch.bayCountY).toBe(3);
     expect(patch.bayWidthsXM).toEqual([3, 3, 3, 3]);
     expect(patch.bayWidthsYM).toEqual([3, 3, 3]);
+  });
+
+  test('treats z-direction spans as the second plan direction when span context is explicit', () => {
+    const patch = normalizeFrameNaturalPatch(
+      '三层钢框架，X向2跨每跨6m，Z向1跨6m，层高3.6m',
+      undefined,
+    );
+
+    expect(patch.frameDimension).toBe('3d');
+    expect(patch.bayCountX).toBe(2);
+    expect(patch.bayCountY).toBe(1);
+    expect(patch.bayWidthsXM).toEqual([6, 6]);
+    expect(patch.bayWidthsYM).toEqual([6]);
+  });
+
+  test('does not claim explicit reinforced-concrete frame prompts', () => {
+    const result = detectFrameStructuralType({
+      message: '两层钢筋混凝土框架，X向2跨，Z向1跨',
+      locale: 'zh',
+    });
+
+    expect(result).toBeNull();
   });
 
   test('extracts repeated english story heights from "4.2m each" phrasing', () => {

--- a/backend/src/agent-skills/structure-type/frame/detect.ts
+++ b/backend/src/agent-skills/structure-type/frame/detect.ts
@@ -12,6 +12,9 @@ export function detectFrameStructuralType({ message, locale, currentState }: Ski
       en: 'The current frame skill only supports regular stories and regular grids. If the structure has setbacks, missing bays, or strong irregularities, please provide JSON or a more explicit node/member description.',
     });
   }
+  if (text.includes('concrete frame') || text.includes('混凝土框架') || text.includes('钢筋混凝土框架') || text.includes('rc frame')) {
+    return null;
+  }
   if (text.includes('steel frame') || text.includes('钢框架')) {
     return buildStructuralTypeMatch('steel-frame', 'frame', 'frame', 'supported', locale);
   }

--- a/backend/src/agent-skills/structure-type/frame/extract-natural.ts
+++ b/backend/src/agent-skills/structure-type/frame/extract-natural.ts
@@ -95,10 +95,8 @@ function repeatScalar(count: number | undefined, value: number | undefined): num
   return Array.from({ length: count }, () => value);
 }
 
-function extractDirectionalSegment(text: string, axis: 'x' | 'y'): string {
-  const pattern = axis === 'x'
-    ? /x(?:方向|向)([\s\S]*?)(?=y(?:方向|向)|$)/i
-    : /y(?:方向|向)([\s\S]*?)$/i;
+function extractDirectionalSegment(text: string, axis: 'x' | 'y' | 'z'): string {
+  const pattern = new RegExp(`${axis}(?:方向|向)([\\s\\S]*?)(?=[xyz](?:方向|向)|$)`, 'i');
   return text.match(pattern)?.[1] || '';
 }
 
@@ -191,7 +189,10 @@ export function normalizeFrameNaturalPatch(message: string, existingState: Draft
   ]);
 
   const xSegment = extractDirectionalSegment(text, 'x');
-  const ySegment = extractDirectionalSegment(text, 'y');
+  const rawYSegment = extractDirectionalSegment(text, 'y');
+  const rawZSegment = extractDirectionalSegment(text, 'z');
+  const zSegmentLooksLikePlanAxis = /(?:[0-9]+|[一二两三四五六七八九十]+)\s*跨|跨度|每跨|bay/i.test(rawZSegment);
+  const ySegment = rawYSegment || (zSegmentLooksLikePlanAxis ? rawZSegment : '');
 
   const bayCountX = extractPositiveInt(xSegment, [
     /([0-9]+|[一二两三四五六七八九十]+)\s*跨/i,
@@ -214,11 +215,13 @@ export function normalizeFrameNaturalPatch(message: string, existingState: Draft
   const xBayScalar = xSpanArray
     ? undefined
     : extractScalar(xSegment, [
+      /(?:[0-9]+|[一二两三四五六七八九十]+)\s*跨\s*(?:每跨)?\s*([0-9]+(?:\.[0-9]+)?)\s*(?:m|米)/i,
       /(?:间隔|跨度|每跨)(?:也?是|都?是|为)?\s*([0-9]+(?:\.[0-9]+)?)\s*(?:m|米)/i,
     ]);
   const yBayScalar = ySpanArray
     ? undefined
     : extractScalar(ySegment, [
+      /(?:[0-9]+|[一二两三四五六七八九十]+)\s*跨\s*(?:每跨)?\s*([0-9]+(?:\.[0-9]+)?)\s*(?:m|米)/i,
       /(?:间隔|跨度|每跨)(?:也?是|都?是|为)?\s*([0-9]+(?:\.[0-9]+)?)\s*(?:m|米)/i,
     ]);
   const genericBayScalar = extractScalar(text, [
@@ -262,6 +265,7 @@ export function normalizeFrameNaturalPatch(message: string, existingState: Draft
       : undefined;
   const inferred3d = text.includes('y方向')
     || text.includes('y向')
+    || (zSegmentLooksLikePlanAxis && (text.includes('z方向') || text.includes('z向')))
     || bayCountY !== undefined
     || yBayScalar !== undefined
     || ySpanArray !== undefined

--- a/backend/src/agent-skills/structure-type/frame/skill.yaml
+++ b/backend/src/agent-skills/structure-type/frame/skill.yaml
@@ -36,8 +36,11 @@ compatibility:
   minRuntimeVersion: 0.1.0
   skillApiVersion: v1
 supportedAnalysisTypes: []
-supportedModelFamilies: []
-materialFamilies: []
+supportedModelFamilies:
+  - frame
+  - generic
+materialFamilies:
+  - steel
 aliases: []
 toolHints: {}
 runtimeContract:

--- a/backend/tests/analysis-yjk-driver-auth.test.mjs
+++ b/backend/tests/analysis-yjk-driver-auth.test.mjs
@@ -1,0 +1,72 @@
+import { describe, expect, test } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function probePython(executable, args) {
+  const result = spawnSync(executable, [...args, '-c', 'import sys; sys.exit(0)'], {
+    encoding: 'utf8',
+    windowsHide: process.platform === 'win32',
+  });
+  return result.status === 0 ? { executable, args } : null;
+}
+
+function resolvePythonCommand() {
+  const candidates = process.platform === 'win32'
+    ? [
+        ['py', ['-3']],
+        ['python', []],
+        ['python3', []],
+      ]
+    : [
+        ['python3', []],
+        ['python', []],
+      ];
+  for (const [executable, args] of candidates) {
+    const found = probePython(executable, args);
+    if (found) return found;
+  }
+  return null;
+}
+
+describe('YJK driver authorization detection', () => {
+  const python = resolvePythonCommand();
+
+  if (!python) {
+    test.skip('detects authorization failure windows from reused YJK processes (no Python)', () => {});
+    return;
+  }
+
+  test('detects authorization failure windows from reused YJK processes', () => {
+    const script = String.raw`
+import importlib.util
+from pathlib import Path
+
+driver_path = Path(r"${repoRoot}") / "backend" / "src" / "agent-skills" / "analysis" / "yjk-static" / "yjk_driver.py"
+spec = importlib.util.spec_from_file_location("yjk_driver_under_test", driver_path)
+driver = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(driver)
+
+driver._get_yjks_processes = lambda: [
+    {"Id": 10, "MainWindowTitle": "授权检测失败"},
+    {"Id": 11, "MainWindowTitle": "YJK main"},
+]
+
+state = driver._wait_for_direct_launch_state({10}, 1.0)
+assert state["state"] == "auth_failed", state
+assert state["pid"] == 10, state
+print("ok")
+`;
+
+    const result = spawnSync(python.executable, [...python.args, '-c', script], {
+      encoding: 'utf8',
+      windowsHide: process.platform === 'win32',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('ok');
+  });
+});

--- a/backend/tests/analysis-yjk-rc-converter.test.mjs
+++ b/backend/tests/analysis-yjk-rc-converter.test.mjs
@@ -1,0 +1,256 @@
+import { describe, expect, test } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+const converterDir = path.join(
+  repoRoot,
+  'backend',
+  'src',
+  'agent-skills',
+  'analysis',
+  'yjk-static',
+);
+
+function probePython(executable, args) {
+  const result = spawnSync(executable, [...args, '-c', 'import sys; sys.exit(0)'], {
+    encoding: 'utf8',
+    windowsHide: process.platform === 'win32',
+  });
+  return result.status === 0 ? { executable, args } : null;
+}
+
+function resolvePythonCommand() {
+  if (process.env.PYTHON_FOR_TEST) {
+    const found = probePython(process.env.PYTHON_FOR_TEST, []);
+    if (found) return found;
+  }
+
+  const candidates = process.platform === 'win32'
+    ? [
+        ['py', ['-3']],
+        ['python', []],
+        ['python3', []],
+      ]
+    : [
+        ['python3', []],
+        ['python', []],
+      ];
+  for (const [executable, args] of candidates) {
+    const found = probePython(executable, args);
+    if (found) return found;
+  }
+  return null;
+}
+
+function writeFile(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf8');
+}
+
+const pythonCommand = resolvePythonCommand();
+
+describe('YJK RC frame converter', () => {
+  if (!pythonCommand) {
+    test.skip('converts reinforced-concrete frame sections with YJK DataFunc (no Python on PATH)', () => {});
+    return;
+  }
+
+  test('converts reinforced-concrete frame sections with YJK DataFunc', () => {
+    const stubsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sclaw-yjk-api-'));
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sclaw-yjk-rc-'));
+
+    try {
+      writeFile(
+        path.join(stubsDir, 'YJKAPI.py'),
+        [
+          'import os',
+          'calls = []',
+          '',
+          'class DataFunc:',
+          '    def StdFlr_Generate(self, height_mm, dead, live):',
+          '        calls.append({"method": "StdFlr_Generate", "height_mm": height_mm, "dead": dead, "live": live})',
+          '        return {"std_floor": len(calls)}',
+          '',
+          '    def ColSect_Def(self, mat, kind, shape_val, name):',
+          '        calls.append({"method": "ColSect_Def", "mat": mat, "kind": kind, "shape_val": shape_val, "name": name})',
+          '        return {"id": "col-section"}',
+          '',
+          '    def BeamSect_Def(self, mat, kind, shape_val, name):',
+          '        calls.append({"method": "BeamSect_Def", "mat": mat, "kind": kind, "shape_val": shape_val, "name": name})',
+          '        return {"id": "beam-section"}',
+          '',
+          '    def node_generate(self, xspans, yspans, std_flr):',
+          '        calls.append({"method": "node_generate", "xspans": xspans, "yspans": yspans})',
+          '        return [[f"N{row}_{col}" for col in range(len(xspans))] for row in range(len(yspans))]',
+          '',
+          '    def column_arrange(self, nodelist, section):',
+          '        calls.append({"method": "column_arrange", "section": section})',
+          '        return [[1, 2], [3, 4]]',
+          '',
+          '    def grid_generate(self, nodelist, dx, dy):',
+          '        calls.append({"method": "grid_generate", "dx": dx, "dy": dy})',
+          '        return {"direction": "x" if dx == 0 and dy == 1 else "y"}',
+          '',
+          '    def beam_arrange(self, grid, section):',
+          '        calls.append({"method": "beam_arrange", "grid": grid, "section": section})',
+          '        return [[101], [102]] if grid.get("direction") == "x" else [[201], [202]]',
+          '',
+          '    def Floors_Assemb(self, start_mm, std_flr, count, height_mm):',
+          '        calls.append({"method": "Floors_Assemb", "start_mm": start_mm, "count": count, "height_mm": height_mm})',
+          '',
+          '    def DbModel_Assign(self):',
+          '        calls.append({"method": "DbModel_Assign"})',
+          '',
+          '    def GetDbModelData(self):',
+          '        calls.append({"method": "GetDbModelData"})',
+          '        return {"model": "stub"}',
+          '',
+          'class Hi_AddToAndReadYjk:',
+          '    def __init__(self, model):',
+          '        self.model = model',
+          '        calls.append({"method": "Hi_AddToAndReadYjk", "model": model})',
+          '',
+          '    def CreateYDB(self, work_dir, filename):',
+          '        calls.append({"method": "CreateYDB", "filename": filename})',
+          '        with open(os.path.join(work_dir, filename), "w", encoding="utf-8") as f:',
+          '            f.write("stub ydb")',
+          '',
+        ].join('\n'),
+      );
+
+      const model = {
+        schema_version: '2.0.0',
+        unit_system: 'SI',
+        project: { name: 'rc_frame_test', extra: { designCode: 'GB50010' } },
+        materials: [
+          { id: '1', name: 'C30', grade: 'C30', category: 'concrete', E: 30000, fc: 14.3 },
+          { id: '2', name: 'HRB400', grade: 'HRB400', category: 'rebar', fy: 360 },
+        ],
+        sections: [
+          {
+            id: '1',
+            name: '400X400',
+            type: 'rectangular',
+            purpose: 'column',
+            width: 400,
+            height: 400,
+            shape: { kind: 'rectangular', B: 400, H: 400 },
+          },
+          {
+            id: '2',
+            name: '250X600',
+            type: 'rectangular',
+            purpose: 'beam',
+            width: 250,
+            height: 600,
+            shape: { kind: 'rectangular', B: 250, H: 600 },
+          },
+        ],
+        nodes: [
+          { id: 'N0_0', x: 0, y: 0, z: 0 },
+          { id: 'N0_1', x: 6, y: 0, z: 0 },
+          { id: 'N1_0', x: 0, y: 0, z: 3, story: 'F1' },
+          { id: 'N1_1', x: 6, y: 0, z: 3, story: 'F1' },
+        ],
+        elements: [
+          { id: 'C1', type: 'column', nodes: ['N0_0', 'N1_0'], material: '1', section: '1', story: 'F1' },
+          { id: 'C2', type: 'column', nodes: ['N0_1', 'N1_1'], material: '1', section: '1', story: 'F1' },
+          { id: 'B3', type: 'beam', nodes: ['N1_0', 'N1_1'], material: '1', section: '2', story: 'F1' },
+        ],
+        stories: [
+          {
+            id: 'F1',
+            height: 3,
+            elevation: 0,
+            floor_loads: [{ type: 'dead', value: 16.67 }],
+          },
+        ],
+      };
+
+      const script = [
+        'import json, os, sys',
+        `sys.path.insert(0, ${JSON.stringify(stubsDir)})`,
+        `sys.path.insert(1, ${JSON.stringify(converterDir)})`,
+        'import yjk_converter',
+        'from YJKAPI import calls',
+        'model = json.loads(sys.stdin.read())',
+        `work_dir = ${JSON.stringify(workDir)}`,
+        'ydb_path = yjk_converter.convert_v2_to_ydb(model, work_dir, "rc.ydb")',
+        'with open(os.path.join(work_dir, "mapping.json"), "r", encoding="utf-8") as f:',
+        '    mapping = json.load(f)',
+        'print(json.dumps({"ydbExists": os.path.exists(ydb_path), "calls": calls, "mapping": mapping}, ensure_ascii=False))',
+      ].join('\n');
+
+      const result = spawnSync(
+        pythonCommand.executable,
+        [...pythonCommand.args, '-c', script],
+        {
+          input: JSON.stringify(model),
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PYTHONPATH: [stubsDir, converterDir, process.env.PYTHONPATH]
+              .filter(Boolean)
+              .join(path.delimiter),
+          },
+          windowsHide: process.platform === 'win32',
+        },
+      );
+
+      if (result.status !== 0) {
+        throw new Error(`converter failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+      }
+
+      const payloadLine = result.stdout
+        .trim()
+        .split(/\r?\n/)
+        .reverse()
+        .find((line) => line.trim().startsWith('{'));
+      expect(payloadLine).toBeTruthy();
+      const payload = JSON.parse(payloadLine);
+      const colSectionCall = payload.calls.find((call) => call.method === 'ColSect_Def');
+      const beamSectionCall = payload.calls.find((call) => call.method === 'BeamSect_Def');
+
+      expect(payload.ydbExists).toBe(true);
+      expect(colSectionCall).toMatchObject({
+        mat: 6,
+        kind: 1,
+        shape_val: '400,400',
+        name: '400X400',
+      });
+      expect(beamSectionCall).toMatchObject({
+        mat: 6,
+        kind: 1,
+        shape_val: '250,600',
+        name: '250X600',
+      });
+      expect(payload.calls.map((call) => call.method)).toEqual(expect.arrayContaining([
+        'node_generate',
+        'column_arrange',
+        'beam_arrange',
+        'Floors_Assemb',
+        'CreateYDB',
+      ]));
+      expect(payload.mapping.sections['1']).toMatchObject({
+        role: 'column',
+        yjk_mat_type: 6,
+        yjk_kind: 1,
+        shape_val: '400,400',
+      });
+      expect(payload.mapping.sections['2']).toMatchObject({
+        role: 'beam',
+        yjk_mat_type: 6,
+        yjk_kind: 1,
+        shape_val: '250,600',
+      });
+    } finally {
+      fs.rmSync(stubsDir, { recursive: true, force: true });
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: YJK frame generation did not cover reinforced-concrete frame prompts end-to-end, and Chinese prompts using `Z向` as the second plan direction could be parsed as steel/default frame geometry with incorrect spans.
- Why it matters: The user-visible workflow could create a steel I-section beam where an RC rectangular beam was requested, and could send the wrong grid to YJK.
- What changed: Added a YJK RC frame design flow, improved RC and steel frame natural-language extraction for X/Z span phrasing, kept explicit RC prompts out of the generic steel frame detector, and fixed YJK authorization-failure detection when a reused/previous `yjks.exe` process owns the failure window.
- What did NOT change (scope boundary): No frontend UI changes, no public API contract changes, and no changes to unrelated analysis engines.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: RC frame extraction only treated Y-direction evidence as the second plan axis, while user prompts and YJK-style descriptions can use `Z向` for the second horizontal direction. The generic frame detector could also claim explicit reinforced-concrete prompts before the RC flow produced a concrete model.
- Missing detection / guardrail: There was no regression case for `两层钢筋混凝土框架...X向2跨每跨6.0m，Z向1跨6.0m...梁截面500x250` verifying concrete rectangular sections and grid dimensions.
- Prior context (`git blame`, prior PR, issue, or refactor if known): YJK launcher authorization prewarm was introduced previously, but the direct-launch watcher filtered out pre-existing PIDs before checking whether they displayed `授权检测失败`.
- Why this regressed now: Interrupted or repeated YJK runs can leave/reuse a `yjks.exe` process whose authorization-failure window is present before the next direct-launch watch starts; that window was skipped as an old PID, so the driver proceeded to `UINew` and could hang.
- If unknown, what was ruled out: The YJK converter was ruled out for the RC section issue; successful mapping now shows `600,600` column and `500,250` beam with concrete YJK material/kind.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs`, `backend/src/agent-skills/structure-type/frame/__tests__/skill-core.test.mjs`, `backend/tests/analysis-yjk-driver-auth.test.mjs`.
- Scenario the test should lock in: Exact RC prompt with X/Z spans builds a 3D concrete frame with rectangular beam/column sections; steel frame extraction treats Z span context as the second plan direction; YJK auth detection catches `授权检测失败` even when it belongs to a reused PID.
- Why this is the smallest reliable guardrail: These tests isolate parser/detector behavior and the YJK launch-state watcher without requiring a live YJK GUI run in CI.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Users can now request a YJK reinforced-concrete frame with Chinese X/Z span phrasing and get an RC rectangular-section frame with the intended grid. YJK runs are less likely to hang after an authorization failure because the driver detects the failure and retries through launcher prewarm.

## Diagram (if applicable)

```text
Before:
RC prompt with Z spans -> generic/partial frame parsing -> steel or wrong grid -> YJK import
YJK direct launch -> reused auth-failure window skipped -> UINew hang

After:
RC prompt with Z spans -> concrete-frame parser -> RC rectangular sections + correct grid -> YJK import
YJK direct launch -> auth-failure window detected -> launcher prewarm -> direct retry -> analysis
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows, PowerShell
- Runtime/container: Local backend Node/Jest plus local YJK 8.0.0 Python runtime
- Model/provider: N/A for deterministic parser and YJK runtime verification
- Integration/channel (if any): YJK static analysis integration
- Relevant config (redacted): `YJK_LAUNCHER_PREWARM=auto`, `YJK_DIRECT_READY_TIMEOUT_S=12`, local `LLM_API_KEY` cleared for the full Jest run that assumes no env fallback

### Steps

1. Submit: `我想设计一个两层钢筋混凝土框架，用YJK计算，X向2跨每跨6.0m，Z向1跨6.0m，层高3.6m×2层。柱截面600x600，梁截面500x250，柱脚刚接，梁柱刚接。具体配筋你来设计`
2. Build the RC frame draft/model and run YJK analysis.
3. Inspect generated YJK mapping, launch steps, and backend regression tests.

### Expected

- 2-story 3D RC frame, X spans `0,6000,12000`, second plan direction `0,6000`, column `600X600`, beam `500X250`, concrete rectangular YJK sections.
- If direct YJK launch hits `授权检测失败`, the driver closes the failed session, prewarms through `YjkLauncher.exe`, retries, and proceeds.

### Actual

- Matches expected in manual YJK verification: 18 nodes, 26 elements, 2 floors analyzed, max displacement about `0.0015`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Manual YJK launch trace after the fix:

```text
RunYJK (direct): warning, launch_state=auth_failed, window_title=授权检测失败
Close failed direct YJK session: success
Prewarm YJK launcher authorization: success
RunYJK (after-launcher-prewarm): success
status=success, nodeCount=18, elementCount=26, floorsAnalyzed=2
```

Verification commands run:

```text
npm run build --prefix backend
npm run lint --prefix backend
npm test --prefix backend -- --runInBand tests/analysis-yjk-driver-auth.test.mjs src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs src/agent-skills/structure-type/frame/__tests__/skill-core.test.mjs
Remove-Item Env:LLM_API_KEY -ErrorAction SilentlyContinue; npm test --prefix backend -- --runInBand
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Exact user RC prompt parses as 3D concrete frame with 2 X bays, 1 Z/Y bay, repeated 3.6m story heights, `600X600` columns, and `500X250` beams; steel frame Z-direction span parsing still works; explicit RC prompts are not claimed by the generic steel frame detector; YJK authorization prewarm path completes a full analysis.
- Edge cases checked: Reused/old PID carrying an authorization-failure title; direct launch after launcher prewarm with blank window title but usable IPC session; local `LLM_API_KEY` env affecting unrelated settings tests.
- What you did **not** verify: Frontend UI flows and non-YJK engines, because this PR does not change them.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Treating all visible `授权检测失败` YJK windows as blocking could stop a run if the user intentionally keeps a failed YJK session open beside another valid session.
  - Mitigation: This is the safer default for automated YJK control; the driver closes failed direct sessions and proceeds through the existing launcher-prewarm recovery path.