### PR TITLE
fix(agent): raise configurable tool call limit

### DIFF
--- a/backend/src/agent-langgraph/graph.ts
+++ b/backend/src/agent-langgraph/graph.ts
@@ -42,7 +42,7 @@ function getAgentLogger(config: LangGraphRunnableConfig) {
 // Max ReAct iterations guard
 // ---------------------------------------------------------------------------
 
-export const DEFAULT_MAX_TOOL_CALLS_PER_TURN = 15;
+export const DEFAULT_MAX_TOOL_CALLS_PER_TURN = 200;
 
 function getMessageType(message: BaseMessage): string | null {
   return typeof (message as any)._getType === 'function'

--- a/backend/src/api/admin-settings.ts
+++ b/backend/src/api/admin-settings.ts
@@ -165,7 +165,7 @@ function buildSettingsResponse(): SettingsResponse {
     allowShell: false,
     allowedShellCommands: 'node,npm,python,python3,./sclaw,./sclaw_cn',
     shellTimeoutMs: 300000,
-    agentMaxToolCallsPerTurn: 15,
+    agentMaxToolCallsPerTurn: 200,
     pkpmCyclePath: '',
     pkpmWorkDir: path.join(runtimeBaseDir, 'analysis', 'pkpm'),
     yjkInstallRoot: '',

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -73,7 +73,7 @@ const AGENT_DEFAULTS = {
   allowShell: false,
   allowedShellCommands: 'node,npm,python,python3,./sclaw,./sclaw_cn',
   shellTimeoutMs: 300000,
-  maxToolCallsPerTurn: 15,
+  maxToolCallsPerTurn: 200,
 } as const;
 
 const PKPM_DEFAULTS = {

--- a/backend/tests/agent-tool-call-limit.test.mjs
+++ b/backend/tests/agent-tool-call-limit.test.mjs
@@ -1,0 +1,19 @@
+import { describe, expect, test } from '@jest/globals';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+
+describe('agent tool call limit defaults', () => {
+  test('defaults maxToolCallsPerTurn to 200 across backend and frontend settings', () => {
+    const configSource = fs.readFileSync(path.join(ROOT, 'src/config/index.ts'), 'utf8');
+    const adminSettingsSource = fs.readFileSync(path.join(ROOT, 'src/api/admin-settings.ts'), 'utf8');
+    const graphSource = fs.readFileSync(path.join(ROOT, 'src/agent-langgraph/graph.ts'), 'utf8');
+    const frontendSettingsSource = fs.readFileSync(path.join(ROOT, '../frontend/src/components/settings/general-settings-panel.tsx'), 'utf8');
+
+    expect(configSource).toContain('maxToolCallsPerTurn: 200');
+    expect(adminSettingsSource).toContain('agentMaxToolCallsPerTurn: 200');
+    expect(graphSource).toContain('DEFAULT_MAX_TOOL_CALLS_PER_TURN = 200');
+    expect(frontendSettingsSource).toContain('maxToolCallsPerTurn: 200');
+  });
+});

--- a/backend/tests/agent-tool-call-limit.test.mjs
+++ b/backend/tests/agent-tool-call-limit.test.mjs
@@ -1,8 +1,10 @@
 import { describe, expect, test } from '@jest/globals';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const ROOT = process.cwd();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
 
 describe('agent tool call limit defaults', () => {
   test('defaults maxToolCallsPerTurn to 200 across backend and frontend settings', () => {

--- a/frontend/src/components/settings/general-settings-panel.tsx
+++ b/frontend/src/components/settings/general-settings-panel.tsx
@@ -117,7 +117,7 @@ const DEFAULTS: Record<string, string | number | boolean> = {
   pythonBin: '', pythonTimeoutMs: 600000, engineManifestPath: '',
   reportsDir: '', maxFileSize: 104857600,
   origins: '',
-  workspaceRoot: '', checkpointDir: '', allowShell: false, allowedShellCommands: 'node,npm,python,python3,./sclaw,./sclaw_cn', shellTimeoutMs: 300000, maxToolCallsPerTurn: 15,
+  workspaceRoot: '', checkpointDir: '', allowShell: false, allowedShellCommands: 'node,npm,python,python3,./sclaw,./sclaw_cn', shellTimeoutMs: 300000, maxToolCallsPerTurn: 200,
   pkpmCyclePath: '', pkpmWorkDir: '',
   yjkInstallRoot: '', yjkExePath: '', yjkPythonBin: '', yjkSdkArchivePath: '', yjkWorkDir: '', yjkVersion: '8.0.0', yjkTimeoutS: 600, yjkInvisible: false,
   yjkLauncherPrewarm: 'auto', yjkLauncherPrewarmS: 18, yjkDirectReadyTimeoutS: 12,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: The agent still defaulted to a low per-turn tool-call cap of 15, which can prematurely stop longer multi-step tool workflows.
- Why it matters: Users already have a settings field for `agent.maxToolCallsPerTurn`, but the default cap made complex workflows hit the guardrail before completing.
- What changed: Raised the backend, graph, admin-settings, and frontend fallback default for `maxToolCallsPerTurn` from 15 to 200, while preserving the existing user-configurable settings path.
- What did NOT change (scope boundary): No detached-house API/tool changes, no new tools, no new permissions, and no changes to the allowed 1-200 settings validation range.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The low default was still hardcoded in multiple fallback/default locations even though the setting was user-configurable.
- Missing detection / guardrail: There was no test ensuring backend graph defaults, admin settings defaults, config defaults, and frontend fallback defaults stayed aligned.
- Prior context (`git blame`, prior PR, issue, or refactor if known): This was isolated from the larger `feat/detached-house-api-tools` branch to avoid pulling in unrelated detached-house changes.
- Why this regressed now: Longer agent workflows need more tool calls per turn than the old 15-call default allows.
- If unknown, what was ruled out: No API schema change was needed; the settings field and validation range already existed.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/tests/agent-tool-call-limit.test.mjs`
- Scenario the test should lock in: Backend config default, admin settings response default, graph fallback default, and frontend settings fallback all remain `200`.
- Why this is the smallest reliable guardrail: The change is default/config alignment, so a focused source-level test catches drift without involving a live LLM run.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Default max tool calls per conversation turn is now 200 instead of 15. Users can still set `agent.maxToolCallsPerTurn` themselves in General Settings within the existing 1-200 range.

## Diagram (if applicable)

```text
Before:
agent turn -> default maxToolCallsPerTurn=15 -> complex workflow may stop early

After:
agent turn -> default maxToolCallsPerTurn=200 -> user can lower/adjust in settings
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: The existing per-turn tool-call guardrail is raised from 15 to 200 by default, but it remains bounded by the existing max validation and uses the same already-configured tool permissions. Users can lower the value in settings.

## Repro + Verification

### Environment

- OS: Windows, PowerShell
- Runtime/container: Local Node backend/frontend tooling
- Model/provider: N/A
- Integration/channel (if any): Agent LangGraph runtime settings
- Relevant config (redacted): default settings only

### Steps

1. Start from current `master`.
2. Inspect General Settings and backend defaults for `agent.maxToolCallsPerTurn`.
3. Run targeted backend and frontend validation.

### Expected

- Defaults are aligned at 200 across backend runtime, graph fallback, admin settings response, and frontend settings fallback.
- Users can still configure the value through the existing settings UI/API.

### Actual

- Defaults are aligned at 200 and tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run:

```text
npm test --prefix backend -- --runInBand tests/agent-tool-call-limit.test.mjs
npm run lint --prefix backend
npm run type-check --prefix frontend
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Confirmed this branch only changes the max tool-call default/fallback locations and adds a focused regression test.
- Edge cases checked: Confirmed the settings UI already exposes `agent.maxToolCallsPerTurn` and the admin API validation remains bounded at `min(1).max(200)`.
- What you did **not** verify: Live LLM multi-tool workflow execution, because this PR only changes configuration defaults and fallback values.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: No migration needed. Existing `settings.json` values continue to override the new default.

## Risks and Mitigations

- Risk: More tool calls can increase runtime and cost for complex turns.
  - Mitigation: The value remains bounded to 200 and user-configurable; existing selected-tool and permission controls still apply.