### PR TITLE
fix(backend): guard PKPM PDB version mismatch

### DIFF
--- a/backend/src/agent-skills/analysis/pkpm-static/runtime.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/runtime.py
@@ -25,6 +25,11 @@ from threading import Lock
 from typing import Any, Dict
 
 from contracts import EngineNotAvailableError
+from pkpm_diagnostics import (
+    find_pdb_version_mismatch,
+    format_pdb_version_mismatch_error,
+    format_pdb_version_mismatch_warning,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +153,25 @@ def _safe_float(val: Any, default: float = 0.0) -> float:
 
 def _max_from_list(values: list[float]) -> float:
     return max(values) if values else 0.0
+
+
+def _has_core_pkpm_results(extracted: Dict[str, Any]) -> bool:
+    if not extracted:
+        return False
+    if extracted.get("mode_periods"):
+        return True
+    if extracted.get("beams") or extracted.get("columns"):
+        return True
+    if extracted.get("node_displacements"):
+        return True
+    if _safe_float(extracted.get("floors_analyzed", 0)) > 0:
+        return True
+    summary = extracted.get("summary") or {}
+    return any(_safe_float(summary.get(key, 0)) > 0 for key in (
+        "max_displacement_mm",
+        "max_shear_force_kn",
+        "max_bending_moment_kNm",
+    ))
 
 
 def _read_satwe_params(result: Any) -> Dict[str, Any]:
@@ -532,8 +556,19 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     try:
         extracted = _extract_results(jws_path, material_family=material_family)
     except Exception as exc:
+        pdb_mismatch = find_pdb_version_mismatch(work_dir)
+        if pdb_mismatch:
+            raise RuntimeError(
+                f"{format_pdb_version_mismatch_error(work_dir, cycle_path, pdb_mismatch)} "
+                f"Result extraction failed: {exc}"
+            ) from exc
         warnings.append(f"Result extraction failed: {exc}")
         extracted = {}
+    pdb_mismatch = find_pdb_version_mismatch(work_dir)
+    if pdb_mismatch:
+        if not _has_core_pkpm_results(extracted):
+            raise RuntimeError(format_pdb_version_mismatch_error(work_dir, cycle_path, pdb_mismatch))
+        warnings.append(format_pdb_version_mismatch_warning(work_dir, cycle_path, pdb_mismatch))
 
     # ---- Phase 4: Map to frontend-compatible analysis result format ----
     pkpm_summary = extracted.get("summary", {})

--- a/backend/src/agent-skills/analysis/runtime/pkpm_diagnostics.py
+++ b/backend/src/agent-skills/analysis/runtime/pkpm_diagnostics.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import re
+from importlib import metadata
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+PDB_MISMATCH_MARKER = "PDB VERSION INCONSISTENT"
+
+
+def collect_apipyinterface_diagnostics() -> Dict[str, str]:
+    """Return APIPyInterface location and package information for diagnostics."""
+    info: Dict[str, str] = {}
+    try:
+        import APIPyInterface
+
+        module_file = getattr(APIPyInterface, "__file__", "")
+        if module_file:
+            info["module_file"] = str(Path(module_file).resolve())
+            info["module_dir"] = str(Path(module_file).resolve().parent)
+    except Exception as exc:
+        info["import_error"] = str(exc)
+
+    for package_name in ("pkpm_api", "pkpm-api"):
+        try:
+            info["package_name"] = package_name
+            info["package_version"] = metadata.version(package_name)
+            break
+        except metadata.PackageNotFoundError:
+            continue
+        except Exception as exc:
+            info["package_error"] = str(exc)
+            break
+
+    return info
+
+
+def find_pdb_version_mismatch(work_dir: Path) -> Optional[Dict[str, Any]]:
+    """Scan PKPM output error files for SATWE PDB schema mismatch warnings."""
+    if not work_dir.exists():
+        return None
+
+    for path in sorted(work_dir.glob("*_ERR.TXT")):
+        try:
+            text = path.read_bytes().decode("gb18030", errors="ignore")
+        except OSError:
+            continue
+        if PDB_MISMATCH_MARKER not in text:
+            continue
+
+        file_version = _match_version(r"FILE\s+PDB\s+VERSION\s+NO\.\s*=\s*(\d+)", text)
+        program_version = _match_version(r"PROGRAM\s+PDB\s+VERSION\s+NO\.\s*=\s*(\d+)", text)
+        project_version = _read_project_version(work_dir)
+        return {
+            "err_file": str(path),
+            "file_version": file_version,
+            "program_version": program_version,
+            "project_version": project_version,
+        }
+    return None
+
+
+def format_pdb_version_mismatch_error(
+    work_dir: Path,
+    cycle_path: Path,
+    mismatch: Dict[str, Any],
+    *,
+    include_file_paths: bool = True,
+) -> str:
+    api_info = collect_apipyinterface_diagnostics()
+    details = [
+        "PKPM/SATWE PDB version mismatch detected / 检测到 PKPM/SATWE PDB 版本不一致.",
+        f"FILE PDB VERSION NO.={mismatch.get('file_version') or 'unknown'}",
+        f"PROGRAM PDB VERSION NO.={mismatch.get('program_version') or 'unknown'}",
+        f"JWSCYCLE={cycle_path}",
+    ]
+    if include_file_paths:
+        details.extend([
+            f"workDir={work_dir}",
+            f"errFile={mismatch.get('err_file')}",
+        ])
+    project_version = mismatch.get("project_version")
+    if project_version:
+        details.append(f"projectVersion={project_version}")
+    package_version = api_info.get("package_version")
+    if package_version:
+        details.append(f"{api_info.get('package_name', 'pkpm_api')}={package_version}")
+    module_file = api_info.get("module_file")
+    if module_file:
+        details.append(f"APIPyInterface={module_file}")
+    details.append(
+        "This usually means the Python APIPyInterface package and the configured "
+        "PKPM/SATWE installation are from incompatible releases. "
+        "请使用与当前 PKPM/SATWE 主程序匹配的 APIPyInterface/pkpm_api 后重试。"
+    )
+    return " ".join(details)
+
+
+def format_pdb_version_mismatch_warning(
+    work_dir: Path,
+    cycle_path: Path,
+    mismatch: Dict[str, Any],
+    *,
+    include_file_paths: bool = True,
+) -> str:
+    api_info = collect_apipyinterface_diagnostics()
+    parts = [
+        "PKPM/SATWE PDB version warning detected; core SATWE results were still readable.",
+        f"FILE PDB VERSION NO.={mismatch.get('file_version') or 'unknown'}",
+        f"PROGRAM PDB VERSION NO.={mismatch.get('program_version') or 'unknown'}",
+        f"JWSCYCLE={cycle_path}",
+    ]
+    if include_file_paths:
+        parts.append(f"workDir={work_dir}")
+    project_version = mismatch.get("project_version")
+    if project_version:
+        parts.append(f"projectVersion={project_version}")
+    package_version = api_info.get("package_version")
+    if package_version:
+        parts.append(f"{api_info.get('package_name', 'pkpm_api')}={package_version}")
+    module_file = api_info.get("module_file")
+    if module_file:
+        parts.append(f"APIPyInterface={module_file}")
+    return " ".join(parts)
+
+def _match_version(pattern: str, text: str) -> str:
+    match = re.search(pattern, text, flags=re.IGNORECASE)
+    return match.group(1) if match else ""
+
+
+def _read_project_version(work_dir: Path) -> str:
+    for path in sorted(work_dir.glob("__PMVERSION*")):
+        name_match = re.search(r"__PMVERSION[:：]?(.+?)\.pm$", path.name, flags=re.IGNORECASE)
+        if name_match:
+            return name_match.group(1).strip()
+        try:
+            text = path.read_bytes().decode("gb18030", errors="ignore")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            normalized = line.strip().strip("+")
+            if normalized:
+                return normalized[:120]
+    return ""

--- a/backend/src/agent-skills/analysis/runtime/registry.py
+++ b/backend/src/agent-skills/analysis/runtime/registry.py
@@ -15,6 +15,12 @@ import yaml
 from fastapi import HTTPException
 
 from contracts import AnalysisResult, EngineNotAvailableError
+from pkpm_diagnostics import (
+    collect_apipyinterface_diagnostics,
+    find_pdb_version_mismatch,
+    format_pdb_version_mismatch_error,
+    format_pdb_version_mismatch_warning,
+)
 from skill_loader import SkillNotLoadedError, build_missing_skill_detail, load_skill_symbol
 from structure_protocol.migrations import migrate_v1_to_v2
 from structure_protocol.structure_model_v2 import StructureModelV2
@@ -120,7 +126,7 @@ class AnalysisEngineRegistry:
         else:
             result = {"passed": False, "error": f"Unknown engine '{engine_id}' for probe"}
         elapsed = round((perf_counter() - start) * 1000)
-        return {
+        response = {
             "engineId": engine_id,
             "engineName": manifest.get("name", engine_id),
             "passed": result["passed"],
@@ -130,6 +136,9 @@ class AnalysisEngineRegistry:
             "steps": result.get("steps"),
             "hint": result.get("hint"),
         }
+        if result.get("warnings"):
+            response["warnings"] = result["warnings"]
+        return response
 
     def _probe_opensees(self) -> Dict[str, Any]:
         try:
@@ -164,7 +173,19 @@ class AnalysisEngineRegistry:
             import APIPyInterface
         except ImportError as exc:
             return {"passed": False, "error": f"APIPyInterface import failed: {exc}", "steps": steps}
-        steps.append({"name": "APIPyInterface import", "passed": True})
+        api_info = collect_apipyinterface_diagnostics()
+        api_details = ", ".join(
+            item for item in [
+                f"{api_info.get('package_name')}={api_info.get('package_version')}"
+                if api_info.get("package_version") else "",
+                api_info.get("module_file", ""),
+            ] if item
+        )
+        steps.append({
+            "name": "APIPyInterface import",
+            "passed": True,
+            **({"details": api_details} if api_details else {}),
+        })
 
         # Step 3-5: create model, run SATWE, extract results — cleanup in finally
         import shutil
@@ -228,14 +249,48 @@ class AnalysisEngineRegistry:
             # Step 5: extract results
             result = APIPyInterface.ResultData()
             ret = result.InitialResult(str(jws_path))
+            core_counts: Dict[str, int] = {}
+            if ret != 0:
+                try:
+                    core_counts["modePeriods"] = len(result.GetModePeriods())
+                except Exception:
+                    core_counts["modePeriods"] = 0
+                try:
+                    core_counts["beams"] = len(result.GetDesignBeams(1))
+                except Exception:
+                    core_counts["beams"] = 0
+                try:
+                    core_counts["columns"] = len(result.GetDesignColumns(1))
+                except Exception:
+                    core_counts["columns"] = 0
             result.ClearResult()
+            mismatch = find_pdb_version_mismatch(work_dir)
+            has_core_results = ret != 0 and any(value > 0 for value in core_counts.values())
+            if mismatch and not has_core_results:
+                return {
+                    "passed": False,
+                    "error": format_pdb_version_mismatch_error(
+                        work_dir, p, mismatch, include_file_paths=False,
+                    ),
+                    "steps": steps,
+                    "hint": "Install a PKPM API package compatible with the configured JWSCYCLE.exe.",
+                }
             if ret == 0:
                 return {
                     "passed": False,
                     "error": "InitialResult returned FALSE — failed to read analysis results",
                     "steps": steps,
                 }
-            steps.append({"name": "Extract results", "passed": True})
+            steps.append({
+                "name": "Extract results",
+                "passed": True,
+                "details": ", ".join(f"{key}={value}" for key, value in core_counts.items()),
+            })
+            warnings: list[str] = []
+            if mismatch:
+                warnings.append(format_pdb_version_mismatch_warning(
+                    work_dir, p, mismatch, include_file_paths=False,
+                ))
 
         except Exception as exc:
             step_label = "Model creation" if len(steps) < 3 else ("SATWE analysis" if len(steps) < 4 else "Result extraction")
@@ -249,7 +304,13 @@ class AnalysisEngineRegistry:
         finally:
             shutil.rmtree(work_dir, ignore_errors=True)
 
-        return {"passed": True, "details": "PKPM probe completed: model created, SATWE ran, results extracted", "steps": steps}
+        details = "PKPM probe completed: model created, SATWE ran, results extracted"
+        return {
+            "passed": True,
+            "details": details,
+            "steps": steps,
+            **({"warnings": warnings} if warnings else {}),
+        }
 
     def _probe_yjk(self) -> Dict[str, Any]:
         steps: list[Dict[str, Any]] = []

--- a/backend/tests/analysis-pkpm-frame-flow.test.mjs
+++ b/backend/tests/analysis-pkpm-frame-flow.test.mjs
@@ -11,6 +11,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..', '..');
 const pkpmDir = path.join(repoRoot, 'backend', 'src', 'agent-skills', 'analysis', 'pkpm-static');
 const runtimeSupportDir = path.join(repoRoot, 'backend', 'src', 'agent-skills', 'analysis', 'runtime');
+const skillSharedPythonRoot = path.join(repoRoot, 'backend', 'src', 'skill-shared', 'python');
 
 function probePython(executable, args) {
   const result = spawnSync(executable, [...args, '-c', 'import sys; sys.exit(0)'], {
@@ -50,6 +51,47 @@ function writeFile(filePath, content) {
 
 function writePkpmApiStub(stubsDir) {
   writeFile(
+    path.join(stubsDir, 'httpx.py'),
+    [
+      'class Client:',
+      '    def __init__(self, *args, **kwargs): pass',
+      '    def __enter__(self): return self',
+      '    def __exit__(self, *args): return False',
+      '    def post(self, *args, **kwargs): raise RuntimeError("httpx stub is not available in this test")',
+    ].join('\n'),
+  );
+
+  writeFile(
+    path.join(stubsDir, 'yaml.py'),
+    'def safe_load(*args, **kwargs): return {}\n',
+  );
+
+  writeFile(
+    path.join(stubsDir, 'fastapi.py'),
+    [
+      'class HTTPException(Exception):',
+      '    def __init__(self, status_code=None, detail=None):',
+      '        self.status_code = status_code',
+      '        self.detail = detail',
+      '        super().__init__(detail)',
+    ].join('\n'),
+  );
+
+  writeFile(path.join(stubsDir, 'structure_protocol', '__init__.py'), '');
+  writeFile(
+    path.join(stubsDir, 'structure_protocol', 'migrations.py'),
+    'def migrate_v1_to_v2(model): return model\n',
+  );
+  writeFile(
+    path.join(stubsDir, 'structure_protocol', 'structure_model_v2.py'),
+    [
+      'class StructureModelV2:',
+      '    def __init__(self, **data): self.data = data',
+      '    def model_dump(self, **kwargs): return dict(self.data)',
+    ].join('\n'),
+  );
+
+  writeFile(
     path.join(stubsDir, 'contracts.py'),
     [
       'class EngineNotAvailableError(RuntimeError):',
@@ -57,6 +99,7 @@ function writePkpmApiStub(stubsDir) {
       '        self.engine = engine',
       '        self.reason = reason',
       '        super().__init__(f"Engine {engine!r} unavailable: {reason}")',
+      'AnalysisResult = dict',
     ].join('\n'),
   );
 
@@ -210,15 +253,23 @@ function writePkpmApiStub(stubsDir) {
       '        self.design_params = list(values)',
       '        calls.append({"method": "Model.SetAllDesignPara", "values": list(values)})',
       '    def SetOneDesignParaValue(self, index, value): calls.append({"method": "Model.SetOneDesignParaValue", "index": index, "value": value})',
+      '    def AddStandFloor(self): calls.append({"method": "Model.AddStandFloor"})',
       '    def SaveProjectPara(self): calls.append({"method": "Model.SaveProjectPara"})',
       '    def SavePMModel(self): calls.append({"method": "Model.SavePMModel"})',
+      '',
+      'class ResultData:',
+      '    def InitialResult(self, jws_path): calls.append({"method": "ResultData.InitialResult", "jws_path": jws_path}); return 1',
+      '    def ClearResult(self): calls.append({"method": "ResultData.ClearResult"})',
+      '    def GetModePeriods(self): return [object(), object(), object()]',
+      '    def GetDesignBeams(self, floor): return [object()] if floor == 1 else []',
+      '    def GetDesignColumns(self, floor): return [object(), object()] if floor == 1 else []',
     ].join('\n'),
   );
 }
 
 const pythonCommand = resolvePythonCommand();
 
-function runPkpmRuntime(model) {
+function runPkpmRuntime(model, options = {}) {
   if (!pythonCommand) {
     throw new Error('No Python command available');
   }
@@ -238,11 +289,28 @@ function runPkpmRuntime(model) {
       'import APIPyInterface',
       'patch_calls = []',
       'run_calls = []',
+      `pdb_mismatch_text = ${JSON.stringify([
+        ' *WRN* PDB VERSION INCONSISTENT !',
+        '         FILE PDB VERSION NO.=    20250310',
+        '      PROGRAM PDB VERSION NO.=    20251220',
+      ].join('\n'))}`,
+      'def write_pdb_mismatch(work_dir):',
+      '    Path(work_dir, "SATWE_stub_MODEL0_HOLO_ERR.TXT").write_text(pdb_mismatch_text, encoding="utf-8")',
       'runtime._check_pkpm_available = lambda: Path("JWSCYCLE.exe")',
       'runtime._import_apipyinterface = lambda: None',
       'runtime._patch_material_label = lambda work_dir: patch_calls.append(str(work_dir))',
       'runtime._run_jws_cycle = lambda cycle_path, work_dir, timeout=600: run_calls.append({"cycle_path": str(cycle_path), "work_dir": str(work_dir), "timeout": timeout})',
       'def fake_extract(jws_path, material_family="steel"):',
+      ...(
+        options.createPdbMismatchDuringExtract
+          ? ['    write_pdb_mismatch(jws_path.parent)']
+          : []
+      ),
+      ...(
+        options.failExtract
+          ? ['    raise RuntimeError("simulated extraction failure")']
+          : []
+      ),
       '    return {',
       '        "summary": {"max_displacement_mm": 1.25, "max_shear_force_kn": 22.5, "max_bending_moment_kNm": 48.0},',
       '        "floors_analyzed": len(model.get("stories", [])),',
@@ -256,8 +324,20 @@ function runPkpmRuntime(model) {
       '    }',
       'runtime._extract_results = fake_extract',
       'model = json.loads(sys.stdin.read())',
-      'result = runtime.run_analysis(model, {"timeout": 12})',
-      'print(json.dumps({"result": result, "calls": APIPyInterface.calls, "patchCalls": patch_calls, "runCalls": run_calls}, ensure_ascii=False))',
+      ...(
+        options.expectFailure
+          ? [
+            'try:',
+            '    result = runtime.run_analysis(model, {"timeout": 12})',
+            '    print(json.dumps({"result": result, "calls": APIPyInterface.calls, "patchCalls": patch_calls, "runCalls": run_calls}, ensure_ascii=False))',
+            'except Exception as exc:',
+            '    print(json.dumps({"error": str(exc), "errorType": type(exc).__name__, "calls": APIPyInterface.calls, "patchCalls": patch_calls, "runCalls": run_calls}, ensure_ascii=False))',
+          ]
+          : [
+            'result = runtime.run_analysis(model, {"timeout": 12})',
+            'print(json.dumps({"result": result, "calls": APIPyInterface.calls, "patchCalls": patch_calls, "runCalls": run_calls}, ensure_ascii=False))',
+          ]
+      ),
     ].join('\n');
 
     const result = spawnSync(
@@ -268,6 +348,7 @@ function runPkpmRuntime(model) {
         encoding: 'utf8',
         env: {
           ...process.env,
+          PYTHONIOENCODING: 'utf-8',
           PKPM_WORK_DIR: workDir,
           PYTHONPATH: [stubsDir, runtimeSupportDir, pkpmDir, process.env.PYTHONPATH]
             .filter(Boolean)
@@ -279,6 +360,85 @@ function runPkpmRuntime(model) {
 
     if (result.status !== 0) {
       throw new Error(`PKPM runtime flow failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    }
+
+    const payloadLine = result.stdout
+      .trim()
+      .split(/\r?\n/)
+      .reverse()
+      .find((line) => line.trim().startsWith('{'));
+    expect(payloadLine).toBeTruthy();
+    return JSON.parse(payloadLine);
+  } finally {
+    fs.rmSync(stubsDir, { recursive: true, force: true });
+    fs.rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+function runPkpmProbe(options = {}) {
+  if (!pythonCommand) {
+    throw new Error('No Python command available');
+  }
+
+  const stubsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sclaw-pkpm-api-'));
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sclaw-pkpm-probe-'));
+  const fakeCyclePath = path.join(stubsDir, 'JWSCYCLE.exe');
+  writePkpmApiStub(stubsDir);
+  writeFile(fakeCyclePath, '');
+
+  try {
+    const script = [
+      'import json, os, sys',
+      'from pathlib import Path',
+      `sys.path.insert(0, ${JSON.stringify(stubsDir)})`,
+      `sys.path.insert(1, ${JSON.stringify(runtimeSupportDir)})`,
+      `sys.path.insert(2, ${JSON.stringify(skillSharedPythonRoot)})`,
+      'import registry',
+      'registry.AnalysisEngineRegistry._discover_builtin_skills = lambda self: [{',
+      '    "id": "pkpm-static",',
+      '    "engineId": "builtin-pkpm",',
+      '    "adapterKey": "builtin-pkpm",',
+      '    "analysisType": "static",',
+      '    "priority": 130,',
+      '    "supportedModelFamilies": ["frame", "generic"],',
+      '}]',
+      `pdb_mismatch_text = ${JSON.stringify([
+        ' *WRN* PDB VERSION INCONSISTENT !',
+        '         FILE PDB VERSION NO.=    20250310',
+        '      PROGRAM PDB VERSION NO.=    20251220',
+      ].join('\n'))}`,
+      'def fake_run(cycle_path, work_dir, timeout=120):',
+      ...(
+        options.createPdbMismatch
+          ? ['    Path(work_dir, "SATWE_probe_MODEL0_HOLO_ERR.TXT").write_text(pdb_mismatch_text, encoding="utf-8")']
+          : ['    return None']
+      ),
+      'registry.AnalysisEngineRegistry._run_jws_cycle_probe = staticmethod(fake_run)',
+      'service = registry.AnalysisEngineRegistry("StructureClaw Analysis Engine", "0.1.0")',
+      'result = service.probe_engine("builtin-pkpm")',
+      'print(json.dumps(result, ensure_ascii=False))',
+    ].join('\n');
+
+    const result = spawnSync(
+      pythonCommand.executable,
+      [...pythonCommand.args, '-c', script],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PYTHONIOENCODING: 'utf-8',
+          PKPM_CYCLE_PATH: fakeCyclePath,
+          PKPM_WORK_DIR: workDir,
+          PYTHONPATH: [stubsDir, runtimeSupportDir, skillSharedPythonRoot, process.env.PYTHONPATH]
+            .filter(Boolean)
+            .join(path.delimiter),
+        },
+        windowsHide: process.platform === 'win32',
+      },
+    );
+
+    if (result.status !== 0) {
+      throw new Error(`PKPM probe flow failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
     }
 
     const payloadLine = result.stdout
@@ -569,6 +729,50 @@ describe('PKPM frame analysis flow', () => {
     expect(payload.result.pkpm_detailed.input_design_conditions.wind).toMatchObject({
       basic_pressure: 0.4,
     });
+  });
+
+  test('keeps PKPM result when PDB version warning is present but core results are readable', () => {
+    const payload = runPkpmRuntime(buildRcUserScenarioModel(), {
+      createPdbMismatchDuringExtract: true,
+    });
+
+    expect(payload.result.status).toBe('success');
+    expect(payload.result.warnings.join('\n')).toContain('PDB version warning');
+    expect(payload.result.warnings.join('\n')).toContain('20250310');
+    expect(payload.result.warnings.join('\n')).toContain('20251220');
+    expect(payload.result.summary.floors_analyzed).toBe(2);
+  });
+
+  test('fails when PKPM result extraction fails with a PDB version mismatch', () => {
+    const payload = runPkpmRuntime(buildRcUserScenarioModel(), {
+      createPdbMismatchDuringExtract: true,
+      failExtract: true,
+      expectFailure: true,
+    });
+
+    expect(payload.result).toBeUndefined();
+    expect(payload.errorType).toBe('RuntimeError');
+    expect(payload.error).toContain('PDB version mismatch');
+    expect(payload.error).toContain('20250310');
+    expect(payload.error).toContain('20251220');
+    expect(payload.error).toContain('JWSCYCLE.exe');
+    expect(payload.error).toContain('APIPyInterface');
+  });
+
+  test('surfaces readable PKPM probe PDB warnings without deleted temp paths', () => {
+    const payload = runPkpmProbe({ createPdbMismatch: true });
+
+    expect(payload.passed).toBe(true);
+    expect(payload.warnings.join('\n')).toContain('PDB version warning');
+    expect(payload.warnings.join('\n')).toContain('20250310');
+    expect(payload.warnings.join('\n')).toContain('20251220');
+    expect(payload.warnings.join('\n')).not.toContain('workDir=');
+    expect(payload.warnings.join('\n')).not.toContain('errFile=');
+    expect(payload.steps).toContainEqual(expect.objectContaining({
+      name: 'Extract results',
+      passed: true,
+      details: 'modePeriods=3, beams=1, columns=2',
+    }));
   });
 
   test('parses WMASS damping as ratio and percent separately', () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: PKPM/SATWE can emit `PDB VERSION INCONSISTENT` in `*_ERR.TXT` while `JWSCYCLE.exe` still exits successfully and core `ResultData` values remain readable.
- Why it matters: treating this only as success hides an important compatibility warning, while treating it as an unconditional failure incorrectly blocks cases that still have usable PKPM results.
- What changed: added PKPM PDB diagnostics, surfaced readable-result warnings, and promoted the mismatch to a runtime failure only when extraction fails or core PKPM results are empty.
- What did NOT change (scope boundary): no PKPM installation files, Python package versions, model conversion rules, or report rendering behavior were changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: PKPM writes PDB compatibility warnings to SATWE error files independently of the process exit code and `ResultData.InitialResult()` status.
- Missing detection / guardrail: the runtime and probe did not inspect SATWE `*_ERR.TXT` files or distinguish warning-only PDB mismatches from result-breaking mismatches.
- Prior context (`git blame`, prior PR, issue, or refactor if known): recent PKPM engine work exposed this through local PKPM2025R2.5 runs using `pkpm_api=0.1.9`.
- Why this regressed now: PKPM diagnostics became more visible during recent engine validation, but the runtime still had no structured policy for this warning.
- If unknown, what was ruled out: ruled out Python debugger `pdb`; this is PKPM/SATWE model database PDB output.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/tests/analysis-pkpm-frame-flow.test.mjs`
- Scenario the test should lock in: PDB mismatch with readable PKPM core results remains successful with warnings; PDB mismatch with failed extraction fails clearly.
- Why this is the smallest reliable guardrail: it exercises the PKPM runtime boundary with the existing APIPyInterface stub without requiring a commercial PKPM install in CI.
- Existing test that already covers this (if any): existing PKPM frame flow tests covered model conversion and normal successful extraction but not SATWE ERR diagnostics.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

PKPM analysis may now include a warning when SATWE writes a PDB version mismatch but core results are still readable. If a PDB mismatch coincides with failed or empty result extraction, the PKPM run fails with a clearer diagnostic that includes the `JWSCYCLE.exe`, work directory, project version, `pkpm_api` version, and `APIPyInterface` path.

## Diagram (if applicable)

```text
Before:
PKPM run -> SATWE ERR warning ignored -> success or vague extraction warning

After:
PKPM run -> scan SATWE ERR -> core results readable -> success + warning
PKPM run -> scan SATWE ERR -> core results missing  -> explicit failure
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows 10/11 local development environment
- Runtime/container: Node backend + `G:\sclaw_data\.venv\Scripts\python.exe`
- Model/provider: N/A
- Integration/channel (if any): local PKPM/SATWE via `G:\PKPM2025R2.5\PkpmCycle\JWSCYCLE.exe`
- Relevant config (redacted): `pkpm.cyclePath` points to PKPM2025R2.5; runtime APIPyInterface loaded from `G:\sclaw_data\.venv\Lib\site-packages\APIPyInterface`

### Steps

1. Run a PKPM analysis/probe that writes `SATWE_*_ERR.TXT` containing `PDB VERSION INCONSISTENT`.
2. Check whether `ResultData.InitialResult()` and core outputs such as mode periods, beams, or columns are readable.
3. Confirm readable results produce success with warning; unreadable results produce explicit failure.

### Expected

- PDB mismatch does not unconditionally fail a PKPM run when core SATWE results are readable.
- PDB mismatch is surfaced in warnings or failure diagnostics instead of being silently ignored.

### Actual

- Before this PR, the warning was ignored by the runtime/probe.
- After this PR, readable-result mismatches are warnings and extraction-breaking mismatches are failures.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local reproduction observed `JWSCYCLE` return code `0`, `InitialResult=1`, readable counts `modePeriods=3`, `beams=1`, `columns=2`, while `SATWE_probe_MODEL0_HOLO_ERR.TXT` contained `PDB VERSION INCONSISTENT`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: stubbed PKPM runtime warning path, stubbed extraction failure path, local PKPM probe readability path.
- Edge cases checked: PDB mismatch with core results available; PDB mismatch with extraction failure; generic analyze contract remains unchanged.
- What you did **not** verify: full UI report rendering and alternate PKPM API package versions.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a PKPM warning may be treated as acceptable when some secondary result tables are degraded.
  - Mitigation: only core-readable cases remain successful, and the warning includes enough environment details for follow-up; extraction failure or empty core results still fails.