### PR TITLE
feat(backend): support PKPM RC design conditions

### DIFF
--- a/backend/src/agent-runtime/types.ts
+++ b/backend/src/agent-runtime/types.ts
@@ -16,6 +16,37 @@ export interface DraftFloorLoad {
   lateralYKN?: number;
 }
 
+export interface DraftSiteSeismicParams {
+  intensity?: number;
+  accelerationG?: number;
+  designGroup?: string;
+  siteCategory?: string;
+  characteristicPeriod?: number;
+  maxInfluenceCoefficient?: number;
+  dampingRatio?: number;
+}
+
+export interface DraftWindParams {
+  basicPressureKNM2?: number;
+  terrainRoughness?: 'A' | 'B' | 'C' | 'D';
+  shapeFactor?: number;
+  heightVariationFactor?: number;
+}
+
+export interface DraftAnalysisControl {
+  pDelta?: boolean;
+  rigidFloor?: boolean;
+  periodReductionFactor?: number;
+  accidentalEccentricity?: number;
+  considerationTorsion?: boolean;
+  modalCount?: number;
+  basementCount?: number;
+  liveLoadReduction?: boolean;
+  structureImportanceFactor?: number;
+  dampingRatioWind?: number;
+  designParams?: Record<string, unknown>;
+}
+
 export type InferredModelType = 'beam' | 'truss' | 'portal-frame' | 'double-span-beam' | 'frame' | 'unknown';
 export type StructuralTypeKey =
   | 'beam'
@@ -72,6 +103,9 @@ export interface DraftState {
   frameRebarGrade?: string;
   frameColumnSection?: string;
   frameBeamSection?: string;
+  siteSeismic?: DraftSiteSeismicParams;
+  wind?: DraftWindParams;
+  analysisControl?: DraftAnalysisControl;
   loadKN?: number;
   loadType?: DraftLoadType;
   loadPosition?: DraftLoadPosition;
@@ -107,6 +141,9 @@ export interface DraftExtraction {
   frameRebarGrade?: string;
   frameColumnSection?: string;
   frameBeamSection?: string;
+  siteSeismic?: DraftSiteSeismicParams;
+  wind?: DraftWindParams;
+  analysisControl?: DraftAnalysisControl;
   loadKN?: number;
   loadType?: DraftLoadType;
   loadPosition?: DraftLoadPosition;

--- a/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
@@ -64,6 +64,10 @@ _STEEL_GRADE_RE = re.compile(r"^[SQ]\d{3}", re.IGNORECASE)
 _CONCRETE_GRADE_TOKEN_RE = re.compile(r"\bC\d{1,2}\b", re.IGNORECASE)
 
 
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
 def _detect_material_family(data: dict) -> str:
     """Detect dominant material from model: 'steel' or 'concrete'."""
     metadata = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
@@ -588,6 +592,10 @@ def _configure_satwe_params(
         mapping = {"A": 1.0, "B": 2.0, "C": 3.0, "D": 4.0}
         return mapping.get(text)
 
+    site_seismic = _as_dict(site_seismic)
+    wind = _as_dict(wind)
+    analysis_control = _as_dict(analysis_control)
+
     if site_seismic:
         intensity = _as_float(site_seismic.get("intensity"))
         site_category = _site_category_code(site_seismic.get("site_category"))
@@ -648,13 +656,9 @@ def _configure_satwe_params(
         if importance_factor is not None:
             design_param_updates[2] = importance_factor
 
-    explicit_design_params = (
-        ((analysis_control or {}).get("design_params") or {})
-        if isinstance((analysis_control or {}).get("design_params"), dict)
-        else {}
-    )
-    pkpm_design_params = explicit_design_params.get("pkpm") if isinstance(explicit_design_params.get("pkpm"), dict) else {}
-    satwe_indices = pkpm_design_params.get("satwe_indices") if isinstance(pkpm_design_params.get("satwe_indices"), dict) else {}
+    explicit_design_params = _as_dict(analysis_control.get("design_params"))
+    pkpm_design_params = _as_dict(explicit_design_params.get("pkpm"))
+    satwe_indices = _as_dict(pkpm_design_params.get("satwe_indices"))
     for raw_index, raw_value in satwe_indices.items():
         try:
             index = int(raw_index)
@@ -786,11 +790,14 @@ def convert_v2_to_jws(
         mat_id_to_grade[mat["id"]] = grade
 
     # ---- Design parameters from V2 model ----
-    site_seismic = data.get("site_seismic") or {}
-    structure_system = data.get("structure_system") or {}
-    analysis_control = data.get("analysis_control") or {}
-    wind = data.get("wind") or {}
-    damping_ratio = float(site_seismic.get("damping_ratio", 0.0))
+    site_seismic = _as_dict(data.get("site_seismic"))
+    structure_system = _as_dict(data.get("structure_system"))
+    analysis_control = _as_dict(data.get("analysis_control"))
+    wind = _as_dict(data.get("wind"))
+    try:
+        damping_ratio = float(site_seismic.get("damping_ratio", 0.0))
+    except (TypeError, ValueError):
+        damping_ratio = 0.0
 
     # ---- Sections ----
     sec_registry = _build_section_registry(model, data.get("sections", []), data, material_family)

--- a/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
@@ -513,6 +513,9 @@ def _build_plan_nodes(
 def _configure_satwe_params(
     model: APIPyInterface.Model,
     material_family: str,
+    site_seismic: dict[str, Any] | None = None,
+    wind: dict[str, Any] | None = None,
+    analysis_control: dict[str, Any] | None = None,
 ) -> None:
     """Set SATWE design parameters via ProjectPara (KIND field codes).
 
@@ -533,6 +536,88 @@ def _configure_satwe_params(
     para.SetParaInt(101, 10101)
 
     model.SaveProjectPara()
+
+    # APIPyInterface exposes SATWE calculation controls as a numeric design
+    # parameter vector. The indices below are adapter-local mappings verified
+    # against the installed API defaults via GetOneDesignParaValue().
+    design_param_updates: dict[int, float] = {}
+
+    def _as_float(value: Any) -> float | None:
+        try:
+            if value is None:
+                return None
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _design_group_code(value: Any) -> float | None:
+        text = str(value or "")
+        if "1" in text or "一" in text:
+            return 1.0
+        if "2" in text or "二" in text or "两" in text:
+            return 2.0
+        if "3" in text or "三" in text:
+            return 3.0
+        return None
+
+    def _site_category_code(value: Any) -> float | None:
+        text = str(value or "").strip().upper().replace("类", "")
+        mapping = {
+            "1": 1.0, "一": 1.0, "I": 1.0,
+            "2": 2.0, "二": 2.0, "两": 2.0, "II": 2.0,
+            "3": 3.0, "三": 3.0, "III": 3.0,
+            "4": 4.0, "四": 4.0, "IV": 4.0,
+        }
+        return mapping.get(text)
+
+    if site_seismic:
+        intensity = _as_float(site_seismic.get("intensity"))
+        site_category = _site_category_code(site_seismic.get("site_category"))
+        design_group = _design_group_code(site_seismic.get("design_group"))
+        if design_group is None:
+            characteristic_period = _as_float(site_seismic.get("characteristic_period"))
+            if site_category == 3.0 and characteristic_period is not None and characteristic_period >= 0.64:
+                design_group = 3.0
+            elif site_category == 2.0 and characteristic_period is not None and characteristic_period >= 0.44:
+                design_group = 3.0
+            elif characteristic_period is not None and characteristic_period >= 0.54:
+                design_group = 2.0
+        if intensity is not None:
+            design_param_updates[25] = intensity
+        if site_category is not None:
+            design_param_updates[27] = site_category
+        if design_group is not None:
+            design_param_updates[31] = design_group
+
+    if wind:
+        basic_pressure = _as_float(wind.get("basic_pressure"))
+        shape_factor = _as_float(wind.get("shape_factor"))
+        if basic_pressure is not None:
+            design_param_updates[33] = basic_pressure
+        if shape_factor is not None:
+            design_param_updates[37] = shape_factor
+
+    explicit_design_params = (
+        ((analysis_control or {}).get("design_params") or {})
+        if isinstance((analysis_control or {}).get("design_params"), dict)
+        else {}
+    )
+    pkpm_design_params = explicit_design_params.get("pkpm") if isinstance(explicit_design_params.get("pkpm"), dict) else {}
+    satwe_indices = pkpm_design_params.get("satwe_indices") if isinstance(pkpm_design_params.get("satwe_indices"), dict) else {}
+    for raw_index, raw_value in satwe_indices.items():
+        try:
+            index = int(raw_index)
+        except (TypeError, ValueError):
+            continue
+        value = _as_float(raw_value)
+        if value is not None:
+            design_param_updates[index] = value
+
+    for index, value in sorted(design_param_updates.items()):
+        try:
+            model.SetOneDesignParaValue(index, value)
+        except Exception as exc:
+            sys.stderr.write(f"[pkpm_converter] SetOneDesignParaValue({index}, {value}) failed: {exc}\n")
 
 
 def _log_design_params(model: APIPyInterface.Model) -> None:
@@ -618,6 +703,7 @@ def convert_v2_to_jws(
     site_seismic = data.get("site_seismic") or {}
     structure_system = data.get("structure_system") or {}
     analysis_control = data.get("analysis_control") or {}
+    wind = data.get("wind") or {}
     damping_ratio = float(site_seismic.get("damping_ratio", 0.0))
 
     # ---- Sections ----
@@ -762,7 +848,7 @@ def convert_v2_to_jws(
         model.AddNaturalFloor(rf)
 
     # ---- Configure SATWE design parameters ----
-    _configure_satwe_params(model, material_family)
+    _configure_satwe_params(model, material_family, site_seismic, wind, analysis_control)
     if os.environ.get("PKPM_DEBUG_PARAMS"):
         _log_design_params(model)
 
@@ -774,4 +860,9 @@ def convert_v2_to_jws(
         "stories": stories,
         "normalization": normalization,
         "material_family": material_family,
+        "design_conditions": {
+            "site_seismic": site_seismic,
+            "wind": wind,
+            "analysis_control": analysis_control,
+        },
     }

--- a/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
@@ -517,12 +517,26 @@ def _configure_satwe_params(
     wind: dict[str, Any] | None = None,
     analysis_control: dict[str, Any] | None = None,
 ) -> None:
-    """Set SATWE design parameters via ProjectPara (KIND field codes).
+    """Set PMCAD/SATWE design parameters through the official API.
 
-    KIND field codes (from PKPM结构数据字段说明):
-      101 = 结构体系: 10101=框架, 10113=钢框架-中心支撑, 10114=钢框架-偏心支撑, ...
-      102 = 结构所在地区: 10201=全国, 10202=广东, ...
-      103 = 结构材料: 10301=钢筋混凝土, 10302=钢砼混合, 10303=钢结构, 10304=砌体
+    `GetAllDesignPara` / `SetAllDesignPara` indices are defined in
+    PKPMAPI5.0参考手册, "楼层-设计参数":
+      24 = 设计地震分组
+      25 = 地震烈度
+      26 = 场地类别
+      30 = 计算振型个数
+      31 = 周期折减系数
+      33 = 修正后的基本风压
+      34 = 地面粗糙度类别
+      35/36/37 = 体型变化分段数 / 第一段最高层号 / 第一段体型系数
+
+    Some SATWE control values such as Tg and alpha max are persisted through
+    PMProjectPara field ids from PKPM结构数据SQLite化数据表及字段说明:
+      312 = 特征周期Tg
+      313 = 多遇地震影响系数最大值
+    The installed API stores 301/303 as compact internal values:
+      301 = 0/1/2 for 第一/第二/第三组
+      303 = 0/1/2/3/4 for I0/I1/II/III/IV
     """
     para = model.GetProjectPara()
 
@@ -537,9 +551,8 @@ def _configure_satwe_params(
 
     model.SaveProjectPara()
 
-    # APIPyInterface exposes SATWE calculation controls as a numeric design
-    # parameter vector. The indices below are adapter-local mappings verified
-    # against the installed API defaults via GetOneDesignParaValue().
+    project_para_updates_int: dict[int, int] = {}
+    project_para_updates_double: dict[int, float] = {}
     design_param_updates: dict[int, float] = {}
 
     def _as_float(value: Any) -> float | None:
@@ -570,6 +583,11 @@ def _configure_satwe_params(
         }
         return mapping.get(text)
 
+    def _terrain_roughness_code(value: Any) -> float | None:
+        text = str(value or "").strip().upper().replace("类", "")
+        mapping = {"A": 1.0, "B": 2.0, "C": 3.0, "D": 4.0}
+        return mapping.get(text)
+
     if site_seismic:
         intensity = _as_float(site_seismic.get("intensity"))
         site_category = _site_category_code(site_seismic.get("site_category"))
@@ -585,17 +603,50 @@ def _configure_satwe_params(
         if intensity is not None:
             design_param_updates[25] = intensity
         if site_category is not None:
-            design_param_updates[27] = site_category
+            design_param_updates[26] = site_category
+            project_para_updates_int[303] = int(site_category)
         if design_group is not None:
-            design_param_updates[31] = design_group
+            design_param_updates[24] = design_group
+            project_para_updates_int[301] = max(int(design_group) - 1, 0)
+        characteristic_period = _as_float(site_seismic.get("characteristic_period"))
+        if characteristic_period is not None:
+            project_para_updates_double[312] = characteristic_period
+        max_influence_coefficient = _as_float(site_seismic.get("max_influence_coefficient"))
+        if max_influence_coefficient is not None:
+            project_para_updates_double[313] = max_influence_coefficient
+        damping_ratio = _as_float(site_seismic.get("damping_ratio"))
+        if damping_ratio is not None:
+            project_para_updates_double[311] = damping_ratio * 100 if damping_ratio <= 1 else damping_ratio
 
     if wind:
         basic_pressure = _as_float(wind.get("basic_pressure"))
         shape_factor = _as_float(wind.get("shape_factor"))
+        terrain_roughness = _terrain_roughness_code(wind.get("terrain_roughness"))
         if basic_pressure is not None:
             design_param_updates[33] = basic_pressure
+            project_para_updates_double[202] = basic_pressure
+        if terrain_roughness is not None:
+            design_param_updates[34] = terrain_roughness
+            project_para_updates_int[201] = int(terrain_roughness)
         if shape_factor is not None:
+            design_param_updates[35] = 1.0
             design_param_updates[37] = shape_factor
+
+    if analysis_control:
+        modal_count = _as_float(analysis_control.get("modal_count"))
+        if modal_count is not None:
+            design_param_updates[30] = modal_count
+            project_para_updates_int[308] = int(modal_count)
+        period_reduction = _as_float(analysis_control.get("period_reduction_factor"))
+        if period_reduction is not None:
+            design_param_updates[31] = period_reduction
+            project_para_updates_double[310] = period_reduction
+        basement_count = _as_float(analysis_control.get("basement_count"))
+        if basement_count is not None:
+            design_param_updates[4] = basement_count
+        importance_factor = _as_float(analysis_control.get("structure_importance_factor"))
+        if importance_factor is not None:
+            design_param_updates[2] = importance_factor
 
     explicit_design_params = (
         ((analysis_control or {}).get("design_params") or {})
@@ -612,6 +663,41 @@ def _configure_satwe_params(
         value = _as_float(raw_value)
         if value is not None:
             design_param_updates[index] = value
+
+    for key, value in sorted(project_para_updates_int.items()):
+        try:
+            para.SetParaInt(key, value)
+        except Exception as exc:
+            sys.stderr.write(f"[pkpm_converter] ProjectPara.SetParaInt({key}, {value}) failed: {exc}\n")
+    for key, value in sorted(project_para_updates_double.items()):
+        try:
+            para.SetParaDouble(key, value)
+        except Exception as exc:
+            sys.stderr.write(f"[pkpm_converter] ProjectPara.SetParaDouble({key}, {value}) failed: {exc}\n")
+    if project_para_updates_int or project_para_updates_double:
+        try:
+            model.SaveProjectPara()
+        except Exception as exc:
+            sys.stderr.write(f"[pkpm_converter] SaveProjectPara failed: {exc}\n")
+
+    if not design_param_updates:
+        return
+
+    try:
+        design_params = list(model.GetAllDesignPara())
+    except Exception:
+        design_params = []
+    if len(design_params) < 128:
+        design_params.extend([0.0] * (128 - len(design_params)))
+    for index, value in sorted(design_param_updates.items()):
+        if 0 <= index < len(design_params):
+            design_params[index] = value
+
+    try:
+        model.SetAllDesignPara(design_params)
+        return
+    except Exception as exc:
+        sys.stderr.write(f"[pkpm_converter] SetAllDesignPara failed: {exc}\n")
 
     for index, value in sorted(design_param_updates.items()):
         try:

--- a/backend/src/agent-skills/analysis/pkpm-static/runtime.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/runtime.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import subprocess
 import tempfile
 import uuid
@@ -165,6 +166,50 @@ def _read_satwe_params(result: Any) -> Dict[str, Any]:
     except Exception:
         pass
     return satwe_params
+
+
+def _read_wmass_design_params(project_dir: Path) -> Dict[str, Any]:
+    """Read actual SATWE design parameters printed in WMASS.OUT."""
+    path = project_dir / "WMASS.OUT"
+    if not path.is_file():
+        return {}
+    try:
+        text = path.read_bytes().decode("gb18030", errors="ignore")
+    except OSError:
+        return {}
+
+    def _match_float(pattern: str) -> float | None:
+        m = re.search(pattern, text)
+        return _safe_float(m.group(1), None) if m else None
+
+    def _match_text(pattern: str) -> str | None:
+        m = re.search(pattern, text)
+        return m.group(1).strip() if m else None
+
+    params: Dict[str, Any] = {}
+    for key, value in [
+        ("basic_wind_pressure", _match_float(r"WO\s*=\s*([\d.]+)")),
+        ("seismic_intensity", _match_float(r"NAF\s*=\s*([\d.]+)")),
+        ("mode_count", _match_float(r"NMODE\s*=\s*([\d.]+)")),
+        ("characteristic_period", _match_float(r"TG\s*=\s*([\d.]+)")),
+        ("max_influence_coefficient", _match_float(r"Rmax1\s*=\s*([\d.]+)")),
+        ("period_reduction_factor", _match_float(r"TC\s*=\s*([\d.]+)")),
+        ("damping_ratio", _match_float(r"DAMP\s*=\s*([\d.]+)")),
+        ("damping_ratio_percent", _match_float(r"DAMP\s*=\s*([\d.]+)")),
+    ]:
+        if value is not None:
+            params[key] = value
+
+    terrain = _match_text(r"地面粗糙程度:\s*([ABCD])\s*类")
+    if terrain:
+        params["terrain_roughness"] = terrain
+    site_category = _match_text(r"场地类别:\s*KD\s*=\s*([A-Z0-9]+)")
+    if site_category:
+        params["site_category"] = site_category
+    design_group = _match_text(r"设计地震分组:\s*([一二三]组)")
+    if design_group:
+        params["design_group"] = design_group
+    return params
 
 
 def _extract_results(jws_path: Path, material_family: str = "steel") -> Dict[str, Any]:
@@ -394,6 +439,9 @@ def _extract_results(jws_path: Path, material_family: str = "steel") -> Dict[str
                 "limit_value": round(_safe_float(bs.GetLimitVal()), 4),
             })
 
+        satwe_params = _read_satwe_params(result)
+        satwe_params.update(_read_wmass_design_params(jws_path.parent))
+
         return {
             "mode_periods": mode_periods,
             "beam_count": len(beam_results),
@@ -413,7 +461,7 @@ def _extract_results(jws_path: Path, material_family: str = "steel") -> Dict[str
             "case_node_disps": case_node_disps,
             "case_beam_forces": case_beam_forces,
             "case_col_forces": case_col_forces,
-            "satwe_params": _read_satwe_params(result),
+            "satwe_params": satwe_params,
         }
     finally:
         result.ClearResult()

--- a/backend/src/agent-skills/analysis/pkpm-static/runtime.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/runtime.py
@@ -490,6 +490,7 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     node_disps = extracted.get("node_displacements", [])
     beams = extracted.get("beams", [])
     columns = extracted.get("columns", [])
+    design_conditions = converter_mappings.get("design_conditions", {})
 
     # ---- Build V2 node → PKPM (floor, pmid) mapping ----
     v2_to_pm: Dict[str, int] = converter_mappings.get("v2_to_pm", {})
@@ -831,6 +832,7 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
             "floors_analyzed": floors_analyzed,
             "beam_count": extracted.get("beam_count", 0),
             "column_count": extracted.get("column_count", 0),
+            "designConditions": design_conditions,
             **pkpm_summary,
         },
         "pkpm_detailed": {
@@ -842,6 +844,7 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
             "storey_stiffness": extracted.get("storey_stiffness", []),
             "bearing_shear": extracted.get("bearing_shear", []),
             "satwe_params": extracted.get("satwe_params", {}),
+            "input_design_conditions": design_conditions,
         },
         "caseResults": case_results,
         "envelopeTables": {

--- a/backend/src/agent-skills/analysis/pkpm-static/runtime.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/runtime.py
@@ -194,11 +194,13 @@ def _read_wmass_design_params(project_dir: Path) -> Dict[str, Any]:
         ("characteristic_period", _match_float(r"TG\s*=\s*([\d.]+)")),
         ("max_influence_coefficient", _match_float(r"Rmax1\s*=\s*([\d.]+)")),
         ("period_reduction_factor", _match_float(r"TC\s*=\s*([\d.]+)")),
-        ("damping_ratio", _match_float(r"DAMP\s*=\s*([\d.]+)")),
-        ("damping_ratio_percent", _match_float(r"DAMP\s*=\s*([\d.]+)")),
     ]:
         if value is not None:
             params[key] = value
+    damping = _match_float(r"DAMP\s*=\s*([\d.]+)")
+    if damping is not None:
+        params["damping_ratio"] = damping / 100.0 if damping > 1.0 else damping
+        params["damping_ratio_percent"] = damping if damping > 1.0 else damping * 100.0
 
     terrain = _match_text(r"地面粗糙程度:\s*([ABCD])\s*类")
     if terrain:

--- a/backend/src/agent-skills/report-export/calculation-book/pkpm-calcbook/__tests__/test_runtime.py
+++ b/backend/src/agent-skills/report-export/calculation-book/pkpm-calcbook/__tests__/test_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import sys
 import types
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -24,6 +25,7 @@ from runtime import (
     _extract_story_stiffness,
     _extract_stiff_weight_ratio,
     _generate_markdown,
+    _generate_pdf,
     _resolve_jws_path,
     run_analysis,
 )
@@ -63,6 +65,34 @@ def _make_column(**kwargs):
     c.GetSlenderRatio.return_value = kwargs.get("slender", [15.0])
     c.GetExceedLimitInfo.return_value = []
     return c
+
+
+def _decode_pdf_literal(value: bytes) -> str:
+    raw = bytearray()
+    i = 0
+    while i < len(value):
+        if value[i] == 0x5C:
+            octal = value[i + 1:i + 4]
+            if len(octal) == 3 and all(48 <= b <= 55 for b in octal):
+                raw.append(int(octal, 8))
+                i += 4
+                continue
+            if i + 1 < len(value):
+                raw.append(value[i + 1])
+                i += 2
+                continue
+        raw.append(value[i])
+        i += 1
+    data = bytes(raw)
+    try:
+        return data.decode("utf-16-be")
+    except UnicodeDecodeError:
+        return data.decode("latin-1", errors="ignore")
+
+
+def _extract_uncompressed_pdf_text(pdf_path: Path) -> str:
+    data = pdf_path.read_bytes()
+    return "\n".join(_decode_pdf_literal(value) for value in re.findall(rb"\((.*?)\)\s*Tj", data, flags=re.S))
 
 
 class TestResolveJwsPath:
@@ -184,6 +214,58 @@ class TestGenerateMarkdown:
         assert "# PKPM SATWE 结构计算书" in md
         assert "模态分析" in md
         assert "0.8" in md
+
+
+class TestGeneratePdf:
+    def test_includes_wmass_wind_and_seismic_parameters(self, tmp_path):
+        pytest.importorskip("reportlab")
+        import reportlab.rl_config
+
+        report = {
+            "detailed": {
+                "out_file_data": {
+                    "wmass_params": {
+                        "wind_info_params": "\n".join([
+                            "修正后的基本风压 (kN/m2):             WO     =   0.40",
+                            "地面粗糙程度:                         B 类",
+                        ]),
+                        "earthquake_params": "\n".join([
+                            "计算振型数:                           NMODE  =      6",
+                            "场地类别:                             KD     =III",
+                            "设计地震分组:                         三组",
+                            "特征周期:                             TG     =   0.65",
+                        ]),
+                    }
+                },
+                "modal_analysis": [],
+                "story_stiffness": [],
+                "story_drift": {"earthquake": {}, "wind": {}, "limit_value": None},
+                "base_shear": {"entries": [], "shear_weight_limit": None},
+                "story_mass": [],
+                "stiff_weight_ratio": {"entries": [], "limit_value": None},
+                "beam_design": {},
+                "column_design": {},
+                "code_exceedance": [],
+            }
+        }
+        output = tmp_path / "calcbook.pdf"
+        old_compression = reportlab.rl_config.pageCompression
+        reportlab.rl_config.pageCompression = 0
+        try:
+            _generate_pdf(report, output)
+        finally:
+            reportlab.rl_config.pageCompression = old_compression
+
+        text = _extract_uncompressed_pdf_text(output)
+        assert "风荷载参数" in text
+        assert "WO" in text
+        assert "0.40" in text
+        assert "B 类" in text
+        assert "地震参数" in text
+        assert "NMODE" in text
+        assert "III" in text
+        assert "三组" in text
+        assert "0.65" in text
 
 
 class TestRunAnalysis:

--- a/backend/src/agent-skills/report-export/calculation-book/pkpm-calcbook/report_render.py
+++ b/backend/src/agent-skills/report-export/calculation-book/pkpm-calcbook/report_render.py
@@ -715,7 +715,12 @@ def _generate_pdf(report: Dict[str, Any], output_path: Path, images: Optional[Li
     params = out_data.get("wmass_params", {})
     if params:
         elements.append(Paragraph("一、设计参数总信息", h1_style))
-        for key, label in [("design_params", "总体信息"), ("earthquake_params", "地震参数"), ("material_params", "材料参数")]:
+        for key, label in [
+            ("design_params", "总体信息"),
+            ("wind_info_params", "风荷载参数"),
+            ("earthquake_params", "地震参数"),
+            ("material_params", "材料参数"),
+        ]:
             section = params.get(key)
             if section:
                 elements.append(Paragraph(label, h2_style))

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
@@ -495,6 +495,29 @@ describe('concrete-frame canonicalize core contract', () => {
     ]);
   });
 
+  test('maps targeted floor loads to structural stories when a separate roof load is present', () => {
+    const patch = buildConcreteFrameDraftPatch(
+      '三层3D混凝土框架，X向2跨每跨6m，Y向1跨6m，层高3.6m，二层楼面恒载1kN/㎡，活载2kN/㎡，三层楼面恒载3kN/㎡，活载4kN/㎡，屋面恒载5kN/㎡，活载6kN/㎡',
+      {
+        inferredType: 'concrete-frame',
+        frameDimension: '3d',
+        storyCount: 3,
+        bayCountX: 2,
+        bayCountY: 1,
+        storyHeightsM: [3.6, 3.6, 3.6],
+        bayWidthsXM: [6, 6],
+        bayWidthsYM: [6],
+      },
+      undefined,
+    );
+
+    expect(patch.floorLoads).toEqual([
+      { story: 1, verticalKN: 72, liveLoadKN: 144 },
+      { story: 2, verticalKN: 216, liveLoadKN: 288 },
+      { story: 3, verticalKN: 360, liveLoadKN: 432 },
+    ]);
+  });
+
   test('extracts PKPM-oriented RC frame design conditions from detailed chinese request', () => {
     const message = [
       '设计计算一个两层混凝土框架，首层4.5米，二层3.8米。',

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
@@ -495,6 +495,90 @@ describe('concrete-frame canonicalize core contract', () => {
     ]);
   });
 
+  test('extracts PKPM-oriented RC frame design conditions from detailed chinese request', () => {
+    const message = [
+      '设计计算一个两层混凝土框架，首层4.5米，二层3.8米。',
+      '纵向开间尺寸8米，共5间，横向进深尺寸6米+3米+6米，',
+      '二层楼面恒载1.8kN/㎡，活载3.5kN/㎡，屋面恒载3.5kN/㎡，活载0.5kN/㎡。',
+      '7度0.1g抗震，第三组，场地类别3类，风荷载0.4kN/㎡，场地类别B类，',
+      '混凝土C30，钢筋HRB400。',
+    ].join('');
+    const patch = buildConcreteFrameDraftPatch(message, null, undefined);
+
+    expect(patch).toMatchObject({
+      inferredType: 'frame',
+      frameDimension: '3d',
+      storyCount: 2,
+      storyHeightsM: [4.5, 3.8],
+      bayCountX: 5,
+      bayWidthsXM: [8, 8, 8, 8, 8],
+      bayCountY: 3,
+      bayWidthsYM: [6, 3, 6],
+      frameConcreteGrade: 'C30',
+      frameRebarGrade: 'HRB400',
+      siteSeismic: {
+        intensity: 7,
+        accelerationG: 0.1,
+        designGroup: '第三组',
+        siteCategory: 'III',
+      },
+      wind: {
+        basicPressureKNM2: 0.4,
+        terrainRoughness: 'B',
+      },
+    });
+    expect(patch.floorLoads).toEqual([
+      { story: 1, verticalKN: 1080, liveLoadKN: 2100 },
+      { story: 2, verticalKN: 2100, liveLoadKN: 300 },
+    ]);
+
+    const model = buildConcreteFrameModel({
+      inferredType: 'frame',
+      structuralTypeKey: 'concrete-frame',
+      skillId: 'concrete-frame',
+      updatedAt: 0,
+      ...patch,
+    });
+
+    expect(model).toBeDefined();
+    expect(model.site_seismic).toMatchObject({
+      intensity: 7,
+      design_group: '第三组',
+      site_category: 'III',
+      characteristic_period: 0.65,
+      max_influence_coefficient: 0.08,
+      damping_ratio: 0.05,
+      extra: { acceleration_g: 0.1 },
+    });
+    expect(model.wind).toMatchObject({
+      basic_pressure: 0.4,
+      terrain_roughness: 'B',
+    });
+    expect(model.analysis_control).toMatchObject({
+      p_delta: false,
+      rigid_floor: true,
+      consideration_torsion: true,
+    });
+    expect(model.stories).toEqual([
+      expect.objectContaining({
+        id: 'F1',
+        dead_load: 1.8,
+        live_load: 3.5,
+      }),
+      expect.objectContaining({
+        id: 'F2',
+        dead_load: 3.5,
+        live_load: 0.5,
+      }),
+    ]);
+    expect(model.load_cases.map((loadCase) => loadCase.id)).toEqual(['D', 'L', 'WX', 'WY', 'EX', 'EY']);
+    expect(model.extensions.pkpm).toMatchObject({
+      materialSystem: 'reinforced-concrete',
+      site_seismic: expect.objectContaining({ site_category: 'III' }),
+      wind: expect.objectContaining({ terrain_roughness: 'B' }),
+    });
+  });
+
   test('derives dead load when live load appears before an unlabeled area intensity', () => {
     const patch = buildConcreteFrameDraftPatch(
       '两层3D混凝土框架，X向2跨每跨6m，Y向1跨6m，层高3.6m，活载2kN/㎡，4kN/㎡',

--- a/backend/src/agent-skills/structure-type/concrete-frame/constants.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/constants.ts
@@ -12,6 +12,8 @@ export const GEOMETRY_KEYS = [
 
 export const LOAD_BOUNDARY_KEYS = ['floorLoads', 'frameBaseSupportType'] as const;
 
+export const DESIGN_CONDITION_KEYS = ['siteSeismic', 'wind', 'analysisControl'] as const;
+
 export const REQUIRED_KEYS = [
   'frameDimension',
   'storyCount',

--- a/backend/src/agent-skills/structure-type/concrete-frame/design-conditions.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/design-conditions.ts
@@ -1,0 +1,34 @@
+import type { DraftWindParams } from '../../../agent-runtime/types.js';
+
+export function seismicDesignGroupIndex(raw: unknown): 1 | 2 | 3 | undefined {
+  if (typeof raw !== 'string' && typeof raw !== 'number') return undefined;
+  const text = String(raw).trim();
+  if (/1|一/.test(text)) return 1;
+  if (/2|二|两/.test(text)) return 2;
+  if (/3|三/.test(text)) return 3;
+  return undefined;
+}
+
+export function normalizeSeismicDesignGroup(raw: unknown): string | undefined {
+  const index = seismicDesignGroupIndex(raw);
+  if (index === 1) return '第一组';
+  if (index === 2) return '第二组';
+  if (index === 3) return '第三组';
+  return undefined;
+}
+
+export function normalizeSeismicSiteCategory(raw: unknown): string | undefined {
+  if (typeof raw !== 'string' && typeof raw !== 'number') return undefined;
+  const text = String(raw).trim().toUpperCase().replace(/类/g, '');
+  if (/^(?:1|一|I)$/.test(text)) return 'I';
+  if (/^(?:2|二|两|II)$/.test(text)) return 'II';
+  if (/^(?:3|三|III)$/.test(text)) return 'III';
+  if (/^(?:4|四|IV)$/.test(text)) return 'IV';
+  return undefined;
+}
+
+export function normalizeWindTerrainRoughness(raw: unknown): DraftWindParams['terrainRoughness'] | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const text = raw.trim().toUpperCase().replace(/类/g, '');
+  return ['A', 'B', 'C', 'D'].includes(text) ? text as DraftWindParams['terrainRoughness'] : undefined;
+}

--- a/backend/src/agent-skills/structure-type/concrete-frame/draft.md
+++ b/backend/src/agent-skills/structure-type/concrete-frame/draft.md
@@ -38,6 +38,13 @@ A `DraftExtraction` JSON object with the following optional keys (see `constants
 | `frameColumnSection` | `string` | `"400X400"` | Column cross‑section description. See section parsing below. |
 | `frameBeamSection` | `"string"` | `"300X600"` | Beam cross‑section description. |
 
+### Site, Seismic & Wind
+| Key | Type | Example | Notes |
+|-----|------|---------|-------|
+| `siteSeismic` | `object` | `{ "intensity": 7, "accelerationG": 0.1, "designGroup": "第三组", "siteCategory": "III" }` | Use for PKPM/YJK-style seismic design parameters. Normalize "3类" to `"III"`. |
+| `wind` | `object` | `{ "basicPressureKNM2": 0.4, "terrainRoughness": "B" }` | Basic wind pressure in kN/m² and terrain roughness A/B/C/D. |
+| `analysisControl` | `object` | `{ "rigidFloor": true, "modalCount": 15 }` | Optional calculation-control values such as rigid diaphragm, modal count, P-Delta. |
+
 ## Section Parsing
 Concrete frame sections are described as rectangular cross‑sections:
 
@@ -51,7 +58,8 @@ Concrete frame sections are described as rectangular cross‑sections:
 2. **Dimensions**: Extract numbers followed by "m", "米", "mm", "毫米". Convert mm to m for story heights and bay widths.
 3. **Loads**: "dead load 5 kN/m²", "恒载 5 kN/m²", "live load 3 kN/m²", "活载 3 kN/m²". Convert distributed loads to total floor loads using floor area.
 4. **Materials**: Look for concrete grades (C20–C80) and rebar grades (HPB300, HRB400, HRB500).
-5. **Boundary**: "fixed base", "pinned base", "固接", "铰接".
+5. **Seismic / wind design basis**: Extract phrases like "7度0.1g", "第三组", "场地类别3类", "基本风压0.4kN/m²", "地面粗糙度B类".
+6. **Boundary**: "fixed base", "pinned base", "固接", "铰接".
 
 ## Examples
 1. "A 2‑story 1‑bay concrete frame, story heights 4 m, bay width 8 m, concrete C35, rebar HRB400, fixed base."

--- a/backend/src/agent-skills/structure-type/concrete-frame/extract-llm.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/extract-llm.ts
@@ -5,14 +5,21 @@ import {
 } from '../../../agent-runtime/legacy.js';
 import { composeStructuralDomainPatch } from '../../../agent-runtime/domains/structural-domains.js';
 import { normalizeNumber } from '../../../agent-runtime/fallback.js';
-import type { DraftExtraction, DraftFloorLoad, DraftState } from '../../../agent-runtime/types.js';
+import type {
+  DraftAnalysisControl,
+  DraftExtraction,
+  DraftFloorLoad,
+  DraftSiteSeismicParams,
+  DraftState,
+  DraftWindParams,
+} from '../../../agent-runtime/types.js';
 import {
   canonicalizeConcreteFramePatch,
   fillConcreteFrameDimensionSpecificGeometry,
   hasLateralYFloorLoad as hasLateralYFloorLoadCanonical,
   resolveConcreteFrameDimension,
 } from './canonicalize.js';
-import { GEOMETRY_KEYS, LOAD_BOUNDARY_KEYS } from './constants.js';
+import { DESIGN_CONDITION_KEYS, GEOMETRY_KEYS, LOAD_BOUNDARY_KEYS } from './constants.js';
 import { normalizeConcreteFrameNaturalPatch } from './extract-natural.js';
 import { normalizeConcreteGrade, normalizeSectionName } from './model.js';
 
@@ -22,7 +29,13 @@ export function toConcreteFramePatch(patch: DraftExtraction): DraftExtraction {
     geometryKeys: GEOMETRY_KEYS,
     loadBoundaryKeys: LOAD_BOUNDARY_KEYS,
   });
-  return restrictLegacyDraftPatch(domainPatch, 'frame', [...GEOMETRY_KEYS, ...LOAD_BOUNDARY_KEYS]);
+  const next = restrictLegacyDraftPatch(domainPatch, 'frame', [...GEOMETRY_KEYS, ...LOAD_BOUNDARY_KEYS]);
+  for (const key of DESIGN_CONDITION_KEYS) {
+    if (patch[key] !== undefined) {
+      next[key] = patch[key];
+    }
+  }
+  return next;
 }
 
 function extractLlmScalar(raw: Record<string, unknown> | null | undefined, keys: string[]): number | undefined {
@@ -114,6 +127,110 @@ function extractLineLoadIntensity(message: string): number | undefined {
   }, ['direct']);
 }
 
+function calculateFloorAreaM2(patch: DraftExtraction): number | undefined {
+  const dimension = patch.frameDimension
+    ?? (patch.bayCountY !== undefined || patch.bayWidthsYM?.length ? '3d' : '2d');
+
+  if (dimension === '3d') {
+    const totalSpanX = sumPositive(patch.bayWidthsXM);
+    const totalSpanY = sumPositive(patch.bayWidthsYM);
+    return totalSpanX !== undefined && totalSpanY !== undefined ? totalSpanX * totalSpanY : undefined;
+  }
+
+  const bayWidths2d = patch.bayWidthsM ?? patch.bayWidthsXM;
+  const totalSpan2d = sumPositive(bayWidths2d);
+  return totalSpan2d !== undefined ? totalSpan2d * totalSpan2d : undefined;
+}
+
+function extractAreaLoadPair(segment: string): { dead?: number; live?: number } {
+  const unit = `(?:\\s*${AREA_LOAD_UNIT_PATTERN})?`;
+  const deadMatch = segment.match(new RegExp(`(?:恒载|恒荷载|永久荷载|dead\\s*load|dead-load)\\s*[：:=为是]*\\s*([0-9]+(?:\\.[0-9]+)?)${unit}`, 'i'));
+  const liveMatch = segment.match(new RegExp(`(?:活载|活荷载|live\\s*load|live-load)\\s*[：:=为是]*\\s*([0-9]+(?:\\.[0-9]+)?)${unit}`, 'i'));
+  return {
+    dead: normalizeNumber(deadMatch?.[1]),
+    live: normalizeNumber(liveMatch?.[1]),
+  };
+}
+
+function chineseStoryOrdinal(raw: string): number | undefined {
+  const text = raw.replace(/第/g, '').replace(/层/g, '').trim();
+  const arabic = Number.parseInt(text, 10);
+  if (Number.isFinite(arabic) && arabic > 0) return arabic;
+  const table: Record<string, number> = {
+    一: 1,
+    二: 2,
+    两: 2,
+    三: 3,
+    四: 4,
+    五: 5,
+    六: 6,
+    七: 7,
+    八: 8,
+    九: 9,
+    十: 10,
+  };
+  return table[text];
+}
+
+function extractTargetedAreaFloorLoads(
+  message: string,
+  patch: DraftExtraction,
+): DraftFloorLoad[] | undefined {
+  const storyCount = patch.storyCount ?? patch.storyHeightsM?.length;
+  const floorAreaM2 = calculateFloorAreaM2(patch);
+  if (!storyCount || !floorAreaM2 || floorAreaM2 <= 0) return undefined;
+
+  const byStory = new Map<number, DraftFloorLoad>();
+  const hasRoofLoad = /屋面[^，。；;]*(?:恒载|活载)/.test(message);
+  const storyPattern = /((?:第?[一二两三四五六七八九十]+|[0-9]+)层楼面)([^。；;]*)/g;
+  for (const match of message.matchAll(storyPattern)) {
+    const label = match[1] ?? '';
+    const storyOrdinal = chineseStoryOrdinal(label.replace(/楼面/g, ''));
+    const pair = extractAreaLoadPair(match[2] ?? '');
+    if (storyOrdinal === undefined || (pair.dead === undefined && pair.live === undefined)) continue;
+    const story = hasRoofLoad && storyOrdinal === storyCount && storyCount > 1
+      ? storyCount - 1
+      : storyOrdinal;
+    if (story < 1 || story > storyCount) continue;
+    byStory.set(story, {
+      story,
+      ...(pair.dead !== undefined && { verticalKN: Number((pair.dead * floorAreaM2).toFixed(6)) }),
+      ...(pair.live !== undefined && { liveLoadKN: Number((pair.live * floorAreaM2).toFixed(6)) }),
+    });
+  }
+
+  const roofMatch = message.match(/屋面([^。；;]*)/);
+  if (roofMatch) {
+    const pair = extractAreaLoadPair(roofMatch[1] ?? '');
+    if (pair.dead !== undefined || pair.live !== undefined) {
+      byStory.set(storyCount, {
+        story: storyCount,
+        ...(pair.dead !== undefined && { verticalKN: Number((pair.dead * floorAreaM2).toFixed(6)) }),
+        ...(pair.live !== undefined && { liveLoadKN: Number((pair.live * floorAreaM2).toFixed(6)) }),
+      });
+    }
+  }
+
+  const genericFloorMatch = message.match(/(?:楼面|标准层|各层)([^。；;]*)/);
+  if (!byStory.size && genericFloorMatch) {
+    const pair = extractAreaLoadPair(genericFloorMatch[1] ?? '');
+    if (pair.dead !== undefined || pair.live !== undefined) {
+      const endStory = hasRoofLoad && storyCount > 1 ? storyCount - 1 : storyCount;
+      for (let story = 1; story <= endStory; story++) {
+        byStory.set(story, {
+          story,
+          ...(pair.dead !== undefined && { verticalKN: Number((pair.dead * floorAreaM2).toFixed(6)) }),
+          ...(pair.live !== undefined && { liveLoadKN: Number((pair.live * floorAreaM2).toFixed(6)) }),
+        });
+      }
+    }
+  }
+
+  return byStory.size
+    ? Array.from(byStory.values()).sort((left, right) => left.story - right.story)
+    : undefined;
+}
+
 function deriveFloorLoadsFromIntensity(
   message: string,
   patch: DraftExtraction,
@@ -126,6 +243,8 @@ function deriveFloorLoadsFromIntensity(
   const areaLoadKNm2 = extractDeadLoadIntensity(message) ?? extractAreaLoadIntensity(message);
   const lineLoadKNm = extractLineLoadIntensity(message);
   const liveLoadKNm2 = extractLiveLoadIntensity(message);
+  const targetedAreaLoads = extractTargetedAreaFloorLoads(message, patch);
+  if (targetedAreaLoads?.length) return { ...patch, floorLoads: targetedAreaLoads };
   if (areaLoadKNm2 === undefined && lineLoadKNm === undefined && liveLoadKNm2 === undefined) return patch;
 
   const dimension = patch.frameDimension
@@ -218,6 +337,9 @@ export function buildConcreteFramePatchFromLlm(
   const frameBeamSection = typeof rawPatch?.frameBeamSection === 'string'
     ? normalizeSectionName(rawPatch.frameBeamSection)
     : undefined;
+  const siteSeismic = normalizeSiteSeismicPatch(rawPatch, existingState);
+  const wind = normalizeWindPatch(rawPatch, existingState);
+  const analysisControl = normalizeAnalysisControlPatch(rawPatch, existingState);
 
   return {
     ...normalized,
@@ -231,6 +353,9 @@ export function buildConcreteFramePatchFromLlm(
     ...(frameRebarGrade !== undefined && { frameRebarGrade }),
     ...(frameColumnSection !== undefined && { frameColumnSection }),
     ...(frameBeamSection !== undefined && { frameBeamSection }),
+    ...(siteSeismic !== undefined && { siteSeismic }),
+    ...(wind !== undefined && { wind }),
+    ...(analysisControl !== undefined && { analysisControl }),
   };
 }
 
@@ -277,6 +402,12 @@ export function buildConcreteFrameDraftPatch(
     ?? (rawNaturalPatch.frameColumnSection as string | undefined);
   const frameBeamSection = (normalizedLlmPatch.frameBeamSection as string | undefined)
     ?? (rawNaturalPatch.frameBeamSection as string | undefined);
+  const siteSeismic = (normalizedLlmPatch.siteSeismic as DraftSiteSeismicParams | undefined)
+    ?? (rawNaturalPatch.siteSeismic as DraftSiteSeismicParams | undefined);
+  const wind = (normalizedLlmPatch.wind as DraftWindParams | undefined)
+    ?? (rawNaturalPatch.wind as DraftWindParams | undefined);
+  const analysisControl = (normalizedLlmPatch.analysisControl as DraftAnalysisControl | undefined)
+    ?? (rawNaturalPatch.analysisControl as DraftAnalysisControl | undefined);
 
   return coerceConcreteFrameDimension(
     {
@@ -286,8 +417,131 @@ export function buildConcreteFrameDraftPatch(
       ...(frameRebarGrade !== undefined && { frameRebarGrade }),
       ...(frameColumnSection !== undefined && { frameColumnSection }),
       ...(frameBeamSection !== undefined && { frameBeamSection }),
+      ...(siteSeismic !== undefined && { siteSeismic }),
+      ...(wind !== undefined && { wind }),
+      ...(analysisControl !== undefined && { analysisControl }),
     },
     existingState,
     message,
   );
+}
+
+function normalizePlainRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function normalizeDesignGroup(raw: unknown): string | undefined {
+  if (typeof raw !== 'string' && typeof raw !== 'number') return undefined;
+  const text = String(raw).trim();
+  if (/1|一/.test(text)) return '第一组';
+  if (/2|二|两/.test(text)) return '第二组';
+  if (/3|三/.test(text)) return '第三组';
+  return undefined;
+}
+
+function normalizeSiteCategory(raw: unknown): string | undefined {
+  if (typeof raw !== 'string' && typeof raw !== 'number') return undefined;
+  const text = String(raw).trim().toUpperCase().replace(/类/g, '');
+  if (/^(?:1|一|I)$/.test(text)) return 'I';
+  if (/^(?:2|二|两|II)$/.test(text)) return 'II';
+  if (/^(?:3|三|III)$/.test(text)) return 'III';
+  if (/^(?:4|四|IV)$/.test(text)) return 'IV';
+  return undefined;
+}
+
+function normalizeTerrainRoughness(raw: unknown): DraftWindParams['terrainRoughness'] | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const text = raw.trim().toUpperCase().replace(/类/g, '');
+  return ['A', 'B', 'C', 'D'].includes(text) ? text as DraftWindParams['terrainRoughness'] : undefined;
+}
+
+function normalizeSiteSeismicPatch(
+  rawPatch: Record<string, unknown> | null | undefined,
+  existingState: DraftState | undefined,
+): DraftSiteSeismicParams | undefined {
+  const raw = normalizePlainRecord(rawPatch?.siteSeismic)
+    ?? normalizePlainRecord(rawPatch?.site_seismic)
+    ?? normalizePlainRecord(rawPatch?.seismic);
+  const intensity = extractLlmScalar(raw ?? rawPatch, ['intensity', 'seismicIntensity', 'frameSeismicIntensity']);
+  const accelerationG = extractLlmScalar(raw ?? rawPatch, ['accelerationG', 'seismicAccelerationG', 'frameSeismicAccelerationG']);
+  const characteristicPeriod = extractLlmScalar(raw ?? rawPatch, ['characteristicPeriod', 'characteristic_period']);
+  const maxInfluenceCoefficient = extractLlmScalar(raw ?? rawPatch, ['maxInfluenceCoefficient', 'max_influence_coefficient']);
+  const dampingRatio = extractLlmScalar(raw ?? rawPatch, ['dampingRatio', 'damping_ratio']);
+  const designGroup = normalizeDesignGroup(raw?.designGroup ?? raw?.design_group ?? rawPatch?.frameSeismicDesignGroup);
+  const siteCategory = normalizeSiteCategory(raw?.siteCategory ?? raw?.site_category ?? rawPatch?.frameSeismicSiteCategory);
+  const merged: DraftSiteSeismicParams = {
+    ...(existingState?.siteSeismic ?? {}),
+    ...(intensity !== undefined && { intensity }),
+    ...(accelerationG !== undefined && { accelerationG }),
+    ...(designGroup !== undefined && { designGroup }),
+    ...(siteCategory !== undefined && { siteCategory }),
+    ...(characteristicPeriod !== undefined && { characteristicPeriod }),
+    ...(maxInfluenceCoefficient !== undefined && { maxInfluenceCoefficient }),
+    ...(dampingRatio !== undefined && { dampingRatio }),
+  };
+  return Object.keys(merged).length ? merged : undefined;
+}
+
+function normalizeWindPatch(
+  rawPatch: Record<string, unknown> | null | undefined,
+  existingState: DraftState | undefined,
+): DraftWindParams | undefined {
+  const raw = normalizePlainRecord(rawPatch?.wind)
+    ?? normalizePlainRecord(rawPatch?.windParams);
+  const basicPressureKNM2 = extractLlmScalar(raw ?? rawPatch, ['basicPressureKNM2', 'basic_pressure', 'basicPressure', 'windPressure', 'frameWindBasicPressureKNM2']);
+  const shapeFactor = extractLlmScalar(raw ?? rawPatch, ['shapeFactor', 'shape_factor']);
+  const heightVariationFactor = extractLlmScalar(raw ?? rawPatch, ['heightVariationFactor', 'height_variation_factor']);
+  const terrainRoughness = normalizeTerrainRoughness(raw?.terrainRoughness ?? raw?.terrain_roughness ?? rawPatch?.frameWindTerrainRoughness);
+  const merged: DraftWindParams = {
+    ...(existingState?.wind ?? {}),
+    ...(basicPressureKNM2 !== undefined && { basicPressureKNM2 }),
+    ...(terrainRoughness !== undefined && { terrainRoughness }),
+    ...(shapeFactor !== undefined && { shapeFactor }),
+    ...(heightVariationFactor !== undefined && { heightVariationFactor }),
+  };
+  return Object.keys(merged).length ? merged : undefined;
+}
+
+function normalizeAnalysisControlPatch(
+  rawPatch: Record<string, unknown> | null | undefined,
+  existingState: DraftState | undefined,
+): DraftAnalysisControl | undefined {
+  const raw = normalizePlainRecord(rawPatch?.analysisControl)
+    ?? normalizePlainRecord(rawPatch?.analysis_control);
+  if (!raw) return existingState?.analysisControl;
+  const merged: DraftAnalysisControl = {
+    ...(existingState?.analysisControl ?? {}),
+    ...(typeof raw.pDelta === 'boolean' && { pDelta: raw.pDelta }),
+    ...(typeof raw.p_delta === 'boolean' && { pDelta: raw.p_delta }),
+    ...(typeof raw.rigidFloor === 'boolean' && { rigidFloor: raw.rigidFloor }),
+    ...(typeof raw.rigid_floor === 'boolean' && { rigidFloor: raw.rigid_floor }),
+    ...(typeof raw.considerationTorsion === 'boolean' && { considerationTorsion: raw.considerationTorsion }),
+    ...(typeof raw.consideration_torsion === 'boolean' && { considerationTorsion: raw.consideration_torsion }),
+    ...(typeof raw.liveLoadReduction === 'boolean' && { liveLoadReduction: raw.liveLoadReduction }),
+    ...(typeof raw.live_load_reduction === 'boolean' && { liveLoadReduction: raw.live_load_reduction }),
+    ...(extractLlmScalar(raw, ['periodReductionFactor', 'period_reduction_factor']) !== undefined && {
+      periodReductionFactor: extractLlmScalar(raw, ['periodReductionFactor', 'period_reduction_factor']),
+    }),
+    ...(extractLlmScalar(raw, ['accidentalEccentricity', 'accidental_eccentricity']) !== undefined && {
+      accidentalEccentricity: extractLlmScalar(raw, ['accidentalEccentricity', 'accidental_eccentricity']),
+    }),
+    ...(extractLlmScalar(raw, ['modalCount', 'modal_count']) !== undefined && {
+      modalCount: extractLlmScalar(raw, ['modalCount', 'modal_count']),
+    }),
+    ...(extractLlmScalar(raw, ['basementCount', 'basement_count']) !== undefined && {
+      basementCount: extractLlmScalar(raw, ['basementCount', 'basement_count']),
+    }),
+    ...(extractLlmScalar(raw, ['structureImportanceFactor', 'structure_importance_factor']) !== undefined && {
+      structureImportanceFactor: extractLlmScalar(raw, ['structureImportanceFactor', 'structure_importance_factor']),
+    }),
+    ...(extractLlmScalar(raw, ['dampingRatioWind', 'damping_ratio_wind']) !== undefined && {
+      dampingRatioWind: extractLlmScalar(raw, ['dampingRatioWind', 'damping_ratio_wind']),
+    }),
+    ...(normalizePlainRecord(raw.designParams ?? raw.design_params) !== undefined && {
+      designParams: normalizePlainRecord(raw.designParams ?? raw.design_params),
+    }),
+  };
+  return Object.keys(merged).length ? merged : undefined;
 }

--- a/backend/src/agent-skills/structure-type/concrete-frame/extract-llm.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/extract-llm.ts
@@ -20,6 +20,11 @@ import {
   resolveConcreteFrameDimension,
 } from './canonicalize.js';
 import { DESIGN_CONDITION_KEYS, GEOMETRY_KEYS, LOAD_BOUNDARY_KEYS } from './constants.js';
+import {
+  normalizeSeismicDesignGroup,
+  normalizeSeismicSiteCategory,
+  normalizeWindTerrainRoughness,
+} from './design-conditions.js';
 import { normalizeConcreteFrameNaturalPatch } from './extract-natural.js';
 import { normalizeConcreteGrade, normalizeSectionName } from './model.js';
 
@@ -182,14 +187,15 @@ function extractTargetedAreaFloorLoads(
 
   const byStory = new Map<number, DraftFloorLoad>();
   const hasRoofLoad = /屋面[^，。；;]*(?:恒载|活载)/.test(message);
-  const storyPattern = /((?:第?[一二两三四五六七八九十]+|[0-9]+)层楼面)([^。；;]*)/g;
+  const storyLabelPattern = '(?:第?[一二两三四五六七八九十]+|[0-9]+)层楼面';
+  const storyPattern = new RegExp(`(${storyLabelPattern})(.*?)(?=${storyLabelPattern}|屋面|[。；;]|$)`, 'g');
   for (const match of message.matchAll(storyPattern)) {
     const label = match[1] ?? '';
     const storyOrdinal = chineseStoryOrdinal(label.replace(/楼面/g, ''));
     const pair = extractAreaLoadPair(match[2] ?? '');
     if (storyOrdinal === undefined || (pair.dead === undefined && pair.live === undefined)) continue;
-    const story = hasRoofLoad && storyOrdinal === storyCount && storyCount > 1
-      ? storyCount - 1
+    const story = hasRoofLoad && storyOrdinal > 1
+      ? storyOrdinal - 1
       : storyOrdinal;
     if (story < 1 || story > storyCount) continue;
     byStory.set(story, {
@@ -432,31 +438,6 @@ function normalizePlainRecord(value: unknown): Record<string, unknown> | undefin
     : undefined;
 }
 
-function normalizeDesignGroup(raw: unknown): string | undefined {
-  if (typeof raw !== 'string' && typeof raw !== 'number') return undefined;
-  const text = String(raw).trim();
-  if (/1|一/.test(text)) return '第一组';
-  if (/2|二|两/.test(text)) return '第二组';
-  if (/3|三/.test(text)) return '第三组';
-  return undefined;
-}
-
-function normalizeSiteCategory(raw: unknown): string | undefined {
-  if (typeof raw !== 'string' && typeof raw !== 'number') return undefined;
-  const text = String(raw).trim().toUpperCase().replace(/类/g, '');
-  if (/^(?:1|一|I)$/.test(text)) return 'I';
-  if (/^(?:2|二|两|II)$/.test(text)) return 'II';
-  if (/^(?:3|三|III)$/.test(text)) return 'III';
-  if (/^(?:4|四|IV)$/.test(text)) return 'IV';
-  return undefined;
-}
-
-function normalizeTerrainRoughness(raw: unknown): DraftWindParams['terrainRoughness'] | undefined {
-  if (typeof raw !== 'string') return undefined;
-  const text = raw.trim().toUpperCase().replace(/类/g, '');
-  return ['A', 'B', 'C', 'D'].includes(text) ? text as DraftWindParams['terrainRoughness'] : undefined;
-}
-
 function normalizeSiteSeismicPatch(
   rawPatch: Record<string, unknown> | null | undefined,
   existingState: DraftState | undefined,
@@ -469,8 +450,8 @@ function normalizeSiteSeismicPatch(
   const characteristicPeriod = extractLlmScalar(raw ?? rawPatch, ['characteristicPeriod', 'characteristic_period']);
   const maxInfluenceCoefficient = extractLlmScalar(raw ?? rawPatch, ['maxInfluenceCoefficient', 'max_influence_coefficient']);
   const dampingRatio = extractLlmScalar(raw ?? rawPatch, ['dampingRatio', 'damping_ratio']);
-  const designGroup = normalizeDesignGroup(raw?.designGroup ?? raw?.design_group ?? rawPatch?.frameSeismicDesignGroup);
-  const siteCategory = normalizeSiteCategory(raw?.siteCategory ?? raw?.site_category ?? rawPatch?.frameSeismicSiteCategory);
+  const designGroup = normalizeSeismicDesignGroup(raw?.designGroup ?? raw?.design_group ?? rawPatch?.frameSeismicDesignGroup);
+  const siteCategory = normalizeSeismicSiteCategory(raw?.siteCategory ?? raw?.site_category ?? rawPatch?.frameSeismicSiteCategory);
   const merged: DraftSiteSeismicParams = {
     ...(existingState?.siteSeismic ?? {}),
     ...(intensity !== undefined && { intensity }),
@@ -493,7 +474,7 @@ function normalizeWindPatch(
   const basicPressureKNM2 = extractLlmScalar(raw ?? rawPatch, ['basicPressureKNM2', 'basic_pressure', 'basicPressure', 'windPressure', 'frameWindBasicPressureKNM2']);
   const shapeFactor = extractLlmScalar(raw ?? rawPatch, ['shapeFactor', 'shape_factor']);
   const heightVariationFactor = extractLlmScalar(raw ?? rawPatch, ['heightVariationFactor', 'height_variation_factor']);
-  const terrainRoughness = normalizeTerrainRoughness(raw?.terrainRoughness ?? raw?.terrain_roughness ?? rawPatch?.frameWindTerrainRoughness);
+  const terrainRoughness = normalizeWindTerrainRoughness(raw?.terrainRoughness ?? raw?.terrain_roughness ?? rawPatch?.frameWindTerrainRoughness);
   const merged: DraftWindParams = {
     ...(existingState?.wind ?? {}),
     ...(basicPressureKNM2 !== undefined && { basicPressureKNM2 }),

--- a/backend/src/agent-skills/structure-type/concrete-frame/extract-natural.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/extract-natural.ts
@@ -1,5 +1,10 @@
 import { normalizeNumber } from '../../../agent-runtime/fallback.js';
 import type { DraftExtraction, DraftState } from '../../../agent-runtime/types.js';
+import {
+  normalizeSeismicDesignGroup,
+  normalizeSeismicSiteCategory,
+  normalizeWindTerrainRoughness,
+} from './design-conditions.js';
 
 // Enhanced digit pattern for explicit structural context
 // Requires specific leading context to avoid false matches like "其中一层"
@@ -497,25 +502,6 @@ function extractFrameDimension(message: string): '2d' | '3d' | undefined {
   return undefined;
 }
 
-function normalizeDesignGroup(raw: string | undefined): string | undefined {
-  if (!raw) return undefined;
-  const text = raw.trim();
-  if (/1|一/.test(text)) return '第一组';
-  if (/2|二|两/.test(text)) return '第二组';
-  if (/3|三/.test(text)) return '第三组';
-  return undefined;
-}
-
-function normalizeSeismicSiteCategory(raw: string | undefined): string | undefined {
-  if (!raw) return undefined;
-  const text = raw.trim().toUpperCase();
-  if (/^(?:1|一|I)$/.test(text)) return 'I';
-  if (/^(?:2|二|两|II)$/.test(text)) return 'II';
-  if (/^(?:3|三|III)$/.test(text)) return 'III';
-  if (/^(?:4|四|IV)$/.test(text)) return 'IV';
-  return undefined;
-}
-
 function extractSiteSeismic(message: string): DraftExtraction['siteSeismic'] {
   const intensityMatch = message.match(/([6-9](?:\.\d+)?)\s*度(?:\s*设防)?(?:\s*[,，、]?\s*([0-9]+(?:\.[0-9]+)?)\s*g)?/i);
   const accelerationMatch = message.match(/([0-9]+(?:\.[0-9]+)?)\s*g/i);
@@ -526,7 +512,7 @@ function extractSiteSeismic(message: string): DraftExtraction['siteSeismic'] {
 
   const intensity = normalizeNumber(intensityMatch?.[1]);
   const accelerationG = normalizeNumber(intensityMatch?.[2]) ?? normalizeNumber(accelerationMatch?.[1]);
-  const designGroup = normalizeDesignGroup(designGroupMatch?.[1]);
+  const designGroup = normalizeSeismicDesignGroup(designGroupMatch?.[1]);
   const siteCategory = normalizeSeismicSiteCategory(siteCategoryMatch?.[1]);
   const dampingRatio = normalizeNumber(dampingMatch?.[1]);
 
@@ -549,7 +535,7 @@ function extractWind(message: string): DraftExtraction['wind'] {
   const heightFactorMatch = message.match(/高度变化系数\s*(?:为|是|:|：)?\s*([0-9]+(?:\.[0-9]+)?)/i);
 
   const basicPressureKNM2 = normalizeNumber(basicPressureMatch?.[1]);
-  const terrainRoughness = terrainMatch?.[1]?.toUpperCase() as 'A' | 'B' | 'C' | 'D' | undefined;
+  const terrainRoughness = normalizeWindTerrainRoughness(terrainMatch?.[1]);
   const shapeFactor = normalizeNumber(shapeFactorMatch?.[1]);
   const heightVariationFactor = normalizeNumber(heightFactorMatch?.[1]);
 

--- a/backend/src/agent-skills/structure-type/concrete-frame/extract-natural.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/extract-natural.ts
@@ -4,6 +4,7 @@ import type { DraftExtraction, DraftState } from '../../../agent-runtime/types.j
 // Enhanced digit pattern for explicit structural context
 // Requires specific leading context to avoid false matches like "其中一层"
 const DIGIT_PATTERN = '[零一二三四五六七八九十百千万两廿0-9]+';
+const DECIMAL_NUMBER_PATTERN = '[0-9]+(?:\\.[0-9]+)?';
 
 // Leading context that indicates structural description (not casual mention)
 // Covers: sentence start, punctuation, or specific aggregate keywords
@@ -168,6 +169,78 @@ function extractBayCountFromDirectionalSegment(segment: string): number | undefi
   ]);
 }
 
+function extractLabeledSegment(message: string, labelPattern: string, stopPattern: string): string {
+  const match = message.match(new RegExp(`${labelPattern}([\\s\\S]*?)(?=${stopPattern}|$)`, 'i'));
+  return match?.[1] ?? '';
+}
+
+const PLAN_SEGMENT_STOP = '(?:横向|纵向|[xXyYzZ](?:方向|向)|首层|一层|二层|三层|每层|层高|楼面|屋面|恒载|活载|抗震|地震|风荷载|基本风压|混凝土|钢筋|柱|梁)';
+
+function extractWidthValuesWithUnit(segment: string): number[] | undefined {
+  const values: number[] = [];
+  const pattern = new RegExp(`(${DECIMAL_NUMBER_PATTERN})\\s*(?:m|米)`, 'gi');
+  for (const match of segment.matchAll(pattern)) {
+    const value = normalizeNumber(match[1]);
+    if (value !== undefined && value > 0) values.push(value);
+  }
+  return values.length ? values : undefined;
+}
+
+function extractBayCountFromOpeningSegment(segment: string): number | undefined {
+  return extractStructuredCount(segment, [
+    new RegExp(`共\\s*(${DIGIT_PATTERN})\\s*(?:间|跨|开间)`, 'i'),
+    new RegExp(`(${DIGIT_PATTERN})\\s*(?:间|跨|开间)`, 'i'),
+  ]);
+}
+
+function extractLongitudinalSegment(message: string): string {
+  return extractLabeledSegment(
+    message,
+    '(?:纵向|[xX](?:方向|向))(?:\\s*(?:开间|跨度|尺寸|轴网|间距|进深))*\\s*',
+    PLAN_SEGMENT_STOP,
+  );
+}
+
+function extractTransverseSegment(message: string): string {
+  return extractLabeledSegment(
+    message,
+    '(?:横向|[yYzZ](?:方向|向))(?:\\s*(?:进深|跨度|尺寸|轴网|间距|开间))*\\s*',
+    PLAN_SEGMENT_STOP,
+  );
+}
+
+function extractLongitudinalBayCount(message: string): number | undefined {
+  const segment = extractLongitudinalSegment(message);
+  return segment ? extractBayCountFromOpeningSegment(segment) : undefined;
+}
+
+function extractLongitudinalBayWidths(message: string, bayCount: number | undefined): number[] | undefined {
+  const segment = extractLongitudinalSegment(message);
+  const values = segment ? extractWidthValuesWithUnit(segment) : undefined;
+  if (!values?.length) return undefined;
+  if (values.length === 1 && bayCount !== undefined) {
+    return Array(bayCount).fill(values[0]);
+  }
+  return values;
+}
+
+function extractTransverseBayCount(message: string): number | undefined {
+  const segment = extractTransverseSegment(message);
+  const explicit = segment ? extractBayCountFromOpeningSegment(segment) : undefined;
+  if (explicit !== undefined) return explicit;
+  return extractTransverseBayWidths(message, undefined)?.length;
+}
+
+function extractTransverseBayWidths(message: string, bayCount: number | undefined): number[] | undefined {
+  const segment = extractTransverseSegment(message);
+  const values = segment ? extractWidthValuesWithUnit(segment) : undefined;
+  if (!values?.length) return undefined;
+  if (values.length === 1 && bayCount !== undefined) {
+    return Array(bayCount).fill(values[0]);
+  }
+  return values;
+}
+
 function extractBayWidthFromDirectionalSegment(segment: string): number[] | undefined {
   return _extractNaturalArray(segment, [
     new RegExp(`(?:每跨|跨度|间隔)(?:都?是|也?是|为|是)?\\s*(${DIGIT_PATTERN}(?:\\.${DIGIT_PATTERN})?)\\s*(?:m|米)`, 'gi'),
@@ -262,6 +335,9 @@ function extractBayCount(message: string): number | undefined {
  * Extract direction-specific bay count for X direction.
  */
 function extractBayCountX(message: string): number | undefined {
+  const longitudinalCount = extractLongitudinalBayCount(message);
+  if (longitudinalCount !== undefined) return longitudinalCount;
+
   const segmentCount = extractBayCountFromDirectionalSegment(extractDirectionalSegment(message, 'x'));
   if (segmentCount !== undefined) return segmentCount;
 
@@ -278,6 +354,9 @@ function extractBayCountX(message: string): number | undefined {
  * Extract direction-specific bay count for Y direction.
  */
 function extractBayCountY(message: string): number | undefined {
+  const transverseCount = extractTransverseBayCount(message);
+  if (transverseCount !== undefined) return transverseCount;
+
   const ySegmentCount = extractBayCountFromDirectionalSegment(extractDirectionalSegment(message, 'y'));
   if (ySegmentCount !== undefined) return ySegmentCount;
   const zSegmentCount = extractBayCountFromDirectionalSegment(extractDirectionalSegment(message, 'z'));
@@ -293,6 +372,9 @@ function extractBayCountY(message: string): number | undefined {
 }
 
 function extractStoryHeights(message: string): number[] | undefined {
+  const explicitStoryHeights = extractExplicitStoryHeights(message);
+  if (explicitStoryHeights?.length) return explicitStoryHeights;
+
   return _extractNaturalArray(message, [
     new RegExp(`(?:层高|story\\s*height)\\s*[：:]*\\s*(${DIGIT_PATTERN}(?:\\.${DIGIT_PATTERN})?)`, 'gi'),
     // English: "4.2m each" - number and unit before "each" or "per story"
@@ -302,8 +384,42 @@ function extractStoryHeights(message: string): number[] | undefined {
   ]);
 }
 
+function storyOrdinalToIndex(raw: string): number | undefined {
+  const normalized = raw.replace(/第/g, '').replace(/层/g, '').trim();
+  if (normalized === '首') return 1;
+  return parseLocalizedNumber(normalized);
+}
+
+function extractExplicitStoryHeights(message: string): number[] | undefined {
+  const values = new Map<number, number>();
+  const pattern = new RegExp(
+    `((?:首|第?[一二两三四五六七八九十]+|[0-9]+)层)\\s*(?:层高|高度)?\\s*(?:为|是|:|：)?\\s*(${DECIMAL_NUMBER_PATTERN})\\s*(?:m|米)`,
+    'gi',
+  );
+  for (const match of message.matchAll(pattern)) {
+    const story = storyOrdinalToIndex(match[1] ?? '');
+    const height = normalizeNumber(match[2]);
+    if (story !== undefined && height !== undefined && height > 0) {
+      values.set(story, height);
+    }
+  }
+  if (!values.size) return undefined;
+  const maxStory = Math.max(...values.keys());
+  const heights: number[] = [];
+  for (let story = 1; story <= maxStory; story++) {
+    const height = values.get(story);
+    if (height === undefined) return undefined;
+    heights.push(height);
+  }
+  return heights;
+}
+
 // Extract bay widths for x-direction (in context of x方向)
 function extractBayWidthsX(message: string): number[] | undefined {
+  const longitudinalCount = extractLongitudinalBayCount(message);
+  const longitudinalWidths = extractLongitudinalBayWidths(message, longitudinalCount);
+  if (longitudinalWidths?.length) return longitudinalWidths;
+
   // Check if message has x-direction context
   if (!/x方向|x向/i.test(message)) {
     return undefined;
@@ -321,6 +437,10 @@ function extractBayWidthsX(message: string): number[] | undefined {
 
 // Extract bay widths for y-direction (in context of y方向)
 function extractBayWidthsY(message: string): number[] | undefined {
+  const transverseCount = extractTransverseBayCount(message);
+  const transverseWidths = extractTransverseBayWidths(message, transverseCount);
+  if (transverseWidths?.length) return transverseWidths;
+
   // Check if message has y-direction context
   if (!/y方向|y向|z方向|z向/i.test(message)) {
     return undefined;
@@ -370,8 +490,78 @@ function extractFrameDimension(message: string): '2d' | '3d' | undefined {
   if (/x方向.*[1-9](?:[0-9])?(?:跨|bay)/i.test(message)) {
     return '3d';
   }
+  if (/(?:纵向|横向|进深|开间尺寸)/i.test(message)) {
+    return '3d';
+  }
   
   return undefined;
+}
+
+function normalizeDesignGroup(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const text = raw.trim();
+  if (/1|一/.test(text)) return '第一组';
+  if (/2|二|两/.test(text)) return '第二组';
+  if (/3|三/.test(text)) return '第三组';
+  return undefined;
+}
+
+function normalizeSeismicSiteCategory(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const text = raw.trim().toUpperCase();
+  if (/^(?:1|一|I)$/.test(text)) return 'I';
+  if (/^(?:2|二|两|II)$/.test(text)) return 'II';
+  if (/^(?:3|三|III)$/.test(text)) return 'III';
+  if (/^(?:4|四|IV)$/.test(text)) return 'IV';
+  return undefined;
+}
+
+function extractSiteSeismic(message: string): DraftExtraction['siteSeismic'] {
+  const intensityMatch = message.match(/([6-9](?:\.\d+)?)\s*度(?:\s*设防)?(?:\s*[,，、]?\s*([0-9]+(?:\.[0-9]+)?)\s*g)?/i);
+  const accelerationMatch = message.match(/([0-9]+(?:\.[0-9]+)?)\s*g/i);
+  const designGroupMatch = message.match(/(?:设计地震分组|地震分组)\s*(?:为|是|:|：)?\s*(第?[一二两三123]组?)/i)
+    ?? (/(?:抗震|地震)/.test(message) ? message.match(/(第?[一二两三123]组)/i) : null);
+  const siteCategoryMatch = message.match(/场地类别\s*(I{1,3}|IV|[一二两三四1234])\s*类?/i);
+  const dampingMatch = message.match(/阻尼比\s*(?:为|是|:|：)?\s*([0-9]+(?:\.[0-9]+)?)/i);
+
+  const intensity = normalizeNumber(intensityMatch?.[1]);
+  const accelerationG = normalizeNumber(intensityMatch?.[2]) ?? normalizeNumber(accelerationMatch?.[1]);
+  const designGroup = normalizeDesignGroup(designGroupMatch?.[1]);
+  const siteCategory = normalizeSeismicSiteCategory(siteCategoryMatch?.[1]);
+  const dampingRatio = normalizeNumber(dampingMatch?.[1]);
+
+  if (intensity === undefined && accelerationG === undefined && designGroup === undefined && siteCategory === undefined && dampingRatio === undefined) {
+    return undefined;
+  }
+  return {
+    ...(intensity !== undefined && { intensity }),
+    ...(accelerationG !== undefined && { accelerationG }),
+    ...(designGroup !== undefined && { designGroup }),
+    ...(siteCategory !== undefined && { siteCategory }),
+    ...(dampingRatio !== undefined && { dampingRatio }),
+  };
+}
+
+function extractWind(message: string): DraftExtraction['wind'] {
+  const basicPressureMatch = message.match(/(?:基本风压|风荷载|风压)\s*(?:为|是|:|：)?\s*([0-9]+(?:\.[0-9]+)?)/i);
+  const terrainMatch = message.match(/(?:地面粗糙度|风荷载[^，。；;]*场地类别|场地类别)\s*([ABCD])\s*类?/i);
+  const shapeFactorMatch = message.match(/体型系数\s*(?:为|是|:|：)?\s*([0-9]+(?:\.[0-9]+)?)/i);
+  const heightFactorMatch = message.match(/高度变化系数\s*(?:为|是|:|：)?\s*([0-9]+(?:\.[0-9]+)?)/i);
+
+  const basicPressureKNM2 = normalizeNumber(basicPressureMatch?.[1]);
+  const terrainRoughness = terrainMatch?.[1]?.toUpperCase() as 'A' | 'B' | 'C' | 'D' | undefined;
+  const shapeFactor = normalizeNumber(shapeFactorMatch?.[1]);
+  const heightVariationFactor = normalizeNumber(heightFactorMatch?.[1]);
+
+  if (basicPressureKNM2 === undefined && terrainRoughness === undefined && shapeFactor === undefined && heightVariationFactor === undefined) {
+    return undefined;
+  }
+  return {
+    ...(basicPressureKNM2 !== undefined && { basicPressureKNM2 }),
+    ...(terrainRoughness !== undefined && { terrainRoughness }),
+    ...(shapeFactor !== undefined && { shapeFactor }),
+    ...(heightVariationFactor !== undefined && { heightVariationFactor }),
+  };
 }
 
 // M1: Separate concrete and rebar grade extraction to avoid losing information
@@ -424,6 +614,8 @@ export function normalizeConcreteFrameNaturalPatch(
   const frameRebarGrade = extractRebarGrade(message) ?? existingState?.frameRebarGrade as string | undefined;
   const frameColumnSection = extractFrameColumnSection(message) ?? existingState?.frameColumnSection as string | undefined;
   const frameBeamSection = extractFrameBeamSection(message) ?? existingState?.frameBeamSection as string | undefined;
+  const siteSeismic = extractSiteSeismic(message) ?? existingState?.siteSeismic;
+  const wind = extractWind(message) ?? existingState?.wind;
 
   // Expand storyHeightsM to match storyCount when it represents a uniform value
   // e.g., [3] with storyCount=3 becomes [3, 3, 3]
@@ -466,6 +658,8 @@ export function normalizeConcreteFrameNaturalPatch(
     ...(frameRebarGrade !== undefined && { frameRebarGrade }),
     ...(frameColumnSection !== undefined && { frameColumnSection }),
     ...(frameBeamSection !== undefined && { frameBeamSection }),
+    ...(siteSeismic !== undefined && { siteSeismic }),
+    ...(wind !== undefined && { wind }),
   };
 }
 

--- a/backend/src/agent-skills/structure-type/concrete-frame/merge.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/merge.ts
@@ -17,5 +17,14 @@ export function mergeConcreteFrameState(existing: DraftState | undefined, patch:
     frameRebarGrade: (patch.frameRebarGrade as string | undefined) ?? (existing?.frameRebarGrade as string | undefined),
     frameColumnSection: (patch.frameColumnSection as string | undefined) ?? (existing?.frameColumnSection as string | undefined),
     frameBeamSection: (patch.frameBeamSection as string | undefined) ?? (existing?.frameBeamSection as string | undefined),
+    siteSeismic: patch.siteSeismic !== undefined
+      ? { ...(existing?.siteSeismic ?? {}), ...patch.siteSeismic }
+      : existing?.siteSeismic,
+    wind: patch.wind !== undefined
+      ? { ...(existing?.wind ?? {}), ...patch.wind }
+      : existing?.wind,
+    analysisControl: patch.analysisControl !== undefined
+      ? { ...(existing?.analysisControl ?? {}), ...patch.analysisControl }
+      : existing?.analysisControl,
   };
 }

--- a/backend/src/agent-skills/structure-type/concrete-frame/model.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/model.ts
@@ -8,6 +8,12 @@ import type {
   DraftState,
   DraftWindParams,
 } from '../../../agent-runtime/types.js';
+import {
+  normalizeSeismicDesignGroup,
+  normalizeSeismicSiteCategory,
+  normalizeWindTerrainRoughness,
+  seismicDesignGroupIndex,
+} from './design-conditions.js';
 
 interface ConcreteMaterial {
   grade: string;   // 如 "C30"
@@ -381,32 +387,6 @@ type ConcreteFrameModel = {
   }>;
 };
 
-function normalizeSeismicSiteCategory(raw: string | undefined): string | undefined {
-  if (!raw) return undefined;
-  const value = raw.trim().toUpperCase().replace(/类/g, '');
-  if (/^(?:1|一|I)$/.test(value)) return 'I';
-  if (/^(?:2|二|两|II)$/.test(value)) return 'II';
-  if (/^(?:3|三|III)$/.test(value)) return 'III';
-  if (/^(?:4|四|IV)$/.test(value)) return 'IV';
-  return undefined;
-}
-
-function seismicDesignGroupIndex(raw: string | undefined): 1 | 2 | 3 | undefined {
-  if (!raw) return undefined;
-  if (/1|一/.test(raw)) return 1;
-  if (/2|二|两/.test(raw)) return 2;
-  if (/3|三/.test(raw)) return 3;
-  return undefined;
-}
-
-function normalizeSeismicDesignGroup(raw: string | undefined): string | undefined {
-  const index = seismicDesignGroupIndex(raw);
-  if (index === 1) return '第一组';
-  if (index === 2) return '第二组';
-  if (index === 3) return '第三组';
-  return undefined;
-}
-
 function deriveCharacteristicPeriod(designGroup: string | undefined, siteCategory: string | undefined): number | undefined {
   const group = seismicDesignGroupIndex(designGroup);
   const category = normalizeSeismicSiteCategory(siteCategory);
@@ -456,9 +436,10 @@ function buildSiteSeismicRecord(input: DraftSiteSeismicParams | undefined): Reco
 
 function buildWindRecord(input: DraftWindParams | undefined): Record<string, unknown> | undefined {
   if (!input || Object.keys(input).length === 0) return undefined;
+  const terrainRoughness = normalizeWindTerrainRoughness(input.terrainRoughness);
   return {
     ...(input.basicPressureKNM2 !== undefined && { basic_pressure: input.basicPressureKNM2 }),
-    ...(input.terrainRoughness !== undefined && { terrain_roughness: input.terrainRoughness }),
+    ...(terrainRoughness !== undefined && { terrain_roughness: terrainRoughness }),
     ...(input.shapeFactor !== undefined && { shape_factor: input.shapeFactor }),
     ...(input.heightVariationFactor !== undefined && { height_variation_factor: input.heightVariationFactor }),
   };

--- a/backend/src/agent-skills/structure-type/concrete-frame/model.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/model.ts
@@ -2,7 +2,12 @@ import {
   STRUCTURAL_COORDINATE_SEMANTICS,
 } from '../../../agent-runtime/coordinate-semantics.js';
 import { buildElementReferenceVectors } from '../../../agent-runtime/reference-vectors.js';
-import type { DraftState } from '../../../agent-runtime/types.js';
+import type {
+  DraftAnalysisControl,
+  DraftSiteSeismicParams,
+  DraftState,
+  DraftWindParams,
+} from '../../../agent-runtime/types.js';
 
 interface ConcreteMaterial {
   grade: string;   // 如 "C30"
@@ -317,6 +322,9 @@ type ConcreteFrameModel = {
   unit_system: 'SI';
   project: Record<string, unknown>;
   structure_system: Record<string, unknown>;
+  site_seismic?: Record<string, unknown>;
+  wind?: Record<string, unknown>;
+  analysis_control?: Record<string, unknown>;
   nodes: Array<Record<string, unknown>>;
   elements: Array<Record<string, unknown>>;
   stories: Array<Record<string, unknown>>;
@@ -373,6 +381,106 @@ type ConcreteFrameModel = {
   }>;
 };
 
+function normalizeSeismicSiteCategory(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const value = raw.trim().toUpperCase().replace(/类/g, '');
+  if (/^(?:1|一|I)$/.test(value)) return 'I';
+  if (/^(?:2|二|两|II)$/.test(value)) return 'II';
+  if (/^(?:3|三|III)$/.test(value)) return 'III';
+  if (/^(?:4|四|IV)$/.test(value)) return 'IV';
+  return undefined;
+}
+
+function seismicDesignGroupIndex(raw: string | undefined): 1 | 2 | 3 | undefined {
+  if (!raw) return undefined;
+  if (/1|一/.test(raw)) return 1;
+  if (/2|二|两/.test(raw)) return 2;
+  if (/3|三/.test(raw)) return 3;
+  return undefined;
+}
+
+function normalizeSeismicDesignGroup(raw: string | undefined): string | undefined {
+  const index = seismicDesignGroupIndex(raw);
+  if (index === 1) return '第一组';
+  if (index === 2) return '第二组';
+  if (index === 3) return '第三组';
+  return undefined;
+}
+
+function deriveCharacteristicPeriod(designGroup: string | undefined, siteCategory: string | undefined): number | undefined {
+  const group = seismicDesignGroupIndex(designGroup);
+  const category = normalizeSeismicSiteCategory(siteCategory);
+  if (!group || !category) return undefined;
+  const table: Record<1 | 2 | 3, Record<string, number>> = {
+    1: { I: 0.25, II: 0.35, III: 0.45, IV: 0.65 },
+    2: { I: 0.30, II: 0.40, III: 0.55, IV: 0.75 },
+    3: { I: 0.35, II: 0.45, III: 0.65, IV: 0.90 },
+  };
+  return table[group][category];
+}
+
+function deriveMaxInfluenceCoefficient(accelerationG: number | undefined): number | undefined {
+  if (accelerationG === undefined) return undefined;
+  const known = [
+    { accelerationG: 0.05, alphaMax: 0.04 },
+    { accelerationG: 0.10, alphaMax: 0.08 },
+    { accelerationG: 0.15, alphaMax: 0.12 },
+    { accelerationG: 0.20, alphaMax: 0.16 },
+    { accelerationG: 0.30, alphaMax: 0.24 },
+    { accelerationG: 0.40, alphaMax: 0.32 },
+  ];
+  const matched = known.find((item) => Math.abs(item.accelerationG - accelerationG) < 0.001);
+  return matched?.alphaMax;
+}
+
+function buildSiteSeismicRecord(input: DraftSiteSeismicParams | undefined): Record<string, unknown> | undefined {
+  if (!input || Object.keys(input).length === 0) return undefined;
+  const designGroup = normalizeSeismicDesignGroup(input.designGroup);
+  const siteCategory = normalizeSeismicSiteCategory(input.siteCategory);
+  const characteristicPeriod = input.characteristicPeriod
+    ?? deriveCharacteristicPeriod(designGroup, siteCategory);
+  const maxInfluenceCoefficient = input.maxInfluenceCoefficient
+    ?? deriveMaxInfluenceCoefficient(input.accelerationG);
+  return {
+    ...(input.intensity !== undefined && { intensity: input.intensity }),
+    ...(designGroup !== undefined && { design_group: designGroup }),
+    ...(siteCategory !== undefined && { site_category: siteCategory }),
+    ...(characteristicPeriod !== undefined && { characteristic_period: characteristicPeriod }),
+    ...(maxInfluenceCoefficient !== undefined && { max_influence_coefficient: maxInfluenceCoefficient }),
+    damping_ratio: input.dampingRatio ?? 0.05,
+    extra: {
+      ...(input.accelerationG !== undefined && { acceleration_g: input.accelerationG }),
+    },
+  };
+}
+
+function buildWindRecord(input: DraftWindParams | undefined): Record<string, unknown> | undefined {
+  if (!input || Object.keys(input).length === 0) return undefined;
+  return {
+    ...(input.basicPressureKNM2 !== undefined && { basic_pressure: input.basicPressureKNM2 }),
+    ...(input.terrainRoughness !== undefined && { terrain_roughness: input.terrainRoughness }),
+    ...(input.shapeFactor !== undefined && { shape_factor: input.shapeFactor }),
+    ...(input.heightVariationFactor !== undefined && { height_variation_factor: input.heightVariationFactor }),
+  };
+}
+
+function buildAnalysisControlRecord(input: DraftAnalysisControl | undefined): Record<string, unknown> | undefined {
+  const base: Record<string, unknown> = {
+    p_delta: input?.pDelta ?? false,
+    rigid_floor: input?.rigidFloor ?? true,
+    consideration_torsion: input?.considerationTorsion ?? true,
+  };
+  if (input?.periodReductionFactor !== undefined) base.period_reduction_factor = input.periodReductionFactor;
+  if (input?.accidentalEccentricity !== undefined) base.accidental_eccentricity = input.accidentalEccentricity;
+  if (input?.modalCount !== undefined) base.modal_count = input.modalCount;
+  if (input?.basementCount !== undefined) base.basement_count = input.basementCount;
+  if (input?.liveLoadReduction !== undefined) base.live_load_reduction = input.liveLoadReduction;
+  if (input?.structureImportanceFactor !== undefined) base.structure_importance_factor = input.structureImportanceFactor;
+  if (input?.dampingRatioWind !== undefined) base.damping_ratio_wind = input.dampingRatioWind;
+  if (input?.designParams !== undefined) base.design_params = input.designParams;
+  return Object.keys(base).length ? base : undefined;
+}
+
 function accumulateCoords(lengths: number[]): number[] {
   const coords = [0];
   for (const value of lengths) {
@@ -425,6 +533,7 @@ function storyHasFloorLoad(story: Record<string, unknown>, loadType: 'dead' | 'l
 function buildConcreteLoadCaseBundle(
   stories: Array<Record<string, unknown>>,
   lateralLoads: Array<Record<string, unknown>>,
+  options: { includeWind?: boolean; includeSeismic?: boolean; frameDimension?: '2d' | '3d' } = {},
 ): { load_cases: Array<Record<string, unknown>>; load_combinations: Array<Record<string, unknown>> } {
   const loadCases: Array<Record<string, unknown>> = [];
 
@@ -436,6 +545,18 @@ function buildConcreteLoadCaseBundle(
   }
   if (lateralLoads.length) {
     loadCases.push({ id: 'LAT', type: 'other', loads: lateralLoads, description: 'Lateral story loads' });
+  }
+  if (options.includeWind) {
+    loadCases.push({ id: 'WX', type: 'wind', loads: [], description: 'X-direction wind load generated by commercial engine parameters' });
+    if (options.frameDimension === '3d') {
+      loadCases.push({ id: 'WY', type: 'wind', loads: [], description: 'Y-direction wind load generated by commercial engine parameters' });
+    }
+  }
+  if (options.includeSeismic) {
+    loadCases.push({ id: 'EX', type: 'seismic', loads: [], description: 'X-direction seismic action generated by commercial engine parameters' });
+    if (options.frameDimension === '3d') {
+      loadCases.push({ id: 'EY', type: 'seismic', loads: [], description: 'Y-direction seismic action generated by commercial engine parameters' });
+    }
   }
   if (!loadCases.length) {
     loadCases.push({ id: 'LC1', type: 'other', loads: [] });
@@ -505,8 +626,11 @@ function buildCommonModelFields(options: {
   rebarProps: RebarMaterialProps;
   columnProps: SectionProps;
   beamProps: SectionProps;
+  siteSeismic?: Record<string, unknown>;
+  wind?: Record<string, unknown>;
+  analysisControl?: Record<string, unknown>;
   metadata: Record<string, unknown>;
-}): Pick<ConcreteFrameModel, 'schema_version' | 'unit_system' | 'project' | 'structure_system' | 'materials' | 'sections' | 'metadata' | 'extensions'> {
+}): Pick<ConcreteFrameModel, 'schema_version' | 'unit_system' | 'project' | 'structure_system' | 'site_seismic' | 'wind' | 'analysis_control' | 'materials' | 'sections' | 'metadata' | 'extensions'> {
   return {
     schema_version: '2.0.0',
     unit_system: 'SI',
@@ -523,6 +647,9 @@ function buildCommonModelFields(options: {
         materialSystem: 'reinforced-concrete',
       },
     },
+    ...(options.siteSeismic !== undefined && { site_seismic: options.siteSeismic }),
+    ...(options.wind !== undefined && { wind: options.wind }),
+    ...(options.analysisControl !== undefined && { analysis_control: options.analysisControl }),
     materials: [
       buildConcreteMaterialRecord(options.concreteProps),
       buildRebarMaterialRecord(options.rebarProps),
@@ -545,8 +672,16 @@ function buildCommonModelFields(options: {
       columnSection: options.frameColumnSection,
       beamSection: options.frameBeamSection,
       storyCount: options.storyCount,
+      ...(options.siteSeismic !== undefined && { siteSeismic: options.siteSeismic }),
+      ...(options.wind !== undefined && { wind: options.wind }),
     },
     extensions: {
+      pkpm: {
+        materialSystem: 'reinforced-concrete',
+        designCode: 'GB50010',
+        ...(options.siteSeismic !== undefined && { site_seismic: options.siteSeismic }),
+        ...(options.wind !== undefined && { wind: options.wind }),
+      },
       yjk: {
         materialSystem: 'reinforced-concrete',
         designCode: 'GB50010',
@@ -574,6 +709,9 @@ function buildConcreteFrame2dLocalModel(options: {
   rebarProps: RebarMaterialProps;
   columnProps: SectionProps;
   beamProps: SectionProps;
+  siteSeismic?: Record<string, unknown>;
+  wind?: Record<string, unknown>;
+  analysisControl?: Record<string, unknown>;
 }): ConcreteFrameModel {
   const xCoords = accumulateCoords(options.bayWidthsM);
   const zCoords = accumulateCoords(options.storyHeightsM);
@@ -654,7 +792,11 @@ function buildConcreteFrame2dLocalModel(options: {
       ...buildStoryFloorLoadFields(deadLoad, liveLoad),
     };
   });
-  const loadCaseBundle = buildConcreteLoadCaseBundle(stories, lateralLoads);
+  const loadCaseBundle = buildConcreteLoadCaseBundle(stories, lateralLoads, {
+    includeWind: options.wind !== undefined,
+    includeSeismic: options.siteSeismic !== undefined,
+    frameDimension: '2d',
+  });
   const common = buildCommonModelFields({
     ...options,
     metadata: {
@@ -705,6 +847,9 @@ function buildConcreteFrame3dLocalModel(options: {
   rebarProps: RebarMaterialProps;
   columnProps: SectionProps;
   beamProps: SectionProps;
+  siteSeismic?: Record<string, unknown>;
+  wind?: Record<string, unknown>;
+  analysisControl?: Record<string, unknown>;
 }): ConcreteFrameModel {
   const xCoords = accumulateCoords(options.bayWidthsXM);
   const yCoords = accumulateCoords(options.bayWidthsYM);
@@ -815,7 +960,11 @@ function buildConcreteFrame3dLocalModel(options: {
       ...buildStoryFloorLoadFields(deadLoad, liveLoad),
     };
   });
-  const loadCaseBundle = buildConcreteLoadCaseBundle(stories, lateralLoads);
+  const loadCaseBundle = buildConcreteLoadCaseBundle(stories, lateralLoads, {
+    includeWind: options.wind !== undefined,
+    includeSeismic: options.siteSeismic !== undefined,
+    frameDimension: '3d',
+  });
   const common = buildCommonModelFields({
     ...options,
     metadata: {
@@ -895,6 +1044,11 @@ export function buildConcreteFrameModel(state: DraftState): ConcreteFrameModel |
   const rebarProps = resolveRebarMaterialProps(frameRebarGrade);
   const columnProps = resolveSectionProps(frameColumnSection, concreteProps.G);
   const beamProps = resolveSectionProps(frameBeamSection, concreteProps.G);
+  const siteSeismic = buildSiteSeismicRecord(state.siteSeismic as DraftSiteSeismicParams | undefined);
+  const wind = buildWindRecord(state.wind as DraftWindParams | undefined);
+  const analysisControl = siteSeismic || wind || state.analysisControl
+    ? buildAnalysisControlRecord(state.analysisControl as DraftAnalysisControl | undefined)
+    : undefined;
 
   if (frameDimension === '3d') {
     const bayWidthsXM = state.bayWidthsXM?.length ? state.bayWidthsXM : state.bayWidthsM;
@@ -926,6 +1080,9 @@ export function buildConcreteFrameModel(state: DraftState): ConcreteFrameModel |
       rebarProps,
       columnProps,
       beamProps,
+      siteSeismic,
+      wind,
+      analysisControl,
     });
   }
 
@@ -954,5 +1111,8 @@ export function buildConcreteFrameModel(state: DraftState): ConcreteFrameModel |
     rebarProps,
     columnProps,
     beamProps,
+    siteSeismic,
+    wind,
+    analysisControl,
   });
 }

--- a/backend/tests/analysis-pkpm-frame-flow.test.mjs
+++ b/backend/tests/analysis-pkpm-frame-flow.test.mjs
@@ -201,6 +201,7 @@ function writePkpmApiStub(stubsDir) {
       '    def GetCurrentStandFloor(self): return self.floor',
       '    def AddNaturalFloor(self, floor): calls.append({"method": "Model.AddNaturalFloor"})',
       '    def GetProjectPara(self): return self.para',
+      '    def SetOneDesignParaValue(self, index, value): calls.append({"method": "Model.SetOneDesignParaValue", "index": index, "value": value})',
       '    def SaveProjectPara(self): calls.append({"method": "Model.SaveProjectPara"})',
       '    def SavePMModel(self): calls.append({"method": "Model.SavePMModel"})',
     ].join('\n'),
@@ -503,6 +504,53 @@ describe('PKPM frame analysis flow', () => {
     expect(findCalls(payload, 'Column.SetConcreteGrade').map((call) => call.grade)).toEqual(expect.arrayContaining(['C35']));
     expect(findCalls(payload, 'Beam.SetConcreteGrade').map((call) => call.grade)).toEqual(expect.arrayContaining(['C35']));
     expect(findCalls(payload, 'Beam.SetSteelGrade')).toHaveLength(0);
+  });
+
+  test('passes V2 seismic and wind design conditions into PKPM design parameters', () => {
+    const model = buildRcUserScenarioModel();
+    model.site_seismic = {
+      intensity: 7,
+      design_group: '第三组',
+      site_category: 'III',
+      characteristic_period: 0.65,
+      max_influence_coefficient: 0.08,
+      damping_ratio: 0.05,
+    };
+    model.wind = {
+      basic_pressure: 0.4,
+      terrain_roughness: 'B',
+      shape_factor: 1.3,
+    };
+    model.analysis_control = {
+      p_delta: false,
+      rigid_floor: true,
+      consideration_torsion: true,
+    };
+
+    const payload = runPkpmRuntime(model);
+    const designParamCalls = findCalls(payload, 'Model.SetOneDesignParaValue');
+
+    expect(designParamCalls).toEqual(expect.arrayContaining([
+      expect.objectContaining({ index: 25, value: 7 }),
+      expect.objectContaining({ index: 27, value: 3 }),
+      expect.objectContaining({ index: 31, value: 3 }),
+      expect.objectContaining({ index: 33, value: 0.4 }),
+      expect.objectContaining({ index: 37, value: 1.3 }),
+    ]));
+    expect(payload.result.summary.designConditions).toMatchObject({
+      site_seismic: {
+        intensity: 7,
+        design_group: '第三组',
+        site_category: 'III',
+      },
+      wind: {
+        basic_pressure: 0.4,
+        terrain_roughness: 'B',
+      },
+    });
+    expect(payload.result.pkpm_detailed.input_design_conditions.wind).toMatchObject({
+      basic_pressure: 0.4,
+    });
   });
 
   test('accepts generic rectangular section properties for PKPM concrete sections', () => {

--- a/backend/tests/analysis-pkpm-frame-flow.test.mjs
+++ b/backend/tests/analysis-pkpm-frame-flow.test.mjs
@@ -128,6 +128,8 @@ function writePkpmApiStub(stubsDir) {
       'class ProjectPara:',
       '    def SetParaInt(self, key, value):',
       '        calls.append({"method": "ProjectPara.SetParaInt", "key": key, "value": value})',
+      '    def SetParaDouble(self, key, value):',
+      '        calls.append({"method": "ProjectPara.SetParaDouble", "key": key, "value": value})',
       '',
       'class Node:',
       '    def __init__(self, node_id): self.node_id = node_id',
@@ -184,7 +186,7 @@ function writePkpmApiStub(stubsDir) {
       '    def SetStandFloorIndex(self, index): calls.append({"method": "RealFloor.SetStandFloorIndex", "index": index})',
       '',
       'class Model:',
-      '    def __init__(self): self.floor = StandFloor(); self.next_col_sec = 1; self.next_beam_sec = 1; self.para = ProjectPara()',
+      '    def __init__(self): self.floor = StandFloor(); self.next_col_sec = 1; self.next_beam_sec = 1; self.para = ProjectPara(); self.design_params = [0.0] * 128',
       '    def CreatNewModel(self, work_dir, project_name): calls.append({"method": "Model.CreatNewModel", "work_dir": work_dir, "project_name": project_name})',
       '    def OpenPMModel(self, jws_path): calls.append({"method": "Model.OpenPMModel", "jws_path": jws_path})',
       '    def AddColumnSection(self, section):',
@@ -201,6 +203,12 @@ function writePkpmApiStub(stubsDir) {
       '    def GetCurrentStandFloor(self): return self.floor',
       '    def AddNaturalFloor(self, floor): calls.append({"method": "Model.AddNaturalFloor"})',
       '    def GetProjectPara(self): return self.para',
+      '    def GetAllDesignPara(self):',
+      '        calls.append({"method": "Model.GetAllDesignPara"})',
+      '        return list(self.design_params)',
+      '    def SetAllDesignPara(self, values):',
+      '        self.design_params = list(values)',
+      '        calls.append({"method": "Model.SetAllDesignPara", "values": list(values)})',
       '    def SetOneDesignParaValue(self, index, value): calls.append({"method": "Model.SetOneDesignParaValue", "index": index, "value": value})',
       '    def SaveProjectPara(self): calls.append({"method": "Model.SaveProjectPara"})',
       '    def SavePMModel(self): calls.append({"method": "Model.SavePMModel"})',
@@ -528,14 +536,24 @@ describe('PKPM frame analysis flow', () => {
     };
 
     const payload = runPkpmRuntime(model);
-    const designParamCalls = findCalls(payload, 'Model.SetOneDesignParaValue');
+    const designParams = findCalls(payload, 'Model.SetAllDesignPara').at(-1).values;
 
-    expect(designParamCalls).toEqual(expect.arrayContaining([
-      expect.objectContaining({ index: 25, value: 7 }),
-      expect.objectContaining({ index: 27, value: 3 }),
-      expect.objectContaining({ index: 31, value: 3 }),
-      expect.objectContaining({ index: 33, value: 0.4 }),
-      expect.objectContaining({ index: 37, value: 1.3 }),
+    expect(designParams[24]).toBe(3);
+    expect(designParams[25]).toBe(7);
+    expect(designParams[26]).toBe(3);
+    expect(designParams[33]).toBe(0.4);
+    expect(designParams[34]).toBe(2);
+    expect(designParams[35]).toBe(1);
+    expect(designParams[37]).toBe(1.3);
+    expect(findCalls(payload, 'ProjectPara.SetParaDouble')).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 202, value: 0.4 }),
+      expect.objectContaining({ key: 312, value: 0.65 }),
+      expect.objectContaining({ key: 313, value: 0.08 }),
+    ]));
+    expect(findCalls(payload, 'ProjectPara.SetParaInt')).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 301, value: 2 }),
+      expect.objectContaining({ key: 303, value: 3 }),
+      expect.objectContaining({ key: 201, value: 2 }),
     ]));
     expect(payload.result.summary.designConditions).toMatchObject({
       site_seismic: {

--- a/backend/tests/analysis-pkpm-frame-flow.test.mjs
+++ b/backend/tests/analysis-pkpm-frame-flow.test.mjs
@@ -581,8 +581,12 @@ describe('PKPM frame analysis flow', () => {
         'DAMP = 5.00',
       ].join('\n'));
       const script = [
-        'import json, sys',
+        'import json, sys, types',
         'from pathlib import Path',
+        'contracts = types.ModuleType("contracts")',
+        'class EngineNotAvailableError(RuntimeError): pass',
+        'contracts.EngineNotAvailableError = EngineNotAvailableError',
+        'sys.modules["contracts"] = contracts',
         'from runtime import _read_wmass_design_params',
         'print(json.dumps(_read_wmass_design_params(Path(sys.argv[1])), ensure_ascii=False))',
       ].join('\n');

--- a/backend/tests/analysis-pkpm-frame-flow.test.mjs
+++ b/backend/tests/analysis-pkpm-frame-flow.test.mjs
@@ -571,6 +571,69 @@ describe('PKPM frame analysis flow', () => {
     });
   });
 
+  test('parses WMASS damping as ratio and percent separately', () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sclaw-pkpm-wmass-'));
+    try {
+      writeFile(path.join(workDir, 'WMASS.OUT'), [
+        'WO = 0.40',
+        'NAF = 7.00',
+        'NMODE = 6',
+        'DAMP = 5.00',
+      ].join('\n'));
+      const script = [
+        'import json, sys',
+        'from pathlib import Path',
+        'from runtime import _read_wmass_design_params',
+        'print(json.dumps(_read_wmass_design_params(Path(sys.argv[1])), ensure_ascii=False))',
+      ].join('\n');
+      const result = spawnSync(
+        pythonCommand.executable,
+        [...pythonCommand.args, '-c', script, workDir],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PYTHONPATH: [runtimeSupportDir, pkpmDir, process.env.PYTHONPATH]
+              .filter(Boolean)
+              .join(path.delimiter),
+          },
+          windowsHide: process.platform === 'win32',
+        },
+      );
+
+      if (result.status !== 0) {
+        throw new Error(`WMASS parser probe failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+      }
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(parsed.damping_ratio).toBeCloseTo(0.05);
+      expect(parsed.damping_ratio_percent).toBeCloseTo(5);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test('ignores malformed PKPM design-condition containers', () => {
+    const model = buildRcUserScenarioModel();
+    model.site_seismic = 'not-a-map';
+    model.wind = ['not-a-map'];
+    model.analysis_control = {
+      design_params: {
+        pkpm: {
+          satwe_indices: ['not-a-map'],
+        },
+      },
+    };
+
+    const payload = runPkpmRuntime(model);
+
+    expect(payload.result.status).toBe('success');
+    expect(findCalls(payload, 'Model.SetAllDesignPara')).toHaveLength(0);
+    expect(payload.result.pkpm_detailed.input_design_conditions).toMatchObject({
+      site_seismic: {},
+      wind: {},
+    });
+  });
+
   test('accepts generic rectangular section properties for PKPM concrete sections', () => {
     const payload = runPkpmRuntime(buildGenericRcFrameModelWithLegacyRectSections());
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: concrete-frame requests could mention PKPM design conditions such as story-specific area loads, seismic intensity/group/site category, and wind pressure/terrain category, but those values were not reliably carried into the computable model or real PKPM/SATWE controls.
- Why it matters: the chat/report could appear to acknowledge those inputs while the actual PKPM calculation still used defaults, producing wrong engineering output.
- What changed: added concrete-frame extraction/model support for these design conditions and mapped them into verified PKPM/SATWE APIs and `ProjectPara` fields; report rendering now surfaces actual `WMASS.OUT` wind/seismic parameters.
- What did NOT change (scope boundary): no frontend UI changes, no new analysis engine, no automatic fallback behavior change, and no fabricated report-only parameter injection.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: concrete-frame design conditions were parsed only partially, and PKPM conversion did not persist SATWE control values through the real PKPM parameter APIs.
- Missing detection / guardrail: tests covered successful PKPM execution but did not assert specific SATWE seismic/wind control indices, `ProjectPara` values, or report values sourced from `WMASS.OUT`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): follows the PKPM concrete-frame runnable flow from #274.
- Why this regressed now: expanding natural-language design inputs exposed that accepted parameters were not actually wired into the PKPM calculation path.
- If unknown, what was ruled out: verified this is not only a report-rendering problem; direct PKPM output needed to contain the requested values.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs`, `backend/tests/analysis-pkpm-frame-flow.test.mjs`, `backend/src/agent-skills/report-export/calculation-book/pkpm-calcbook/__tests__/test_runtime.py`.
- Scenario the test should lock in: a two-story RC frame request with story loads, 7 degree 0.1g seismic group 3/site III, and wind pressure 0.4/terrain B reaches the model, PKPM converter controls, and calcbook output.
- Why this is the smallest reliable guardrail: it checks the parser/model seam, the PKPM integration seam, and the final report source without requiring a full UI run.
- Existing test that already covers this (if any): existing PKPM frame-flow test covered execution, but not these detailed control mappings.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Concrete-frame chat requests can now preserve and use design conditions including story-specific floor/roof area loads, seismic intensity, acceleration, design group, seismic site category, wind pressure, wind terrain category, damping, period reduction, modal count, and wind shape factor.
- PKPM reports now show wind/seismic parameters read from actual PKPM/SATWE output instead of echoing unverified inputs.

## Diagram (if applicable)

```text
Before:
[user design request] -> [partial draft/model] -> [PKPM defaults for some SATWE controls] -> [misleading result]

After:
[user design request] -> [draft/model design conditions] -> [PKPM/SATWE controls + WMASS.OUT] -> [report from actual output]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local development machine
- Runtime/container: Node.js backend tests, Python PKPM/OpenSees helper runtime, local PKPM installation
- Model/provider: N/A for automated tests; parser/model unit tests do not require an LLM
- Integration/channel (if any): PKPM/SATWE local integration
- Relevant config (redacted): local PKPM API/runtime paths available; secrets redacted

### Steps

1. Ask for a two-story RC frame with first story 4.5 m, second story 3.8 m, X spans 8 m x 5, Y spans 6 m + 3 m + 6 m.
2. Include floor loads 1.8/3.5 kN/m2, roof loads 3.5/0.5 kN/m2, 7 degree 0.1g seismic, group 3, site category III, wind pressure 0.4 kN/m2, terrain B, C30, HRB400.
3. Run the PKPM concrete-frame flow and generate the calculation book.

### Expected

- The model contains the requested plan, story heights, materials, story loads, seismic controls, and wind controls.
- PKPM/SATWE output includes the requested seismic and wind controls.
- The calculation book reports values sourced from actual PKPM output.

### Actual

- Verified local PKPM output `WMASS.OUT` contains `WO = 0.40`, terrain `B`, `NMODE = 6`, `NAF = 7.00`, `KD = III`, design group `三组`, `TG = 0.65`, `Rmax1 = 0.080`, and `DAMP = 5.00`.
- Verified generated PDF contains matching wind and seismic parameter sections from `WMASS.OUT`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

```text
python -m py_compile backend/src/agent-skills/analysis/pkpm-static/runtime.py backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
npm test --prefix backend -- --runInBand tests/analysis-pkpm-frame-flow.test.mjs
uv run --with pytest --with reportlab --with python-docx python -m pytest backend/src/agent-skills/report-export/calculation-book/pkpm-calcbook/__tests__/test_runtime.py -q
npm run build --prefix backend
npm run lint --prefix backend
```

Results: all passed locally.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: real local PKPM run for the requested two-story RC frame; checked `WMASS.OUT` and extracted PDF text for the requested wind/seismic parameters.
- Edge cases checked: Chinese natural-language spans/load/seismic/wind extraction; PKPM `SetAllDesignPara` persistence; report output using actual PKPM values.
- What you did **not** verify: full frontend browser workflow and cloud/CI PKPM runtime, because PKPM is local Windows software.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: PKPM parameter indices and persisted `ProjectPara` fields are version-sensitive.
  - Mitigation: mappings were checked against local PKPM API documentation and covered by integration-seam tests.
- Risk: LLM extraction may emit partial or differently named condition fields.
  - Mitigation: natural-language extraction and LLM normalization both merge into the same typed draft fields with tests for the target Chinese request.
