### PR TITLE
fix(agent): repair DeepSeek tool message history

### DIFF
--- a/backend/src/agent-langgraph/__tests__/message-protocol.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/message-protocol.test.mjs
@@ -58,6 +58,58 @@ describe('agent message tool protocol repair', () => {
     ]);
   });
 
+  test('falls back to additional kwargs when top-level tool calls are empty and preserves metadata', async () => {
+    const { repairToolMessageProtocol } = await import('../../../dist/agent-langgraph/message-protocol.js');
+    const usageMetadata = {
+      input_tokens: 12,
+      output_tokens: 3,
+      total_tokens: 15,
+    };
+    const invalidToolCalls = [{ id: 'bad-call', name: 'bad_tool', args: '{}', error: 'invalid' }];
+    const aiMessage = {
+      _getType: () => 'ai',
+      id: 'ai-with-empty-tool-calls',
+      content: '',
+      tool_calls: [],
+      additional_kwargs: {
+        tool_calls: [{
+          id: 'call-build',
+          type: 'function',
+          function: {
+            name: 'build_model',
+            arguments: '{"span":8}',
+          },
+        }],
+      },
+      response_metadata: { finish_reason: 'tool_calls' },
+      usage_metadata: usageMetadata,
+      invalid_tool_calls: invalidToolCalls,
+    };
+
+    const result = repairToolMessageProtocol([
+      new HumanMessage('build it'),
+      aiMessage,
+      new ToolMessage({
+        name: 'build_model',
+        tool_call_id: 'call-build',
+        content: '{"success":true}',
+      }),
+    ]);
+
+    expect(result.repairedCount).toBe(1);
+    expect(result.messages[1].id).toBe('ai-with-empty-tool-calls');
+    expect(result.messages[1].usage_metadata).toEqual(usageMetadata);
+    expect(result.messages[1].invalid_tool_calls).toEqual(invalidToolCalls);
+    expect(result.messages[1].tool_calls).toEqual([
+      {
+        id: 'call-build',
+        name: 'build_model',
+        args: { span: 8 },
+        type: 'tool_call',
+      },
+    ]);
+  });
+
   test('strips incomplete tool-call protocol instead of sending unmatched tool messages', async () => {
     const { repairToolMessageProtocol } = await import('../../../dist/agent-langgraph/message-protocol.js');
     const result = repairToolMessageProtocol([
@@ -81,5 +133,40 @@ describe('agent message tool protocol repair', () => {
     expect(result.messages[1].tool_calls || []).toEqual([]);
     expect(String(result.messages[1].content)).toContain('repaired before model invocation');
     expect(String(result.messages[2].content)).toContain('Previous detect_structure_type tool result');
+  });
+
+  test('preserves ids and usage metadata when repairing incomplete tool-call history', async () => {
+    const { repairToolMessageProtocol } = await import('../../../dist/agent-langgraph/message-protocol.js');
+    const usageMetadata = {
+      input_tokens: 10,
+      output_tokens: 1,
+      total_tokens: 11,
+    };
+    const result = repairToolMessageProtocol([
+      new HumanMessage('do two things'),
+      new AIMessage({
+        id: 'ai-incomplete',
+        content: '',
+        usage_metadata: usageMetadata,
+        tool_calls: [
+          { id: 'call-a', name: 'detect_structure_type', args: {}, type: 'tool_call' },
+          { id: 'call-b', name: 'build_model', args: {}, type: 'tool_call' },
+        ],
+      }),
+      {
+        _getType: () => 'tool',
+        id: 'tool-a',
+        name: 'detect_structure_type',
+        tool_call_id: 'call-a',
+        content: undefined,
+      },
+    ]);
+
+    expect(result.repairedCount).toBe(2);
+    expect(result.messages[1].id).toBe('ai-incomplete');
+    expect(result.messages[1].usage_metadata).toEqual(usageMetadata);
+    expect(result.messages[2].id).toBe('tool-a');
+    expect(String(result.messages[2].content)).toContain('Previous detect_structure_type tool result');
+    expect(String(result.messages[2].content)).toContain('null');
   });
 });

--- a/backend/src/agent-langgraph/__tests__/message-protocol.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/message-protocol.test.mjs
@@ -1,0 +1,85 @@
+import { describe, expect, test } from '@jest/globals';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+
+describe('agent message tool protocol repair', () => {
+  test('converts orphan tool messages to assistant summaries', async () => {
+    const { repairToolMessageProtocol } = await import('../../../dist/agent-langgraph/message-protocol.js');
+    const result = repairToolMessageProtocol([
+      new HumanMessage('continue'),
+      new ToolMessage({
+        name: 'run_analysis',
+        tool_call_id: 'call-orphan',
+        content: '{"ok":true}',
+      }),
+    ]);
+
+    expect(result.repairedCount).toBe(1);
+    expect(result.messages.map((message) => message._getType())).toEqual(['human', 'ai']);
+    expect(String(result.messages[1].content)).toContain('Previous run_analysis tool result');
+    expect(String(result.messages[1].content)).toContain('call-orphan');
+  });
+
+  test('restores top-level tool calls from additional kwargs before paired tool messages', async () => {
+    const { repairToolMessageProtocol } = await import('../../../dist/agent-langgraph/message-protocol.js');
+    const aiMessage = {
+      _getType: () => 'ai',
+      content: '',
+      additional_kwargs: {
+        tool_calls: [{
+          id: 'call-build',
+          type: 'function',
+          function: {
+            name: 'build_model',
+            arguments: '{"span":6}',
+          },
+        }],
+      },
+    };
+
+    const result = repairToolMessageProtocol([
+      new HumanMessage('build it'),
+      aiMessage,
+      new ToolMessage({
+        name: 'build_model',
+        tool_call_id: 'call-build',
+        content: '{"success":true}',
+      }),
+    ]);
+
+    expect(result.repairedCount).toBe(1);
+    expect(result.messages.map((message) => message._getType())).toEqual(['human', 'ai', 'tool']);
+    expect(result.messages[1].tool_calls).toEqual([
+      {
+        id: 'call-build',
+        name: 'build_model',
+        args: { span: 6 },
+        type: 'tool_call',
+      },
+    ]);
+  });
+
+  test('strips incomplete tool-call protocol instead of sending unmatched tool messages', async () => {
+    const { repairToolMessageProtocol } = await import('../../../dist/agent-langgraph/message-protocol.js');
+    const result = repairToolMessageProtocol([
+      new HumanMessage('do two things'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'call-a', name: 'detect_structure_type', args: {}, type: 'tool_call' },
+          { id: 'call-b', name: 'build_model', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        name: 'detect_structure_type',
+        tool_call_id: 'call-a',
+        content: '{"type":"frame"}',
+      }),
+    ]);
+
+    expect(result.repairedCount).toBe(2);
+    expect(result.messages.map((message) => message._getType())).toEqual(['human', 'ai', 'ai']);
+    expect(result.messages[1].tool_calls || []).toEqual([]);
+    expect(String(result.messages[1].content)).toContain('repaired before model invocation');
+    expect(String(result.messages[2].content)).toContain('Previous detect_structure_type tool result');
+  });
+});

--- a/backend/src/agent-langgraph/graph.ts
+++ b/backend/src/agent-langgraph/graph.ts
@@ -33,6 +33,7 @@ import { resolveActiveToolIds } from './tool-policy.js';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import { getLogger } from '../utils/agent-logger.js';
 import { compactMessagesForContext, estimateMessagesCharLength } from './context-window.js';
+import { repairToolMessageProtocol } from './message-protocol.js';
 
 function getAgentLogger(config: LangGraphRunnableConfig) {
   return getLogger(config.configurable as Partial<AgentConfigurable> | undefined);
@@ -94,7 +95,11 @@ function buildAiMessageFields(content: unknown, name: unknown, source: Record<st
   if (responseMetadata) fields.response_metadata = responseMetadata;
 
   if (source.usage_metadata !== undefined) fields.usage_metadata = source.usage_metadata;
+  const additionalToolCalls = Array.isArray(additionalKwargs?.tool_calls)
+    ? additionalKwargs.tool_calls
+    : undefined;
   if (Array.isArray(source.tool_calls)) fields.tool_calls = source.tool_calls;
+  else if (additionalToolCalls) fields.tool_calls = additionalToolCalls;
   if (Array.isArray(source.invalid_tool_calls)) fields.invalid_tool_calls = source.invalid_tool_calls;
 
   return fields;
@@ -353,7 +358,14 @@ function createCallModelNode(
       }, 'agent context compacted before LLM invocation');
     }
 
-    const allMessages = [...systemMessages, ...compaction.messages];
+    const protocol = repairToolMessageProtocol(compaction.messages);
+    if (protocol.repairedCount > 0) {
+      log.warn({
+        node: 'agent',
+        repairedMessageCount: protocol.repairedCount,
+      }, 'agent repaired tool-message protocol before LLM invocation');
+    }
+    const allMessages = [...systemMessages, ...protocol.messages];
 
     log.info({ node: 'agent', messageCount: allMessages.length, activeToolCount: activeTools.length, toolCallCount, compacted: compaction.compacted }, 'agent node invoking LLM');
     const llmStart = Date.now();

--- a/backend/src/agent-langgraph/graph.ts
+++ b/backend/src/agent-langgraph/graph.ts
@@ -94,11 +94,14 @@ function buildAiMessageFields(content: unknown, name: unknown, source: Record<st
   const responseMetadata = asRecord(source.response_metadata);
   if (responseMetadata) fields.response_metadata = responseMetadata;
 
+  if (typeof source.id === 'string' && source.id.trim().length > 0) fields.id = source.id;
   if (source.usage_metadata !== undefined) fields.usage_metadata = source.usage_metadata;
   const additionalToolCalls = Array.isArray(additionalKwargs?.tool_calls)
     ? additionalKwargs.tool_calls
     : undefined;
-  if (Array.isArray(source.tool_calls)) fields.tool_calls = source.tool_calls;
+  if (Array.isArray(source.tool_calls) && source.tool_calls.length > 0) fields.tool_calls = source.tool_calls;
+  else if (additionalToolCalls && additionalToolCalls.length > 0) fields.tool_calls = additionalToolCalls;
+  else if (Array.isArray(source.tool_calls)) fields.tool_calls = source.tool_calls;
   else if (additionalToolCalls) fields.tool_calls = additionalToolCalls;
   if (Array.isArray(source.invalid_tool_calls)) fields.invalid_tool_calls = source.invalid_tool_calls;
 
@@ -109,6 +112,7 @@ function hasRestorableAiMetadata(source: Record<string, unknown>): boolean {
   const additionalKwargs = asRecord(source.additional_kwargs);
   return (
     (Array.isArray(source.tool_calls) && source.tool_calls.length > 0)
+    || (Array.isArray(additionalKwargs?.tool_calls) && additionalKwargs.tool_calls.length > 0)
     || (additionalKwargs !== undefined && 'reasoning_content' in additionalKwargs)
   );
 }

--- a/backend/src/agent-langgraph/message-protocol.ts
+++ b/backend/src/agent-langgraph/message-protocol.ts
@@ -37,7 +37,11 @@ function contentAsString(content: unknown): string {
       })
       .join('');
   }
-  return content === undefined ? '' : JSON.stringify(content);
+  try {
+    return JSON.stringify(content ?? null) ?? String(content);
+  } catch {
+    return String(content);
+  }
 }
 
 function parseToolArgs(value: unknown): Record<string, unknown> {
@@ -82,7 +86,9 @@ function extractToolCalls(message: BaseMessage): NormalizedToolCall[] {
   const fromKwargs = Array.isArray(additionalKwargs?.tool_calls)
     ? additionalKwargs.tool_calls
     : undefined;
-  const rawToolCalls: unknown[] = topLevel ?? fromKwargs ?? [];
+  const rawToolCalls: unknown[] = topLevel && topLevel.length > 0
+    ? topLevel
+    : fromKwargs ?? topLevel ?? [];
   return rawToolCalls
     .map((toolCall: unknown) => normalizeToolCall(toolCall))
     .filter((toolCall: NormalizedToolCall | undefined): toolCall is NormalizedToolCall => toolCall !== undefined);
@@ -125,11 +131,14 @@ function ensureTopLevelToolCalls(message: BaseMessage, toolCalls: NormalizedTool
     additional_kwargs: asRecord((message as any).additional_kwargs),
     response_metadata: asRecord((message as any).response_metadata),
     tool_calls: toolCalls,
+    id: message.id,
+    usage_metadata: (message as any).usage_metadata,
+    invalid_tool_calls: (message as any).invalid_tool_calls,
   } as any);
 }
 
 function stripToolCalls(message: BaseMessage, toolCalls: NormalizedToolCall[]): BaseMessage {
-  const text = contentAsString(message.content).trim();
+  const text = message.content == null ? '' : contentAsString(message.content).trim();
   const names = toolCalls
     .map((toolCall) => toolCall.name || toolCall.id)
     .filter(Boolean)
@@ -141,14 +150,19 @@ function stripToolCalls(message: BaseMessage, toolCalls: NormalizedToolCall[]): 
     name: typeof (message as any).name === 'string' ? (message as any).name : undefined,
     additional_kwargs: additionalKwargs,
     response_metadata: asRecord((message as any).response_metadata),
-  });
+    id: message.id,
+    usage_metadata: (message as any).usage_metadata,
+  } as any);
 }
 
 function toolResultAsAssistantMessage(message: BaseMessage): BaseMessage {
   const toolName = getToolName(message);
   const toolCallId = getToolCallId(message);
   const idSuffix = toolCallId ? ` id=${toolCallId}` : '';
-  return new AIMessage(`Previous ${toolName} tool result${idSuffix}: ${contentAsString(message.content)}`);
+  return new AIMessage({
+    content: `Previous ${toolName} tool result${idSuffix}: ${contentAsString(message.content)}`,
+    id: message.id,
+  } as any);
 }
 
 function hasExactToolResponses(toolCalls: NormalizedToolCall[], toolMessages: BaseMessage[]): boolean {

--- a/backend/src/agent-langgraph/message-protocol.ts
+++ b/backend/src/agent-langgraph/message-protocol.ts
@@ -1,0 +1,213 @@
+import { AIMessage, type BaseMessage } from '@langchain/core/messages';
+
+type NormalizedToolCall = {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+  type: 'tool_call';
+};
+
+export interface ToolProtocolRepairResult {
+  messages: BaseMessage[];
+  repairedCount: number;
+}
+
+function messageType(message: BaseMessage): string {
+  return typeof (message as any)._getType === 'function'
+    ? String((message as any)._getType())
+    : String((message as any).role || 'message');
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function contentAsString(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (typeof block === 'string') return block;
+        if (block && typeof block === 'object' && 'text' in block) {
+          return String((block as { text?: unknown }).text ?? '');
+        }
+        return '';
+      })
+      .join('');
+  }
+  return content === undefined ? '' : JSON.stringify(content);
+}
+
+function parseToolArgs(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function normalizeToolCall(raw: unknown): NormalizedToolCall | undefined {
+  const record = asRecord(raw);
+  if (!record || typeof record.id !== 'string' || !record.id.trim()) return undefined;
+  const functionCall = asRecord(record.function);
+  const name = typeof record.name === 'string'
+    ? record.name
+    : typeof functionCall?.name === 'string'
+      ? functionCall.name
+      : '';
+  return {
+    id: record.id,
+    name,
+    args: parseToolArgs(record.args ?? functionCall?.arguments),
+    type: 'tool_call',
+  };
+}
+
+function extractToolCalls(message: BaseMessage): NormalizedToolCall[] {
+  const topLevel = Array.isArray((message as any).tool_calls)
+    ? (message as any).tool_calls
+    : undefined;
+  const additionalKwargs = asRecord((message as any).additional_kwargs);
+  const fromKwargs = Array.isArray(additionalKwargs?.tool_calls)
+    ? additionalKwargs.tool_calls
+    : undefined;
+  const rawToolCalls: unknown[] = topLevel ?? fromKwargs ?? [];
+  return rawToolCalls
+    .map((toolCall: unknown) => normalizeToolCall(toolCall))
+    .filter((toolCall: NormalizedToolCall | undefined): toolCall is NormalizedToolCall => toolCall !== undefined);
+}
+
+function getToolCallId(message: BaseMessage): string {
+  return typeof (message as any).tool_call_id === 'string'
+    ? (message as any).tool_call_id
+    : '';
+}
+
+function getToolName(message: BaseMessage): string {
+  return typeof (message as any).name === 'string' && (message as any).name.trim()
+    ? (message as any).name
+    : 'tool';
+}
+
+function hasNormalizedTopLevelToolCalls(message: BaseMessage, toolCalls: NormalizedToolCall[]): boolean {
+  const topLevel = Array.isArray((message as any).tool_calls)
+    ? (message as any).tool_calls
+    : undefined;
+  return Boolean(topLevel)
+    && topLevel!.length === toolCalls.length
+    && topLevel!.every((toolCall: unknown, index: number) => {
+      const normalized = asRecord(toolCall);
+      return normalized?.id === toolCalls[index].id
+        && normalized?.name === toolCalls[index].name
+        && typeof normalized?.args === 'object'
+        && normalized?.args !== null;
+    });
+}
+
+function ensureTopLevelToolCalls(message: BaseMessage, toolCalls: NormalizedToolCall[]): BaseMessage {
+  if (hasNormalizedTopLevelToolCalls(message, toolCalls)) {
+    return message;
+  }
+  return new AIMessage({
+    content: message.content as any,
+    name: typeof (message as any).name === 'string' ? (message as any).name : undefined,
+    additional_kwargs: asRecord((message as any).additional_kwargs),
+    response_metadata: asRecord((message as any).response_metadata),
+    tool_calls: toolCalls,
+  } as any);
+}
+
+function stripToolCalls(message: BaseMessage, toolCalls: NormalizedToolCall[]): BaseMessage {
+  const text = contentAsString(message.content).trim();
+  const names = toolCalls
+    .map((toolCall) => toolCall.name || toolCall.id)
+    .filter(Boolean)
+    .join(', ');
+  const additionalKwargs = { ...(asRecord((message as any).additional_kwargs) ?? {}) };
+  delete additionalKwargs.tool_calls;
+  return new AIMessage({
+    content: text || `Previous assistant tool request was repaired before model invocation: ${names || 'unknown tool calls'}.`,
+    name: typeof (message as any).name === 'string' ? (message as any).name : undefined,
+    additional_kwargs: additionalKwargs,
+    response_metadata: asRecord((message as any).response_metadata),
+  });
+}
+
+function toolResultAsAssistantMessage(message: BaseMessage): BaseMessage {
+  const toolName = getToolName(message);
+  const toolCallId = getToolCallId(message);
+  const idSuffix = toolCallId ? ` id=${toolCallId}` : '';
+  return new AIMessage(`Previous ${toolName} tool result${idSuffix}: ${contentAsString(message.content)}`);
+}
+
+function hasExactToolResponses(toolCalls: NormalizedToolCall[], toolMessages: BaseMessage[]): boolean {
+  if (toolCalls.length === 0 || toolMessages.length !== toolCalls.length) return false;
+  const expected = new Set(toolCalls.map((toolCall) => toolCall.id));
+  const seen = new Set<string>();
+  for (const toolMessage of toolMessages) {
+    const id = getToolCallId(toolMessage);
+    if (!expected.has(id) || seen.has(id)) return false;
+    seen.add(id);
+  }
+  return seen.size === expected.size;
+}
+
+export function repairToolMessageProtocol(messages: BaseMessage[]): ToolProtocolRepairResult {
+  const result: BaseMessage[] = [];
+  let repairedCount = 0;
+
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    const type = messageType(message);
+
+    if (type === 'ai') {
+      const toolCalls = extractToolCalls(message);
+      if (toolCalls.length === 0) {
+        result.push(message);
+        continue;
+      }
+
+      const toolMessages: BaseMessage[] = [];
+      let nextIndex = index + 1;
+      while (nextIndex < messages.length && messageType(messages[nextIndex]) === 'tool') {
+        toolMessages.push(messages[nextIndex]);
+        nextIndex += 1;
+      }
+
+      if (hasExactToolResponses(toolCalls, toolMessages)) {
+        const repairedMessage = ensureTopLevelToolCalls(message, toolCalls);
+        if (repairedMessage !== message) repairedCount += 1;
+        result.push(repairedMessage, ...toolMessages);
+      } else {
+        repairedCount += 1 + toolMessages.length;
+        result.push(stripToolCalls(message, toolCalls));
+        for (const toolMessage of toolMessages) {
+          result.push(toolResultAsAssistantMessage(toolMessage));
+        }
+      }
+      index = nextIndex - 1;
+      continue;
+    }
+
+    if (type === 'tool') {
+      repairedCount += 1;
+      result.push(toolResultAsAssistantMessage(message));
+      continue;
+    }
+
+    result.push(message);
+  }
+
+  return { messages: result, repairedCount };
+}

--- a/backend/src/config/__tests__/settings-file.test.mjs
+++ b/backend/src/config/__tests__/settings-file.test.mjs
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, test } from '@jest/globals';
+
+function withTempSettingsDir(settingsText, callback) {
+  const previousDataDir = process.env.SCLAW_DATA_DIR;
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sclaw-settings-'));
+  process.env.SCLAW_DATA_DIR = tempDir;
+  fs.writeFileSync(path.join(tempDir, 'settings.json'), settingsText, 'utf8');
+
+  return Promise.resolve()
+    .then(callback)
+    .finally(() => {
+      if (previousDataDir === undefined) {
+        delete process.env.SCLAW_DATA_DIR;
+      } else {
+        process.env.SCLAW_DATA_DIR = previousDataDir;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+}
+
+describe('settings file', () => {
+  test('reads settings.json with comments without falling back to env settings', async () => {
+    await withTempSettingsDir(`{
+      "server": { "port": 31415 },
+      // Keep an old provider config as a note.
+      // "llm": { "model": "glm-5-turbo" },
+      "llm": {
+        "baseUrl": "https://llmapi.paratera.com",
+        /* current provider */
+        "model": "DeepSeek-V4-Pro",
+        "apiKey": "test-key"
+      }
+    }`, async () => {
+      const { readSettingsFile } = await import('../../../dist/config/settings-file.js');
+
+      const settings = readSettingsFile();
+
+      expect(settings?.llm).toMatchObject({
+        baseUrl: 'https://llmapi.paratera.com',
+        model: 'DeepSeek-V4-Pro',
+        apiKey: 'test-key',
+      });
+    });
+  });
+
+  test('settings-file can be imported before config without a circular init error', async () => {
+    await withTempSettingsDir(`{
+      "llm": {
+        "baseUrl": "https://example.com/v1",
+        "model": "test-model",
+        "apiKey": "test-key"
+      }
+    }`, async () => {
+      const { readSettingsFile } = await import('../../../dist/config/settings-file.js');
+      const { config } = await import('../../../dist/config/index.js');
+
+      expect(readSettingsFile()?.llm?.model).toBe('test-model');
+      expect(config.llmModel).toBe('test-model');
+    });
+  });
+});

--- a/backend/src/config/settings-file.ts
+++ b/backend/src/config/settings-file.ts
@@ -6,8 +6,8 @@
  */
 import crypto from 'node:crypto';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
-import { runtimeBaseDir } from './index.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -103,9 +103,11 @@ export type SettingsFile = {
 
 function getSettingsFilePath(): string {
   // Allow runtime override for testing
-  const overrideDir = process.env.SCLAW_DATA_DIR;
-  const baseDir = overrideDir || runtimeBaseDir;
-  return path.join(baseDir, 'settings.json');
+  return path.join(getRuntimeBaseDir(), 'settings.json');
+}
+
+function getRuntimeBaseDir(): string {
+  return process.env.SCLAW_DATA_DIR || path.join(os.homedir(), '.structureclaw');
 }
 
 // ---------------------------------------------------------------------------
@@ -400,11 +402,78 @@ function setCache(
 
 function readSettingsFromDisk(filePath: string): SettingsFile | null {
   try {
-    const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    const raw = JSON.parse(stripJsonComments(fs.readFileSync(filePath, 'utf8')));
     return normalizeSettingsFile(raw);
   } catch {
     return null;
   }
+}
+
+function stripJsonComments(source: string): string {
+  let output = '';
+  let inString = false;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < source.length; i += 1) {
+    const char = source[i];
+    const next = source[i + 1];
+
+    if (inLineComment) {
+      if (char === '\n' || char === '\r') {
+        inLineComment = false;
+        output += char;
+      }
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (char === '*' && next === '/') {
+        inBlockComment = false;
+        i += 1;
+        continue;
+      }
+      if (char === '\n' || char === '\r') {
+        output += char;
+      }
+      continue;
+    }
+
+    if (inString) {
+      output += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      output += char;
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      inLineComment = true;
+      i += 1;
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      inBlockComment = true;
+      i += 1;
+      continue;
+    }
+
+    output += char;
+  }
+
+  return output;
 }
 
 export function readSettingsFile(): SettingsFile | null {
@@ -451,7 +520,7 @@ export function writeSettingsFile(settings: SettingsFile): void {
 
 export function migrateLegacyLlmSettings(): void {
   const settingsPath = getSettingsFilePath();
-  const legacyPath = path.join(runtimeBaseDir, 'llm-settings.json');
+  const legacyPath = path.join(getRuntimeBaseDir(), 'llm-settings.json');
 
   // Skip if settings.json already exists or legacy file is missing
   if (fs.existsSync(settingsPath) || !fs.existsSync(legacyPath)) return;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: DeepSeek V4 Pro / OpenAI-compatible providers can reject continued conversations with `INVALID_TOOL_RESULTS` / `Messages with role 'tool' must be a response to a preceding message with 'tool_calls'` after tool calls enter message history.
- Why it matters: a multi-turn agent session can fail after otherwise successful tool execution, especially when resuming or compacting history.
- What changed: repair agent message history before LLM invocation, restore missing top-level tool calls, convert orphan/incomplete tool outputs into assistant summaries, and add regression tests.
- What changed: allow `settings.json` to contain JSON comments so local provider settings such as DeepSeek V4 Pro are not silently ignored and replaced by env/default fallbacks.
- What did NOT change (scope boundary): no tool permission policy, shell execution policy, model routing, UI, or analysis-engine behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: provider requests could contain malformed tool protocol history after checkpoint/compaction/deserialization, such as tool calls only present under `additional_kwargs`, orphan `ToolMessage`s, or assistant tool-call messages without matching tool outputs.
- Root cause: local `settings.json` parsing used strict `JSON.parse`; comments in the settings file caused parsing to fail and silently fall back to environment/default LLM settings.
- Missing detection / guardrail: no unit test covered malformed tool-message history repair before model invocation, and no settings-file test covered commented JSON.
- Prior context (`git blame`, prior PR, issue, or refactor if known): user-reported DeepSeek V4 Pro long-thinking multi-turn failure; exact originating commit unknown.
- Why this regressed now: DeepSeek V4 Pro/OpenAI-compatible endpoints enforce stricter tool-message ordering, and the local commented settings file masked the intended provider during verification.
- If unknown, what was ruled out: real multi-turn `calculate` calls with DeepSeek V4 Pro now pass after the repair and settings parser fix.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/src/agent-langgraph/__tests__/message-protocol.test.mjs`, `backend/src/config/__tests__/settings-file.test.mjs`
- Scenario the test should lock in: orphan tool messages, missing top-level tool calls, incomplete assistant/tool-call protocol, commented settings files, and settings-file import order.
- Why this is the smallest reliable guardrail: the failure is caused by message serialization/normalization and settings parsing before provider invocation.
- Existing test that already covers this (if any): `backend/src/utils/__tests__/llm-options.test.mjs` covers DeepSeek reasoning-content compatibility.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Multi-turn tool-using chats are less likely to fail with OpenAI-compatible tool-message protocol errors.
- `settings.json` now tolerates `//` and `/* */` comments, matching the way local settings files are commonly edited.

## Diagram (if applicable)

```text
Before:
[checkpointed history] -> [orphan/mismatched tool messages] -> [LLM 400]

After:
[checkpointed history] -> [repair tool protocol] -> [valid LLM request] -> [response]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows, PowerShell
- Runtime/container: Node.js v24.14.1, npm 11.11.0, local backend build
- Model/provider: DeepSeek-V4-Pro via `https://llmapi.paratera.com`
- Integration/channel (if any): LangGraph agent, `calculate` tool enabled
- Relevant config (redacted): `G:\sclaw_data\settings.json` with API key redacted; file includes commented-out old LLM settings

### Steps

1. Configure `settings.json` with DeepSeek V4 Pro provider settings and comments in the file.
2. Run a single conversation with `calculate` enabled and ask for a tool calculation.
3. Continue the same conversation with a second tool calculation.
4. Continue the same conversation again and ask for a summary using prior tool results.

### Expected

- The backend reads DeepSeek V4 Pro settings from `settings.json`.
- Tool-call history remains valid across turns.
- No `INVALID_TOOL_RESULTS` or `Messages with role 'tool'` 400 is returned.

### Actual

- Verified locally: model resolved to `DeepSeek-V4-Pro`, first two turns used `calculate`, third turn summarized prior tool results, and all turns completed successfully.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification highlights:

```text
conversationId: deepseek-settings-protocol-test-1780213261645
model: DeepSeek-V4-Pro
turn 1: success=true, toolCallCount=1
turn 2: success=true, toolCallCount=2
turn 3: success=true, toolCallCount=2
log search: no INVALID_TOOL_RESULTS / Messages with role 'tool'
```

Commands run:

```bash
npm run build --prefix backend
npm test --prefix backend -- --runInBand src/config/__tests__/settings-file.test.mjs src/agent-langgraph/__tests__/message-protocol.test.mjs src/agent-langgraph/__tests__/graph-routing.test.mjs src/utils/__tests__/llm-options.test.mjs
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted backend build/tests; real three-turn DeepSeek V4 Pro conversation with repeated tool calls and history reuse.
- Edge cases checked: orphan tool output, missing top-level tool calls, incomplete assistant tool-call protocol, commented settings file parsing, settings-file import before config.
- What you did **not** verify: full frontend chat UI flow and all engineering/analysis tools.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): Yes
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: existing strict JSON settings remain valid; commented settings now read correctly. No user action required.

## Risks and Mitigations

- Risk: converting malformed tool messages into assistant summaries may lose structured tool-call metadata for already-broken history.
  - Mitigation: only repair invalid protocol shapes before LLM invocation; valid tool-call/tool-output pairs are preserved.
- Risk: comment stripping could alter strings containing comment-like text.
  - Mitigation: parser tracks string/escape state and only strips comments outside JSON strings; covered by settings-file tests.
