### PR TITLE
feat(backend): add concrete-frame skill core implementation (Part 3/4)

### DIFF
--- a/backend/src/agent-skills/code-check/entry.ts
+++ b/backend/src/agent-skills/code-check/entry.ts
@@ -333,11 +333,19 @@ function extractElementDataForCodeCheck(
       ...(typeof elem['lambdaLimit'] === 'number' ? { lambdaLimit: elem['lambdaLimit'] } : {}),
       ...(typeof elem['deflectionLimitN'] === 'number' ? { deflectionLimitN: elem['deflectionLimitN'] } : {}),
       ...(typeof elem['deflection'] === 'number' ? { deflection: elem['deflection'] } : {}),
-      // from metadata
-      ...(typeof elemMetadata['phi'] === 'number' ? { phi: elemMetadata['phi'] } : {}),
-      ...(typeof elemMetadata['phi_b'] === 'number' ? { phi_b: elemMetadata['phi_b'] } : {}),
-      ...(typeof elemMetadata['phi_axial'] === 'number' ? { phi_axial: elemMetadata['phi_axial'] } : {}),
-    };
+    // from metadata — steel design params
+    ...(typeof elemMetadata['phi'] === 'number' ? { phi: elemMetadata['phi'] } : {}),
+    ...(typeof elemMetadata['phi_b'] === 'number' ? { phi_b: elemMetadata['phi_b'] } : {}),
+    ...(typeof elemMetadata['phi_axial'] === 'number' ? { phi_axial: elemMetadata['phi_axial'] } : {}),
+    // from metadata — concrete rebar design (concrete-frame PR4)
+    ...(typeof elemMetadata['As'] === 'number' ? { As: elemMetadata['As'] } : {}),
+    ...(typeof elemMetadata['Asv'] === 'number' ? { Asv: elemMetadata['Asv'] } : {}),
+    ...(typeof elemMetadata['stirrup_dia'] === 'number' ? { stirrup_dia: elemMetadata['stirrup_dia'] } : {}),
+    ...(typeof elemMetadata['stirrup_spacing'] === 'number' ? { stirrup_spacing: elemMetadata['stirrup_spacing'] } : {}),
+    ...(typeof elemMetadata['main_dia'] === 'number' ? { main_dia: elemMetadata['main_dia'] } : {}),
+    ...(typeof elemMetadata['cover'] === 'number' ? { cover: elemMetadata['cover'] } : {}),
+    ...(typeof elemMetadata['crack_cover'] === 'number' ? { crack_cover: elemMetadata['crack_cover'] } : {}),
+  };
   }
 
   return elementData;

--- a/backend/src/agent-skills/code-check/gb50010/__tests__/test_gb50010.py
+++ b/backend/src/agent-skills/code-check/gb50010/__tests__/test_gb50010.py
@@ -141,7 +141,12 @@ class TestCheckElementResult:
                 'E1': {
                     'type': 'column',
                     'section': {'id': '1', 'name': '400X400'},
-                    'material': {'id': '1', 'grade': 'C30', 'category': 'concrete'},
+                    'material': {
+                        'id': '1', 'name': 'C30', 'grade': 'C30',
+                        'category': 'concrete', 'fc': 14.3, 'ft': 1.43,
+                        'ftk': 2.01, 'Ec': 30000, 'E': 30000,
+                        'ecu': 0.0033, 'alpha1': 1.0, 'beta1': 0.80,
+                    },
                     'concreteGrade': 'C30',
                     'rebarGrade': 'HRB400',
                 },
@@ -150,13 +155,8 @@ class TestCheckElementResult:
         assert result['elementType'] == 'column'
         assert result['checks'][0]['name'] == '柱承载力验算'
         assert result['checks'][0]['items'][0]['item'] == '轴压比'
-        assert result['elementContext'] == {
-            'type': 'column',
-            'section': {'id': '1', 'name': '400X400'},
-            'material': {'id': '1', 'grade': 'C30', 'category': 'concrete'},
-            'concreteGrade': 'C30',
-            'rebarGrade': 'HRB400',
-        }
+        assert result['elementContext']['concreteGrade'] == 'C30'
+        assert result['elementContext']['rebarGrade'] == 'HRB400'
 
     def test_element_type_column_from_id_prefix(self):
         checker = MockCodeChecker()
@@ -204,6 +204,210 @@ class TestCheckElementResult:
         checker = MockCodeChecker()
         result = gb50010.check_element(checker, 'E5', {})
         assert result['elementId'] == 'E5'
+
+
+class TestComputedUtilizationOverrides:
+    \"\"\"Integration tests: verify _compute_utilization_overrides produces real
+    utilization values from elementData (mirrors gb50017 paradigm).\"\"\"
+
+    def _make_concrete_element_data(self, **overrides):
+        \"\"\"Build elementData dict for a rectangular concrete element.\"\"\"
+        base = {
+            'type': 'beam',
+            'section': {
+                'width': 300, 'height': 500, 'A': 150000, 'Iy': 3.125e9,
+                'shape': {'kind': 'rectangular', 'B': 0.3, 'H': 0.5},
+            },
+            'material': {'fc': 14.3, 'fy': 360, 'E': 30000, 'nu': 0.2, 'rho': 2500},
+            'forces': {'N': 0, 'V': 100000, 'Mx': 50e6},
+            'length': 6000,
+            # Rebar design — from model element metadata (PR4)
+            'As': 628,         # 2Φ20
+            'Asv': 101,        # 2-leg Φ8
+            'stirrup_dia': 8,
+            'stirrup_spacing': 200,
+            'main_dia': 20,
+            'cover': 20,
+            'crack_cover': 25,
+        }
+        base.update(overrides)
+        return base
+
+    def _make_context(self, elem_data, concrete_grade='C30', rebar_grade='HRB400', elem_type='beam'):
+        return {
+            'elementData': {'B1': elem_data},
+            'elementContextById': {
+                'B1': {
+                    'type': elem_type,
+                    'concreteGrade': concrete_grade,
+                    'rebarGrade': rebar_grade,
+                    'section': {'id': '1', 'name': '300X500'},
+                    'material': {'id': '1', 'grade': 'C30', 'category': 'concrete'},
+                },
+            },
+        }
+
+    def test_beam_flexure_computes_real_value(self):
+        \"\"\"正截面受弯: elementData with real Mx → computed utilization.\"\"\"
+        elem_data = self._make_concrete_element_data()
+        context = self._make_context(elem_data)
+        computed = gb50010._compute_utilization_overrides('B1', context)
+        assert '正截面受弯' in computed
+        assert isinstance(computed['正截面受弯'], float)
+        assert computed['正截面受弯'] > 0
+
+    def test_beam_shear_computes_real_value(self):
+        \"\"\"斜截面受剪: V=100kN on 300×500 beam → realistic utilization.\"\"\"
+        elem_data = self._make_concrete_element_data(forces={'N': 0, 'V': 100000, 'Mx': 50e6})
+        context = self._make_context(elem_data)
+        computed = gb50010._compute_utilization_overrides('B1', context)
+        assert '斜截面受剪' in computed
+        assert isinstance(computed['斜截面受剪'], float)
+        assert computed['斜截面受剪'] > 0
+
+    def test_column_axial_ratio_from_element_data(self):
+        \"\"\"轴压比: N=1000kN, 400×400 C30 column → computed ratio.\"\"\"
+        elem_data = self._make_concrete_element_data(
+            type='column',
+            section={'width': 400, 'height': 400, 'A': 160000, 'Iy': 2.133e9,
+                     'shape': {'kind': 'rectangular', 'B': 0.4, 'H': 0.4}},
+            forces={'N': 1000000, 'V': 0, 'Mx': 0},
+        )
+        context = self._make_context(elem_data, elem_type='column')
+        computed = gb50010._compute_utilization_overrides('B1', context)
+        assert '轴压比' in computed
+        assert isinstance(computed['轴压比'], float)
+        # N=1000kN, fc=14.3, A=160000mm² → 1000*1000/(14.3*160000) ≈ 0.437
+        assert 0.3 < computed['轴压比'] < 0.7
+
+    def test_column_slenderness_computes_from_geometry(self):
+        \"\"\"长细比: l=3600mm, 400×400 section → λ computation.\"\"\"
+        elem_data = self._make_concrete_element_data(
+            type='column',
+            section={'width': 400, 'height': 400, 'A': 160000, 'Iy': 2.133e9,
+                     'shape': {'kind': 'rectangular', 'B': 0.4, 'H': 0.4}},
+            forces={'N': 1000000, 'V': 0, 'Mx': 0},
+            length=3600,
+        )
+        context = self._make_context(elem_data, elem_type='column')
+        computed = gb50010._compute_utilization_overrides('B1', context)
+        assert '长细比' in computed
+        assert isinstance(computed['长细比'], float)
+        assert computed['长细比'] > 0
+
+    def test_empty_element_data_returns_empty_dict(self):
+        \"\"\"No elementData → no computed overrides — graceful fallback.\"\"\"
+        computed = gb50010._compute_utilization_overrides('B1', {})
+        assert computed == {}
+
+    def test_missing_element_id_returns_empty_dict(self):
+        \"\"\"elementData exists but element ID not found → safe return.\"\"\"
+        context = {'elementData': {'OTHER': {'type': 'beam'}}}
+        computed = gb50010._compute_utilization_overrides('B1', context)
+        assert computed == {}
+
+    def test_material_fallback_from_element_data_when_no_context_grades(self):
+        \"\"\"When elementContextById has no grades, fall back to elementData.material.\"\"\"
+        elem_data = self._make_concrete_element_data(
+            material={'fc': 14.3, 'fy': 360, 'E': 30000},
+        )
+        context = {
+            'elementData': {'B1': elem_data},
+            'elementContextById': {},
+        }
+        computed = gb50010._compute_utilization_overrides('B1', context)
+        assert '正截面受弯' in computed
+
+    def test_beam_deflection_uses_element_data(self):
+        \"\"\"挠度: Mx + length + section → simplified deflection ratio.\"\"\"
+        elem_data = self._make_concrete_element_data(
+            forces={'N': 0, 'V': 50000, 'Mx': 30e6},
+            length=6000,
+        )
+        context = self._make_context(elem_data)
+        computed = gb50010._compute_utilization_overrides('B1', context)
+        assert '挠度' in computed
+        assert isinstance(computed['挠度'], float)
+        assert computed['挠度'] > 0
+
+    def test_eccentric_compression_with_moment(self):
+        \"\"\"偏心受压: N + Mx → N-M interaction utilization.\"\"\"
+        elem_data = self._make_concrete_element_data(
+            type='column',
+            section={'width': 400, 'height': 400, 'A': 160000, 'Iy': 2.133e9,
+                     'shape': {'kind': 'rectangular', 'B': 0.4, 'H': 0.4}},
+            forces={'N': 800000, 'V': 50000, 'Mx': 80e6},
+            length=3600,
+        )
+        context = self._make_context(elem_data, elem_type='column')
+        computed = gb50010._compute_utilization_overrides('B1', context)
+        assert '偏心受压' in computed
+        assert isinstance(computed['偏心受压'], float)
+        assert computed['偏心受压'] > 0
+
+    def test_check_element_uses_real_values_via_merged_context(self):
+        \"\"\"End-to-end: check_element with elementData → real utilization
+        flows through _calc_item instead of mock 0.55 default.\"\"\"
+        elem_data = self._make_concrete_element_data(
+            forces={'N': 0, 'V': 100000, 'Mx': 50e6},
+        )
+        context = self._make_context(elem_data)
+        checker = MockCodeChecker()
+        result = gb50010.check_element(checker, 'B1', context)
+
+        assert result['elementType'] == 'beam'
+        assert result['code'] == 'GB50010-2010'
+
+        # Find 正截面受弯 item — should have real computed utilization, not mock 0.55
+        flexure_item = result['checks'][0]['items'][0]
+        assert flexure_item['item'] == '正截面受弯'
+        # Real utilization should differ from the 0.55 mock default
+        assert flexure_item['utilization'] != 0.55
+        assert flexure_item['utilization'] > 0
+
+    def test_crack_width_computes_real_value(self):
+        \"\"\"裂缝宽度: Mx+geometry → ω_max/w_lim  utilization.\"\"\"
+        elem_data = self._make_concrete_element_data(
+            section={'width': 300, 'height': 500, 'A': 150000, 'Iy': 3.125e9,
+                     'shape': {'kind': 'rectangular', 'B': 0.3, 'H': 0.5}},
+            material={'fc': 14.3, 'ft': 1.43, 'ftk': 2.01, 'Ec': 30000, 'E': 30000,
+                      'Es': 200000, 'ecu': 0.0033, 'alpha1': 1.0, 'beta1': 0.80},
+            forces={'N': 0, 'V': 50000, 'Mx': 40e6},
+            length=6000,
+        )
+        context = self._make_context(elem_data)
+        computed = gb50010._compute_utilization_overrides('B1', context)
+        assert '裂缝宽度' in computed
+        assert isinstance(computed['裂缝宽度'], float)
+        assert computed['裂缝宽度'] > 0
+
+    def test_material_design_values_from_element_data(self):
+        \"\"\"When elementData has full concrete design values (ft/ftk/Ec/alpha1/
+        beta1/ecu), _resolve_material_props uses them directly — not lookup.\"\"\"
+        elem_data = self._make_concrete_element_data(
+            material={
+                'fc': 23.1, 'ft': 1.89, 'ftk': 2.64, 'Ec': 34500, 'E': 34500,
+                'ecu': 0.0033, 'alpha1': 0.98, 'beta1': 0.78,
+            },
+        )
+        mat = gb50010._resolve_material_props('C30', 'HRB400', elem_data)
+        # C50 design values from elementData — NOT C30 fallback
+        assert mat['fc'] == 23.1
+        assert mat['ft'] == 1.89
+        assert mat['ftk'] == 2.64
+        assert mat['alpha1'] == 0.98
+        assert mat['beta1'] == 0.78
+
+    def test_material_falls_back_when_element_data_incomplete(self):
+        \"\"\"When elementData has only fc, fall back to lookup table for others.\"\"\"
+        elem_data = self._make_concrete_element_data(
+            material={'fc': 14.3},  # only fc, no ft/ftk/etc.
+        )
+        mat = gb50010._resolve_material_props('C30', 'HRB400', elem_data)
+        assert mat['fc'] == 14.3  # from elementData
+        assert mat['ft'] == 1.43  # from C30 lookup
+        assert mat['ftk'] == 2.01  # from C30 lookup
+        assert mat['alpha1'] == 1.0  # from C30 lookup
 
 
 if __name__ == '__main__':

--- a/backend/src/agent-skills/code-check/gb50010/__tests__/test_gb50010.py
+++ b/backend/src/agent-skills/code-check/gb50010/__tests__/test_gb50010.py
@@ -23,6 +23,15 @@ class MockCodeChecker:
         raw = per_elem.get(item_name)
         if isinstance(raw, (int, float)):
             return max(0.0, float(raw))
+        # Fallback: read computed overrides from context (set by
+        # _compute_utilization_overrides + check_element merge)
+        ube = context.get('utilizationByElement', {})
+        if isinstance(ube, dict):
+            per_elem_ctx = ube.get(elem_id, {})
+            if isinstance(per_elem_ctx, dict):
+                raw = per_elem_ctx.get(item_name)
+                if isinstance(raw, (int, float)):
+                    return max(0.0, float(raw))
         return 0.55
 
     def _calc_item(self, elem_id, item_name, context, clause, formula, limit):
@@ -207,11 +216,11 @@ class TestCheckElementResult:
 
 
 class TestComputedUtilizationOverrides:
-    \"\"\"Integration tests: verify _compute_utilization_overrides produces real
-    utilization values from elementData (mirrors gb50017 paradigm).\"\"\"
+    """Integration tests: verify _compute_utilization_overrides produces real
+    utilization values from elementData (mirrors gb50017 paradigm)."""
 
     def _make_concrete_element_data(self, **overrides):
-        \"\"\"Build elementData dict for a rectangular concrete element.\"\"\"
+        """Build elementData dict for a rectangular concrete element."""
         base = {
             'type': 'beam',
             'section': {
@@ -248,7 +257,7 @@ class TestComputedUtilizationOverrides:
         }
 
     def test_beam_flexure_computes_real_value(self):
-        \"\"\"正截面受弯: elementData with real Mx → computed utilization.\"\"\"
+        """正截面受弯: elementData with real Mx → computed utilization."""
         elem_data = self._make_concrete_element_data()
         context = self._make_context(elem_data)
         computed = gb50010._compute_utilization_overrides('B1', context)
@@ -257,7 +266,7 @@ class TestComputedUtilizationOverrides:
         assert computed['正截面受弯'] > 0
 
     def test_beam_shear_computes_real_value(self):
-        \"\"\"斜截面受剪: V=100kN on 300×500 beam → realistic utilization.\"\"\"
+        """斜截面受剪: V=100kN on 300×500 beam → realistic utilization."""
         elem_data = self._make_concrete_element_data(forces={'N': 0, 'V': 100000, 'Mx': 50e6})
         context = self._make_context(elem_data)
         computed = gb50010._compute_utilization_overrides('B1', context)
@@ -266,7 +275,7 @@ class TestComputedUtilizationOverrides:
         assert computed['斜截面受剪'] > 0
 
     def test_column_axial_ratio_from_element_data(self):
-        \"\"\"轴压比: N=1000kN, 400×400 C30 column → computed ratio.\"\"\"
+        """轴压比: N=1000kN, 400×400 C30 column → computed ratio."""
         elem_data = self._make_concrete_element_data(
             type='column',
             section={'width': 400, 'height': 400, 'A': 160000, 'Iy': 2.133e9,
@@ -281,7 +290,7 @@ class TestComputedUtilizationOverrides:
         assert 0.3 < computed['轴压比'] < 0.7
 
     def test_column_slenderness_computes_from_geometry(self):
-        \"\"\"长细比: l=3600mm, 400×400 section → λ computation.\"\"\"
+        """长细比: l=3600mm, 400×400 section → λ computation."""
         elem_data = self._make_concrete_element_data(
             type='column',
             section={'width': 400, 'height': 400, 'A': 160000, 'Iy': 2.133e9,
@@ -296,18 +305,18 @@ class TestComputedUtilizationOverrides:
         assert computed['长细比'] > 0
 
     def test_empty_element_data_returns_empty_dict(self):
-        \"\"\"No elementData → no computed overrides — graceful fallback.\"\"\"
+        """No elementData → no computed overrides — graceful fallback."""
         computed = gb50010._compute_utilization_overrides('B1', {})
         assert computed == {}
 
     def test_missing_element_id_returns_empty_dict(self):
-        \"\"\"elementData exists but element ID not found → safe return.\"\"\"
+        """elementData exists but element ID not found → safe return."""
         context = {'elementData': {'OTHER': {'type': 'beam'}}}
         computed = gb50010._compute_utilization_overrides('B1', context)
         assert computed == {}
 
     def test_material_fallback_from_element_data_when_no_context_grades(self):
-        \"\"\"When elementContextById has no grades, fall back to elementData.material.\"\"\"
+        """When elementContextById has no grades, fall back to elementData.material."""
         elem_data = self._make_concrete_element_data(
             material={'fc': 14.3, 'fy': 360, 'E': 30000},
         )
@@ -319,7 +328,7 @@ class TestComputedUtilizationOverrides:
         assert '正截面受弯' in computed
 
     def test_beam_deflection_uses_element_data(self):
-        \"\"\"挠度: Mx + length + section → simplified deflection ratio.\"\"\"
+        """挠度: Mx + length + section → simplified deflection ratio."""
         elem_data = self._make_concrete_element_data(
             forces={'N': 0, 'V': 50000, 'Mx': 30e6},
             length=6000,
@@ -331,7 +340,7 @@ class TestComputedUtilizationOverrides:
         assert computed['挠度'] > 0
 
     def test_eccentric_compression_with_moment(self):
-        \"\"\"偏心受压: N + Mx → N-M interaction utilization.\"\"\"
+        """偏心受压: N + Mx → N-M interaction utilization."""
         elem_data = self._make_concrete_element_data(
             type='column',
             section={'width': 400, 'height': 400, 'A': 160000, 'Iy': 2.133e9,
@@ -346,8 +355,8 @@ class TestComputedUtilizationOverrides:
         assert computed['偏心受压'] > 0
 
     def test_check_element_uses_real_values_via_merged_context(self):
-        \"\"\"End-to-end: check_element with elementData → real utilization
-        flows through _calc_item instead of mock 0.55 default.\"\"\"
+        """End-to-end: check_element with elementData → real utilization
+        flows through _calc_item instead of mock 0.55 default."""
         elem_data = self._make_concrete_element_data(
             forces={'N': 0, 'V': 100000, 'Mx': 50e6},
         )
@@ -366,7 +375,7 @@ class TestComputedUtilizationOverrides:
         assert flexure_item['utilization'] > 0
 
     def test_crack_width_computes_real_value(self):
-        \"\"\"裂缝宽度: Mx+geometry → ω_max/w_lim  utilization.\"\"\"
+        """裂缝宽度: Mx+geometry → ω_max/w_lim  utilization."""
         elem_data = self._make_concrete_element_data(
             section={'width': 300, 'height': 500, 'A': 150000, 'Iy': 3.125e9,
                      'shape': {'kind': 'rectangular', 'B': 0.3, 'H': 0.5}},
@@ -382,8 +391,8 @@ class TestComputedUtilizationOverrides:
         assert computed['裂缝宽度'] > 0
 
     def test_material_design_values_from_element_data(self):
-        \"\"\"When elementData has full concrete design values (ft/ftk/Ec/alpha1/
-        beta1/ecu), _resolve_material_props uses them directly — not lookup.\"\"\"
+        """When elementData has full concrete design values (ft/ftk/Ec/alpha1/
+        beta1/ecu), _resolve_material_props uses them directly — not lookup."""
         elem_data = self._make_concrete_element_data(
             material={
                 'fc': 23.1, 'ft': 1.89, 'ftk': 2.64, 'Ec': 34500, 'E': 34500,
@@ -399,7 +408,7 @@ class TestComputedUtilizationOverrides:
         assert mat['beta1'] == 0.78
 
     def test_material_falls_back_when_element_data_incomplete(self):
-        \"\"\"When elementData has only fc, fall back to lookup table for others.\"\"\"
+        """When elementData has only fc, fall back to lookup table for others."""
         elem_data = self._make_concrete_element_data(
             material={'fc': 14.3},  # only fc, no ft/ftk/etc.
         )

--- a/backend/src/agent-skills/code-check/gb50010/code_check.py
+++ b/backend/src/agent-skills/code-check/gb50010/code_check.py
@@ -1,6 +1,14 @@
+\"\"\"GB50010-2010 混凝土结构设计规范 — 构件校核实现。
+
+覆盖第 6 章（承载能力极限状态）、第 7 章（构造与稳定）中梁、柱的
+构件级验算。采用 gb50017 范式：_compute_utilization_overrides()
+从 elementData 读取 OpenSees 真实内力，计算实际利用率。
+\"\"\"
 from __future__ import annotations
 
 from typing import Any, Dict, List
+
+import math
 
 
 def get_rules() -> Dict[str, Any]:
@@ -47,6 +55,386 @@ def _resolve_element_type(elem_id: str, context: Dict[str, Any]) -> str:
     if lower.startswith('c') or 'column' in lower or 'col' in lower:
         return 'column'
     return 'beam'
+
+
+# ---------------------------------------------------------------------------
+# Material property lookup — GB/T 50010-2010 Tables 4.1.3, 4.1.5, 4.2.3
+# ---------------------------------------------------------------------------
+
+_CONCRETE_GRADES: Dict[str, Dict[str, float]] = {
+    'C20':  {'fck': 13.4, 'ftk': 1.54, 'fc': 9.6,  'ft': 1.10, 'Ec': 25500, 'ecu': 0.0033, 'alpha1': 1.0,  'beta1': 0.80},
+    'C25':  {'fck': 16.7, 'ftk': 1.78, 'fc': 11.9, 'ft': 1.27, 'Ec': 28000, 'ecu': 0.0033, 'alpha1': 1.0,  'beta1': 0.80},
+    'C30':  {'fck': 20.1, 'ftk': 2.01, 'fc': 14.3, 'ft': 1.43, 'Ec': 30000, 'ecu': 0.0033, 'alpha1': 1.0,  'beta1': 0.80},
+    'C35':  {'fck': 23.4, 'ftk': 2.20, 'fc': 16.7, 'ft': 1.57, 'Ec': 31500, 'ecu': 0.0033, 'alpha1': 1.0,  'beta1': 0.80},
+    'C40':  {'fck': 26.8, 'ftk': 2.39, 'fc': 19.1, 'ft': 1.71, 'Ec': 32500, 'ecu': 0.0033, 'alpha1': 1.0,  'beta1': 0.80},
+    'C45':  {'fck': 29.6, 'ftk': 2.51, 'fc': 21.1, 'ft': 1.80, 'Ec': 33500, 'ecu': 0.0033, 'alpha1': 0.99, 'beta1': 0.79},
+    'C50':  {'fck': 32.4, 'ftk': 2.64, 'fc': 23.1, 'ft': 1.89, 'Ec': 34500, 'ecu': 0.0033, 'alpha1': 0.98, 'beta1': 0.78},
+    'C55':  {'fck': 35.5, 'ftk': 2.74, 'fc': 25.3, 'ft': 1.96, 'Ec': 35500, 'ecu': 0.00325,'alpha1': 0.97, 'beta1': 0.77},
+    'C60':  {'fck': 38.5, 'ftk': 2.85, 'fc': 27.5, 'ft': 2.04, 'Ec': 36000, 'ecu': 0.0032, 'alpha1': 0.96, 'beta1': 0.76},
+    'C65':  {'fck': 41.5, 'ftk': 2.93, 'fc': 29.7, 'ft': 2.09, 'Ec': 36500, 'ecu': 0.00315,'alpha1': 0.95, 'beta1': 0.75},
+    'C70':  {'fck': 44.5, 'ftk': 2.99, 'fc': 31.8, 'ft': 2.14, 'Ec': 37000, 'ecu': 0.0031, 'alpha1': 0.94, 'beta1': 0.74},
+    'C75':  {'fck': 47.4, 'ftk': 3.05, 'fc': 33.8, 'ft': 2.18, 'Ec': 37500, 'ecu': 0.00305,'alpha1': 0.93, 'beta1': 0.73},
+    'C80':  {'fck': 50.2, 'ftk': 3.11, 'fc': 35.9, 'ft': 2.22, 'Ec': 38000, 'ecu': 0.003,  'alpha1': 0.92, 'beta1': 0.72},
+}
+
+_REBAR_GRADES: Dict[str, Dict[str, float]] = {
+    'HPB300': {'fyk': 300, 'fstk': 420, 'fy': 270, 'fy_compression': 270, 'fyv': 270, 'Es': 210000},
+    'HRB335': {'fyk': 335, 'fstk': 455, 'fy': 300, 'fy_compression': 300, 'fyv': 300, 'Es': 200000},
+    'HRB400': {'fyk': 400, 'fstk': 540, 'fy': 360, 'fy_compression': 360, 'fyv': 360, 'Es': 200000},
+    'HRBF400':{'fyk': 400, 'fstk': 540, 'fy': 360, 'fy_compression': 360, 'fyv': 360, 'Es': 200000},
+    'RRB400': {'fyk': 400, 'fstk': 540, 'fy': 360, 'fy_compression': 360, 'fyv': 360, 'Es': 200000},
+    'HRB500': {'fyk': 500, 'fstk': 630, 'fy': 435, 'fy_compression': 410, 'fyv': 360, 'Es': 200000},
+    'HRBF500':{'fyk': 500, 'fstk': 630, 'fy': 435, 'fy_compression': 410, 'fyv': 360, 'Es': 200000},
+}
+
+
+def _resolve_material_props(
+    concrete_grade: str | None,
+    rebar_grade: str | None,
+    elem_data: Dict[str, Any],
+) -> Dict[str, float]:
+    \"\"\"Resolve full concrete/rebar design properties.
+
+    Prefers values from elementData.material (model design values from
+    concrete-frame material records). Falls back to built-in lookup table
+    when elementData is incomplete (e.g. for analysis engines that don't
+    populate full design values).
+    \"\"\"
+    material_raw = elem_data.get('material', {})
+    material = material_raw if isinstance(material_raw, dict) else {}
+
+    # Concrete — prefer elementData, fallback to lookup
+    lookup_concrete = _CONCRETE_GRADES.get(concrete_grade or '', {})
+
+    def _get(key: str, fallback_key: str | None = None, default: float = 0.0) -> float:
+        val = material.get(key)
+        if isinstance(val, (int, float)):
+            return float(val)
+        if fallback_key:
+            val = material.get(fallback_key)
+            if isinstance(val, (int, float)):
+                return float(val)
+        return float(lookup_concrete.get(key, default))
+
+    # Rebar — prefer elementData, fallback to lookup
+    lookup_rebar = _REBAR_GRADES.get(rebar_grade or '', {})
+
+    def _get_rebar(key: str, default: float = 0.0) -> float:
+        val = material.get(key)
+        if isinstance(val, (int, float)):
+            return float(val)
+        return float(lookup_rebar.get(key, default))
+
+    return {
+        # Concrete design values (from model or lookup)
+        'fc':     _get('fc', default=14.3),
+        'ft':     _get('ft', default=1.43),
+        'ftk':    _get('ftk', default=2.01),
+        'Ec':     _get('Ec', 'E', 30000),
+        'ecu':    _get('ecu', default=0.0033),
+        'alpha1': _get('alpha1', default=1.0),
+        'beta1':  _get('beta1', default=0.80),
+        # Rebar design values (from model or lookup)
+        'fy':     _get_rebar('fy', 360),
+        'fyv':    _get_rebar('fyv', 360),
+        'fy_comp': _get_rebar('fy_compression', 360),
+        'Es':     _get_rebar('Es', _get_rebar('E', 200000)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Utilization computation from elementData (gb50017 paradigm)
+# ---------------------------------------------------------------------------
+
+_STABILITY_COEFF_TABLE: List[tuple[float, float]] = [
+    (8, 1.00), (10, 0.98), (12, 0.95), (14, 0.92),
+    (16, 0.87), (18, 0.81), (20, 0.75), (22, 0.70),
+    (24, 0.65), (26, 0.60), (28, 0.56), (30, 0.52),
+]
+
+
+def _stability_coeff(l0b: float) -> float:
+    \"\"\"Axial compression stability coefficient φ (GB50010-2010 Table 6.2.15).\"\"\"
+    if l0b <= 8:
+        return 1.00
+    if l0b >= 30:
+        return 0.52
+    for i in range(len(_STABILITY_COEFF_TABLE) - 1):
+        a, phi_a = _STABILITY_COEFF_TABLE[i]
+        b, phi_b = _STABILITY_COEFF_TABLE[i + 1]
+        if a <= l0b <= b:
+            return phi_a + (phi_b - phi_a) * (l0b - a) / (b - a)
+    return 0.52
+
+
+def _compute_utilization_overrides(
+    elem_id: str, context: Dict[str, Any],
+) -> Dict[str, float]:
+    \"\"\"Compute utilization ratios from elementData for GB50010.
+
+    Reads OpenSees real forces (N, V, Mx), section geometry (b, h, A, I),
+    and material grades from elementContextById to compute actual
+    utilization ratios per GB50010-2010 formulas.
+
+    Returns a new dict of computed overrides. Does NOT mutate context.
+    \"\"\"
+    element_data = context.get('elementData', {})
+    if not isinstance(element_data, dict):
+        return {}
+    elem = element_data.get(elem_id)
+    if not isinstance(elem, dict):
+        return {}
+
+    section = elem.get('section', {})
+    material = elem.get('material', {})
+    forces = elem.get('forces', {})
+    if not isinstance(section, dict) or not isinstance(material, dict) or not isinstance(forces, dict):
+        return {}
+
+    # Resolve element context for grade info
+    element_context = _resolve_element_context(elem_id, context)
+    concrete_grade = element_context.get('concreteGrade')
+    rebar_grade = element_context.get('rebarGrade')
+    mat = _resolve_material_props(concrete_grade, rebar_grade, elem)
+
+    # Section geometry (mm)
+    b = section.get('width') or section.get('B')
+    h = section.get('height') or section.get('H')
+    A_mm2 = section.get('A')
+    I_min = section.get('I') or section.get('Iy')
+
+    # Rebar design — from model element metadata (concrete-frame PR4) or compute minimums
+    As_design = elem.get('As')               # total rebar area (mm²) — model design value
+    Asv_design = elem.get('Asv')             # stirrup area (mm²)
+    stirrup_dia = elem.get('stirrup_dia')    # stirrup diameter (mm)
+    stirrup_spacing = elem.get('stirrup_spacing')  # stirrup spacing (mm)
+    main_dia = elem.get('main_dia')          # main bar diameter (mm)
+    cover = elem.get('cover')                # concrete cover (mm)
+    crack_cover = elem.get('crack_cover')    # cover for crack check (mm)
+
+    # Forces (N, N·mm)
+    N_newton = forces.get('N')  # axial force in N
+    V_newton = forces.get('V')  # shear force in N
+    Mx = forces.get('Mx')       # moment (N·mm from OpenSees envelope)
+
+    # Element length (mm)
+    length_mm = elem.get('length')
+
+    # Existing caller overrides take priority
+    existing = context.get('utilizationByElement', {})
+    if isinstance(existing, dict):
+        per_elem = existing.get(elem_id, {})
+        if not isinstance(per_elem, dict):
+            per_elem = {}
+    else:
+        per_elem = {}
+
+    def _has_override(key: str) -> bool:
+        val = per_elem.get(key)
+        return isinstance(val, (int, float))
+
+    computed: Dict[str, float] = {}
+
+    # ---------- COLUMN CHECKS ----------
+
+    # 轴压比 (§6.2.15): N / (fc * A)
+    if not _has_override('轴压比') and N_newton is not None and A_mm2 is not None and mat['fc'] > 0:
+        try:
+            N_kn = abs(float(N_newton)) / 1000.0  # N → kN
+            fc_mpa = mat['fc']  # N/mm²
+            A = float(A_mm2)  # mm²
+            computed['轴压比'] = (N_kn * 1000) / (fc_mpa * A)
+        except (ZeroDivisionError, ValueError, TypeError):
+            pass
+
+    # 长细比 (§6.2.20): l0/i / limit
+    if not _has_override('长细比') and length_mm is not None and A_mm2 is not None and I_min is not None:
+        try:
+            A = float(A_mm2)
+            I = float(I_min)
+            L = float(length_mm)
+            if A > 0 and I > 0:
+                i_min = math.sqrt(I / A)
+                slenderness = L / i_min
+                # General limit for concrete columns: 120 (GB50010-2010 §6.2.20)
+                limit = float(elem.get('lambdaLimit', 120))
+                if limit > 0:
+                    computed['长细比'] = slenderness / limit
+        except (ZeroDivisionError, ValueError, TypeError):
+            pass
+
+    # 偏心受压 (§6.2.17): simplified N-M interaction using φ·fc·A + fy·As
+    if not _has_override('偏心受压') and N_newton is not None and Mx is not None and b is not None and h is not None and A_mm2 is not None:
+        try:
+            B = float(b)
+            H = float(h)
+            A = float(A_mm2)
+            N_kn = abs(float(N_newton)) / 1000.0  # N → kN
+            M_knm = abs(float(Mx)) / 1e6            # N·mm → kN·m
+
+            # Rebar: use model design value, fallback to min 0.6% (§9.3.1)
+            h0 = H - (float(cover) if isinstance(cover, (int, float)) else 40)
+            if isinstance(As_design, (int, float)) and float(As_design) > 0:
+                As_total = float(As_design)
+            else:
+                rho_min = max(0.006, 0.55 * mat['ft'] / mat['fy'])
+                As_total = rho_min * A
+
+            # Section capacity estimates
+            N_capacity = 0.9 * mat['fc'] * A  # kN
+            M_capacity = 0.9 * mat['fy'] * As_total * h0 / 1e6  # kN·m
+
+            # Simplified linear interaction: N/Nu + M/Mu
+            if N_capacity > 0:
+                n_ratio = N_kn / N_capacity
+            else:
+                n_ratio = 0.0
+
+            if M_knm > 0 and M_capacity > 0:
+                m_ratio = M_knm / M_capacity
+                # For high axial load, stability reduction
+                if N_kn > 0.3 * N_capacity and length_mm is not None:
+                    L = float(length_mm)
+                    l0b = L / min(B, H)
+                    phi = _stability_coeff(l0b)
+                    n_ratio = N_kn / (phi * N_capacity) if phi > 0 else n_ratio
+                computed['偏心受压'] = n_ratio + m_ratio if M_knm > 0 else n_ratio
+            else:
+                computed['偏心受压'] = n_ratio
+
+        except (ZeroDivisionError, ValueError, TypeError):
+            pass
+
+    # 斜截面受剪 — column (§6.3.12): V / (Vc + Vs)
+    if not _has_override('斜截面受剪') and V_newton is not None and b is not None and h is not None:
+        try:
+            B = float(b)
+            H = float(h)
+            V_kn = abs(float(V_newton)) / 1000.0  # N → kN
+            h0 = H - 40
+
+            # Concrete shear contribution: Vc = 0.7 * ft * b * h0 / 1000
+            Vc = 0.7 * mat['ft'] * B * h0 / 1000.0  # kN
+
+            # Stirrup: use model design values, fallback to Φ8@200
+            fyv_capped = min(mat['fyv'], 360)  # §4.2.3 cap
+            s = float(stirrup_spacing) if isinstance(stirrup_spacing, (int, float)) else 200.0
+            if isinstance(Asv_design, (int, float)) and float(Asv_design) > 0:
+                Asv = float(Asv_design)
+            else:
+                Asv = 2 * math.pi * 8**2 / 4  # 2-leg Φ8 ≈ 100.5 mm²
+            Vs = fyv_capped * Asv * h0 / s / 1000.0  # kN
+
+            V_capacity = Vc + Vs
+            if V_capacity > 0:
+                computed['斜截面受剪'] = V_kn / V_capacity
+
+        except (ZeroDivisionError, ValueError, TypeError):
+            pass
+
+    # ---------- BEAM CHECKS ----------
+
+    # 正截面受弯 (§6.2.1 / §6.2.10): M / Mu
+    if not _has_override('正截面受弯') and Mx is not None and b is not None and h is not None:
+        try:
+            B = float(b)
+            H = float(h)
+            M_knm = abs(float(Mx)) / 1e6  # N·mm → kN·m
+            h0 = H - 40
+
+            # Rebar: use model design value, fallback to min 0.2% (§8.5)
+            if isinstance(As_design, (int, float)) and float(As_design) > 0:
+                As_min = float(As_design)
+            else:
+                rho_min = max(0.002, 0.45 * mat['ft'] / mat['fy'])
+                As_min = rho_min * B * h0
+
+            # Equivalent stress block (§6.2.6)
+            x = mat['fy'] * As_min / (mat['alpha1'] * mat['fc'] * B) if mat['fc'] > 0 and B > 0 else 0
+            xi_b = mat['beta1'] / (1 + mat['fy'] / (mat['Es'] * mat['ecu']))  # balanced xi
+            xb = xi_b * h0
+            x = min(x, xb)  # ensure under-reinforced
+            Mu = mat['alpha1'] * mat['fc'] * B * x * (h0 - x / 2) / 1e6  # kN·m
+            if Mu > 0:
+                computed['正截面受弯'] = M_knm / Mu
+
+        except (ZeroDivisionError, ValueError, TypeError):
+            pass
+
+    # 挠度 (§3.3.2): simplified — assume simply-supported, check mid-span
+    if not _has_override('挠度') and Mx is not None and b is not None and h is not None and length_mm is not None:
+        try:
+            B = float(b)
+            H = float(h)
+            L = float(length_mm)  # mm
+            M_knm = abs(float(Mx)) / 1e6  # N·mm → kN·m
+
+            # EI from section and Ec
+            I_cracked = B * H**3 / 12  # gross section I, mm⁴
+            # Reduced stiffness: Bs = 0.85 * Ec * I (short-term, §7.2.3 simplified)
+            Bs = 0.85 * mat['Ec'] * I_cracked  # N·mm²
+            if Bs > 0:
+                # Deflection for simply-supported uniform load: f = 5Ml²/(48EI)
+                # Use service moment ≈ 0.6 * ULS moment (approximate)
+                M_service = M_knm * 0.6 * 1e6  # N·mm
+                f_max = 5 * M_service * L**2 / (48 * Bs)  # mm
+                f_limit = L / 250  # common limit
+                if f_limit > 0:
+                    computed['挠度'] = f_max / f_limit
+
+        except (ZeroDivisionError, ValueError, TypeError):
+            pass
+
+    # 裂缝宽度 (§7.1.2): ω_max = α_cr·ψ·σ_sk/Es·(1.9·c_s+0.08·d_eq/ρ_te)
+    if not _has_override('裂缝宽度') and Mx is not None and b is not None and h is not None:
+        try:
+            B = float(b)
+            H = float(h)
+            M_knm = abs(float(Mx)) / 1e6
+            h0 = H - (float(cover) if isinstance(cover, (int, float)) else 40)
+
+            # Rebar: use model design values, fallback to minimum
+            if isinstance(As_design, (int, float)) and float(As_design) > 0:
+                As_crack = float(As_design)
+            else:
+                rho_min = max(0.002, 0.45 * mat['ft'] / mat['fy'])
+                As_crack = rho_min * B * h0
+
+            d_main = float(main_dia) if isinstance(main_dia, (int, float)) else (
+                25 if H >= 600 else (20 if H >= 400 else 16))
+            c_s = float(crack_cover) if isinstance(crack_cover, (int, float)) else 25
+
+            # Effective tension zone
+            A_te = 0.5 * B * H
+            rho_te = As_crack / A_te if A_te > 0 else 0.01
+            rho_te = max(rho_te, 0.01)  # minimum per §7.1.2
+
+            # Service load steel stress (§7.1.4)
+            M_service = M_knm * 0.6 * 1e6  # N·mm
+            sigma_sk = M_service / (0.87 * h0 * As_crack) if As_crack > 0 and h0 > 0 else 0
+
+            # Strain nonuniformity coefficient ψ
+            if mat['ftk'] > 0 and rho_te > 0 and sigma_sk > 0:
+                psi = 1.1 - 0.65 * mat['ftk'] / (rho_te * sigma_sk)
+                psi = max(0.2, min(psi, 1.0))  # bounds
+            else:
+                psi = 0.2
+
+            # Crack width (mm)
+            alpha_cr = 1.9  # bending member
+            d_eq = d_main
+            if mat['Es'] > 0:
+                omega = alpha_cr * psi * sigma_sk / mat['Es'] * (
+                    1.9 * c_s + 0.08 * d_eq / rho_te
+                )
+                # Limit: 0.3mm (indoor normal environment, §3.4.5)
+                w_lim = 0.3
+                if w_lim > 0:
+                    computed['裂缝宽度'] = omega / w_lim
+        except (ZeroDivisionError, ValueError, TypeError):
+            pass
+
+    return computed
 
 
 def _build_chapter_summaries(checks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -117,9 +505,38 @@ def _check_column(checker: Any, elem_id: str, context: Dict[str, Any]) -> List[D
 
 
 def check_element(checker: Any, elem_id: str, context: Dict[str, Any]) -> Dict[str, Any]:
+    \"\"\"GB50010-2010 构件校核入口 — gb50017 范式。
+
+    1. 从 elementData 计算真实利用率 (_compute_utilization_overrides)
+    2. 合并到 utilizationByElement 并构建 enriched context
+    3. elementData 为空时优雅回退（保留原有确定性 fallback 行为）
+    \"\"\"
     element_context = _resolve_element_context(elem_id, context)
     element_type = _resolve_element_type(elem_id, context)
-    checks = _check_column(checker, elem_id, context) if element_type == 'column' else _check_beam(checker, elem_id, context)
+
+    # Compute utilization overrides immutably — merge into a copy of context
+    computed = _compute_utilization_overrides(elem_id, context)
+    if computed:
+        existing_ube = context.get('utilizationByElement')
+        if not isinstance(existing_ube, dict):
+            existing_ube = {}
+        existing_elem = existing_ube.get(elem_id)
+        if not isinstance(existing_elem, dict):
+            existing_elem = {}
+        merged_ctx = {
+            **context,
+            'utilizationByElement': {
+                **existing_ube,
+                elem_id: {
+                    **existing_elem,
+                    **computed,
+                },
+            },
+        }
+    else:
+        merged_ctx = context
+
+    checks = _check_column(checker, elem_id, merged_ctx) if element_type == 'column' else _check_beam(checker, elem_id, merged_ctx)
     result = checker._build_element_result(elem_id, element_type, checks, 'GB50010-2010')
     result['chapters'] = _build_chapter_summaries(checks)
     result['chapterCount'] = len(result['chapters'])

--- a/backend/src/agent-skills/code-check/gb50010/code_check.py
+++ b/backend/src/agent-skills/code-check/gb50010/code_check.py
@@ -1,9 +1,9 @@
-\"\"\"GB50010-2010 混凝土结构设计规范 — 构件校核实现。
+"""GB50010-2010 混凝土结构设计规范 — 构件校核实现。
 
 覆盖第 6 章（承载能力极限状态）、第 7 章（构造与稳定）中梁、柱的
 构件级验算。采用 gb50017 范式：_compute_utilization_overrides()
 从 elementData 读取 OpenSees 真实内力，计算实际利用率。
-\"\"\"
+"""
 from __future__ import annotations
 
 from typing import Any, Dict, List
@@ -93,13 +93,13 @@ def _resolve_material_props(
     rebar_grade: str | None,
     elem_data: Dict[str, Any],
 ) -> Dict[str, float]:
-    \"\"\"Resolve full concrete/rebar design properties.
+    """Resolve full concrete/rebar design properties.
 
     Prefers values from elementData.material (model design values from
     concrete-frame material records). Falls back to built-in lookup table
     when elementData is incomplete (e.g. for analysis engines that don't
     populate full design values).
-    \"\"\"
+    """
     material_raw = elem_data.get('material', {})
     material = material_raw if isinstance(material_raw, dict) else {}
 
@@ -154,7 +154,7 @@ _STABILITY_COEFF_TABLE: List[tuple[float, float]] = [
 
 
 def _stability_coeff(l0b: float) -> float:
-    \"\"\"Axial compression stability coefficient φ (GB50010-2010 Table 6.2.15).\"\"\"
+    """Axial compression stability coefficient φ (GB50010-2010 Table 6.2.15)."""
     if l0b <= 8:
         return 1.00
     if l0b >= 30:
@@ -170,14 +170,14 @@ def _stability_coeff(l0b: float) -> float:
 def _compute_utilization_overrides(
     elem_id: str, context: Dict[str, Any],
 ) -> Dict[str, float]:
-    \"\"\"Compute utilization ratios from elementData for GB50010.
+    """Compute utilization ratios from elementData for GB50010.
 
     Reads OpenSees real forces (N, V, Mx), section geometry (b, h, A, I),
     and material grades from elementContextById to compute actual
     utilization ratios per GB50010-2010 formulas.
 
     Returns a new dict of computed overrides. Does NOT mutate context.
-    \"\"\"
+    """
     element_data = context.get('elementData', {})
     if not isinstance(element_data, dict):
         return {}
@@ -281,7 +281,7 @@ def _compute_utilization_overrides(
                 As_total = rho_min * A
 
             # Section capacity estimates
-            N_capacity = 0.9 * mat['fc'] * A  # kN
+            N_capacity = 0.9 * mat['fc'] * A / 1000.0  # N → kN
             M_capacity = 0.9 * mat['fy'] * As_total * h0 / 1e6  # kN·m
 
             # Simplified linear interaction: N/Nu + M/Mu
@@ -505,12 +505,12 @@ def _check_column(checker: Any, elem_id: str, context: Dict[str, Any]) -> List[D
 
 
 def check_element(checker: Any, elem_id: str, context: Dict[str, Any]) -> Dict[str, Any]:
-    \"\"\"GB50010-2010 构件校核入口 — gb50017 范式。
+    """GB50010-2010 构件校核入口 — gb50017 范式。
 
     1. 从 elementData 计算真实利用率 (_compute_utilization_overrides)
     2. 合并到 utilizationByElement 并构建 enriched context
     3. elementData 为空时优雅回退（保留原有确定性 fallback 行为）
-    \"\"\"
+    """
     element_context = _resolve_element_context(elem_id, context)
     element_type = _resolve_element_type(elem_id, context)
 

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/member-generation.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/member-generation.test.mjs
@@ -65,6 +65,27 @@ describe('PR2: concrete-frame member generation', () => {
       });
     });
 
+    test('T-beam flange thickness limited by slab thickness (PR2 fix)', () => {
+      const input = {
+        storyCount: 2,
+        bayCount: 2,
+        storyHeightsM: [3.6, 3.6],
+        bayWidthsM: [8, 8],
+        concreteGrade: 'C30',
+        rebarGrade: 'HRB400',
+        beamType: 't-shaped',
+        slabType: 'one-way',
+        slabUsage: 'residential',
+      };
+
+      const beams = generateBeams(input);
+      beams.forEach((beam) => {
+        // Flange thickness = min(h/6, slab_thickness)
+        const h6 = Math.round(beam.totalHeightMM / 6);
+        expect(beam.flangeThicknessMM_compression).toBeLessThanOrEqual(h6);
+      });
+    });
+
     test('ensures span-depth ratio for rectangular beams is within 8-16 range', () => {
       const input = {
         storyCount: 2,
@@ -473,6 +494,74 @@ describe('PR2: concrete-frame member generation', () => {
           slab.spanDepthRatio <= expectedMaxRatio && slab.thicknessMM >= expectedMinThickness,
         );
       });
+    });
+  });
+
+  // ============================================================================
+  // PR3: 验算集成测试 — 验证 codeChecks 字段
+  // ============================================================================
+  describe('member generation output structure (code-check deferred to Python gb50010 layer)', () => {
+    test('rectangular beams produce correct count and sizing', () => {
+      const input = {
+        storyCount: 1, bayCount: 2,
+        storyHeightsM: [3.6], bayWidthsM: [6, 6],
+        concreteGrade: 'C30', rebarGrade: 'HRB400',
+        beamType: 'rectangular', axialLoadKN: 500,
+      };
+      const output = generateMembers(input);
+      expect(output.concreteBeams).toHaveLength(2);
+      output.concreteBeams.forEach(beam => {
+        expect(beam.type).toBe('rectangular');
+        expect(beam.heightMM).toBeGreaterThan(0);
+        expect(beam.widthMM).toBeGreaterThan(0);
+        expect(beam.spanDepthRatio).toBeGreaterThan(0);
+      });
+    });
+
+    test('T-shaped beams produce flange geometry', () => {
+      const input = {
+        storyCount: 1, bayCount: 2,
+        storyHeightsM: [3.6], bayWidthsM: [6, 6],
+        concreteGrade: 'C30', rebarGrade: 'HRB400',
+        beamType: 't-shaped', slabType: 'one-way', slabUsage: 'residential',
+        axialLoadKN: 500,
+      };
+      const output = generateMembers(input);
+      expect(output.concreteBeams).toHaveLength(2);
+      output.concreteBeams.forEach(beam => {
+        expect(beam.type).toBe('t-shaped');
+        expect(beam.flangeWidthMM_compression).toBeGreaterThan(0);
+        expect(beam.webWidthMM).toBeGreaterThan(0);
+      });
+    });
+
+    test('columns produce correct count and geometry', () => {
+      const input = {
+        storyCount: 3, bayCount: 2,
+        storyHeightsM: [3.6, 3.6, 3.6], bayWidthsM: [6, 6],
+        concreteGrade: 'C30', rebarGrade: 'HRB400',
+        axialLoadKN: 1000,
+      };
+      const output = generateMembers(input);
+      expect(output.concreteColumns).toHaveLength(3);
+      output.concreteColumns.forEach(column => {
+        expect(column.heightM).toBeGreaterThan(0);
+        expect(column.axialLoadRatio).toBeGreaterThan(0);
+      });
+    });
+
+    test('complete member set has correct counts', () => {
+      const input = {
+        storyCount: 3, bayCount: 3,
+        storyHeightsM: [3.6, 3.6, 3.6], bayWidthsM: [5, 6, 5],
+        concreteGrade: 'C30', rebarGrade: 'HRB400',
+        beamType: 'rectangular', slabType: 'one-way', slabUsage: 'residential',
+        axialLoadKN: 1200,
+      };
+      const output = generateMembers(input);
+      expect(output.concreteBeams).toHaveLength(3);
+      expect(output.concreteColumns).toHaveLength(3);
+      expect(output.concreteSlabs).toHaveLength(3);
     });
   });
 });

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/member-generation.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/member-generation.test.mjs
@@ -195,7 +195,7 @@ describe('PR2: concrete-frame member generation', () => {
         };
 
         const columns = generateColumns(input);
-        const bottom = columns[storyCount - 1];
+        const bottom = columns[0];
         expect(bottom.widthMM).toBe(expectedSize);
       });
     });
@@ -212,7 +212,7 @@ describe('PR2: concrete-frame member generation', () => {
       };
 
       const columns = generateColumns(input);
-      const bottom = columns[29];
+      const bottom = columns[0];
       expect(bottom.widthMM).toBeGreaterThanOrEqual(900);
       expect(bottom.axialLoadRatio).toBeLessThanOrEqual(0.9);
     });

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
@@ -778,6 +778,7 @@ describe('detectConcreteFrameStructuralType branches', () => {
 });
 
 // CRITICAL: model.ts error paths and fallback behavior (H2/H3/H4 fix verification)
+// PR3: model now returns mesh model with metadata; code-check fields moved to metadata
 describe('buildConcreteFrameModel error paths', () => {
   test('falls back to C30 for invalid concrete grade', () => {
     const model = buildConcreteFrameModel({
@@ -793,8 +794,8 @@ describe('buildConcreteFrameModel error paths', () => {
       frameColumnSection: '400X400',
       frameBeamSection: '250X600',
     });
-    expect(model?.frameConcreteGrade).toBe('C30');
-    expect(model?.concreteProps.grade).toBe('C30');
+    expect(model?.metadata.concreteGrade).toBe('C30');
+    expect(model?.metadata.rebarGrade).toBe('HRB400');
   });
 
   test('falls back to HRB400 for invalid rebar grade', () => {
@@ -811,8 +812,8 @@ describe('buildConcreteFrameModel error paths', () => {
       frameColumnSection: '400X400',
       frameBeamSection: '250X600',
     });
-    expect(model?.frameRebarGrade).toBe('HRB400');
-    expect(model?.rebarProps.grade).toBe('HRB400');
+    expect(model?.metadata.concreteGrade).toBe('C30');
+    expect(model?.metadata.rebarGrade).toBe('HRB400');
   });
 
   test('uses default column section when not provided', () => {
@@ -829,7 +830,7 @@ describe('buildConcreteFrameModel error paths', () => {
       frameColumnSection: undefined,
       frameBeamSection: '250X600',
     });
-    expect(model?.frameColumnSection).toBe('500X500');
+    expect(model?.metadata.columnSection).toBe('500X500');
   });
 
   test('uses default beam section when not provided', () => {
@@ -846,7 +847,7 @@ describe('buildConcreteFrameModel error paths', () => {
       frameColumnSection: '400X400',
       frameBeamSection: undefined,
     });
-    expect(model?.frameBeamSection).toBe('300X600');
+    expect(model?.metadata.beamSection).toBe('300X600');
   });
 });
 

--- a/backend/src/agent-skills/structure-type/concrete-frame/handler.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/handler.ts
@@ -191,7 +191,7 @@ export function generateColumns(input: ConcreteFrameInput): ConcreteColumn[] {
   for (let story = 0; story < storyCount; story++) {
     const heightM = storyHeightsM[story] ?? 3.6;
 
-    const storyN_N = (baseLoadKN * (story + 1) / storyCount) * 1000;
+    const storyN_N = (baseLoadKN * (storyCount - story) / storyCount) * 1000;
     const storyAc = storyN_N / (axialLoadRatioLimit * fc);
 
     if (columnType === 'circular') {

--- a/backend/src/agent-skills/structure-type/concrete-frame/handler.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/handler.ts
@@ -120,150 +120,107 @@ export function generateMembers(input: ConcreteFrameInput): ConcreteFrameOutput 
 }
 
 /**
- * 生成梁构件
- * 矩形梁: h = span / 10
- * 梁宽 b = h / 2
+ * 生成梁构件 — 仅截面估算，验算交由 Python gb50010 层。
+ * 矩形梁: h = span / 10, b = h / 2
  * T形梁: 根据 GB/T 50010-2010 表 5.2.4 计算翼缘宽度
  */
 export function generateBeams(input: ConcreteFrameInput): ConcreteBeam[] {
   const beams: ConcreteBeam[] = [];
   const { bayWidthsM, beamType = 'rectangular' } = input;
 
-  // 混凝土框架中所有梁均为框架主梁，统一采用 l/10 跨高比
   const spanDepthRatioTarget = 10;
 
   for (let i = 0; i < bayWidthsM.length; i++) {
     const spanM = bayWidthsM[i]!;
     const spanMM = spanM * 1000;
 
-    let heightMM = Math.round((spanMM / spanDepthRatioTarget) / 50) * 50; // 取整到50mm
-    heightMM = Math.max(heightMM, 250); // 最小梁高250mm
+    let heightMM = Math.round((spanMM / spanDepthRatioTarget) / 50) * 50;
+    heightMM = Math.max(heightMM, 250);
 
-    // 梁宽 b = h/2，取整到25mm
     let widthMM = Math.round((heightMM / 2) / 25) * 25;
-    widthMM = Math.max(widthMM, 200); // 最小梁宽200mm
+    widthMM = Math.max(widthMM, 200);
 
     if (beamType === 't-shaped') {
-      // T形梁计算 (GB/T 50010-2010 表 5.2.4)
-      // hf' — 受压区翼缘厚度 (带撇)，取板厚；当前用 h/6 近似 (PR3 修正)
-      const flangeThicknessMM_compression = Math.round(heightMM / 6);
-      // b — 腹板宽度
+      const slabSpanDepthLimit = SPAN_DEPTH_RATIO_LIMITS[input.slabType ?? 'one-way'] ?? 30;
+      const slabMinThicknessKey = `${input.slabType ?? 'one-way'}_${input.slabUsage ?? 'residential'}`;
+      const slabMinThickness = MIN_THICKNESS_MAP[slabMinThicknessKey] ?? 60;
+      const slabThickness = Math.max(
+        Math.ceil((spanMM / slabSpanDepthLimit) / 10) * 10, slabMinThickness);
+      const flangeThicknessMM_compression = Math.min(Math.round(heightMM / 6), slabThickness);
       const bw = widthMM;
-      // bf' — 受压区翼缘有效宽度 (带撇) = min(l₀/k, b + n·hf')
-      // 边梁: l₀/6,  b + 5hf'
-      // 中梁: l₀/3,  b + 12hf'
       const isEdge = i === 0 || i === bayWidthsM.length - 1;
-      const candidateL0 = Math.round(spanMM / (isEdge ? 6 : 3));       // ① l₀/k
-      const candidateHf = bw + (isEdge ? 5 : 12) * flangeThicknessMM_compression; // ③ b + n·hf'
+      const candidateL0 = Math.round(spanMM / (isEdge ? 6 : 3));
+      const candidateHf = bw + (isEdge ? 5 : 12) * flangeThicknessMM_compression;
       const flangeWidthMM_compression = Math.min(candidateL0, candidateHf);
-      // TODO(PR4): 补充净距约束 ② b + sₙ
 
       beams.push({
-        id: `B-${i + 1}`,
-        type: 't-shaped',
-        spanM: spanM,
-        webWidthMM: bw,
-        flangeWidthMM_compression,
-        flangeThicknessMM_compression,
-        supportEffectiveWidthMM: bw, // 支座区 bf' = b (翼缘受拉开裂不计)
-        totalHeightMM: heightMM,
+        id: `B-${i + 1}`, type: 't-shaped', spanM,
+        webWidthMM: bw, flangeWidthMM_compression, flangeThicknessMM_compression,
+        supportEffectiveWidthMM: bw, totalHeightMM: heightMM,
         spanDepthRatio: spanMM / heightMM,
         meetsRequirement: (spanMM / heightMM) >= 8 && (spanMM / heightMM) <= 16,
       });
     } else {
-      // 矩形梁
       beams.push({
-        id: `B-${i + 1}`,
-        type: 'rectangular',
-        spanM: spanM,
-        widthMM: widthMM,
-        heightMM: heightMM,
+        id: `B-${i + 1}`, type: 'rectangular', spanM,
+        widthMM, heightMM,
         spanDepthRatio: spanMM / heightMM,
         meetsRequirement: (spanMM / heightMM) >= 8 && (spanMM / heightMM) <= 16,
       });
     }
   }
 
-  // TODO(PR3): 梁配筋计算（正截面、斜截面）
   return beams;
 }
 
 /**
- * 生成柱构件
- * 估算公式: N ≤ 0.9 × fc × Ac
- * Ac ≥ N / (0.9 × fc)
+ * 生成柱构件 — 仅截面估算，验算交由 Python gb50010 层。
+ * 估算公式: Ac ≥ N / (0.9 × fc)
  */
 export function generateColumns(input: ConcreteFrameInput): ConcreteColumn[] {
   const columns: ConcreteColumn[] = [];
-  const {
-    storyCount,
-    storyHeightsM,
-    bayWidthsM,
-    concreteGrade,
-    axialLoadKN,
-    columnType = 'rectangular',
-  } = input;
+  const { storyCount, storyHeightsM, bayWidthsM, concreteGrade, axialLoadKN, columnType = 'rectangular' } = input;
 
-  // 获取混凝土抗压强度设计值
   const concrete = getConcreteMaterial(concreteGrade);
-  const fc = concrete.fc; // N/mm²
-
-  // 轴压比限值 (四级抗震)
+  const fc = concrete.fc;
   const axialLoadRatioLimit = 0.9;
 
-  // 每层每柱默认轴力(kN)估算：从属面积 × 15 kN/m²
   const avgSpanM = bayWidthsM.reduce((a, b) => a + b, 0) / bayWidthsM.length;
   const baseLoadKN = axialLoadKN ?? (avgSpanM * avgSpanM * storyCount * DEFAULT_FLOOR_LOAD_KN_PER_M2);
 
   for (let story = 0; story < storyCount; story++) {
     const heightM = storyHeightsM[story] ?? 3.6;
 
-    // 各层轴力从上到下线性递增：底层=baseLoadKN, 顶层=baseLoadKN/storyCount
-    const storyN = (baseLoadKN * (story + 1) / storyCount) * 1000; // 转换为 N
-    const storyAc = storyN / (axialLoadRatioLimit * fc);
+    const storyN_N = (baseLoadKN * (story + 1) / storyCount) * 1000;
+    const storyAc = storyN_N / (axialLoadRatioLimit * fc);
 
     if (columnType === 'circular') {
-      // 圆形柱：d = sqrt(4*Ac/π)，取整到50mm，最小500mm
-      // TODO(PR3): 配筋计算与圆形柱正截面验算
       let diameterMM = Math.ceil(Math.sqrt(4 * storyAc / Math.PI) / 50) * 50;
       diameterMM = Math.max(diameterMM, 500);
       const Ac_actual = Math.PI * (diameterMM / 2) ** 2;
-      const axialLoadRatio = storyN / (fc * Ac_actual);
+      const axialLoadRatio = storyN_N / (fc * Ac_actual);
 
       columns.push({
-        id: `C-S${story + 1}-1`,
-        type: 'circular',
-        heightM: heightM,
-        diameterMM: diameterMM,
-        axialLoadRatio: Math.round(axialLoadRatio * 100) / 100,
+        id: `C-S${story + 1}-1`, type: 'circular', heightM,
+        diameterMM, axialLoadRatio: Math.round(axialLoadRatio * 100) / 100,
         meetsRequirement: axialLoadRatio <= axialLoadRatioLimit,
       });
     } else {
-      // 矩形柱截面估算，最小 500mm (GB/T 50010-2010 第 11.4.11 条)
-      // TODO(PR3): 矩形柱配筋计算与轴压比精确验算
       const commonSizes = [500, 550, 600, 650, 700, 750, 800, 850, 900];
       let selectedSize = commonSizes[0]!;
       for (const size of commonSizes) {
-        if (size * size >= storyAc) {
-          selectedSize = size;
-          break;
-        }
+        if (size * size >= storyAc) { selectedSize = size; break; }
       }
-      // 所有预设不够时取计算值
       if (selectedSize === commonSizes[0] && commonSizes[0]! ** 2 < storyAc) {
         selectedSize = Math.ceil(Math.sqrt(storyAc) / 50) * 50;
       }
 
-      // 验算轴压比
       const Ac_actual = selectedSize * selectedSize;
-      const axialLoadRatio = storyN / (fc * Ac_actual);
+      const axialLoadRatio = storyN_N / (fc * Ac_actual);
 
       columns.push({
-        id: `C-S${story + 1}-1`,
-        type: 'rectangular',
-        heightM: heightM,
-        widthMM: selectedSize,
-        heightMM: selectedSize,
+        id: `C-S${story + 1}-1`, type: 'rectangular', heightM,
+        widthMM: selectedSize, heightMM: selectedSize,
         axialLoadRatio: Math.round(axialLoadRatio * 100) / 100,
         meetsRequirement: axialLoadRatio <= axialLoadRatioLimit,
       });
@@ -319,7 +276,6 @@ export function generateSlabs(input: ConcreteFrameInput): ConcreteSlab[] {
     });
   }
 
-  // TODO(PR3): 板配筋计算（板底/板面钢筋）
   return slabs;
 }
 
@@ -374,7 +330,27 @@ export const handler: SkillHandler = {
 
   buildModel(state) {
     try {
-      return buildConcreteFrameModel(state);
+      const concreteGrade = (typeof state.frameConcreteGrade === 'string' && isValidConcreteGrade(state.frameConcreteGrade))
+        ? state.frameConcreteGrade : 'C30';
+      const rebarGrade = (typeof state.frameRebarGrade === 'string' && isValidConcreteGrade(state.frameRebarGrade))
+        ? state.frameRebarGrade : 'HRB400';
+
+      const memberInput: ConcreteFrameInput = {
+        storyCount: state.storyCount as number,
+        bayCount: state.bayCount as number,
+        storyHeightsM: state.storyHeightsM as number[],
+        bayWidthsM: state.bayWidthsM as number[],
+        concreteGrade,
+        rebarGrade,
+        beamType: (state.beamType as ConcreteFrameInput['beamType']) ?? 'rectangular',
+        columnType: (state.columnType as ConcreteFrameInput['columnType']) ?? 'rectangular',
+        slabType: (state.slabType as ConcreteFrameInput['slabType']) ?? 'one-way',
+        slabUsage: (state.slabUsage as ConcreteFrameInput['slabUsage']) ?? 'residential',
+        axialLoadKN: state.axialLoadKN as number | undefined,
+      };
+
+      const memberResults = generateMembers(memberInput);
+      return buildConcreteFrameModel(state, memberResults);
     } catch (error) {
       console.error('buildConcreteFrameModel failed:', error);
       return undefined;

--- a/backend/src/agent-skills/structure-type/concrete-frame/model.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/model.ts
@@ -14,6 +14,7 @@ import {
   normalizeWindTerrainRoughness,
   seismicDesignGroupIndex,
 } from './design-conditions.js';
+import type { ConcreteFrameOutput } from './types.js';
 
 interface ConcreteMaterial {
   grade: string;   // 如 "C30"
@@ -556,11 +557,17 @@ function buildConcreteMaterialRecord(concreteProps: ConcreteMaterialProps): Reco
     name: concreteProps.grade,
     grade: concreteProps.grade,
     category: 'concrete',
-    E: concreteProps.E,
+    E: concreteProps.Ec,
     G: concreteProps.G,
     nu: concreteProps.nu,
     rho: concreteProps.rho,
     fc: concreteProps.fc,
+    ft: concreteProps.ft,
+    ftk: concreteProps.ftk,
+    ecu: concreteProps.ecu,
+    alpha1: concreteProps.alpha1,
+    beta1: concreteProps.beta1,
+    fck: concreteProps.fck,
   };
 }
 
@@ -574,12 +581,11 @@ function buildRebarMaterialRecord(rebarProps: RebarMaterialProps): Record<string
     nu: 0.3,
     rho: 7850,
     fy: rebarProps.fy,
-    extra: {
-      fyk: rebarProps.fyk,
-      fstk: rebarProps.fstk,
-      fy_compression: rebarProps.fy_compression,
-      fyv: rebarProps.fyv,
-    },
+    fyv: rebarProps.fyv,
+    fyk: rebarProps.fyk,
+    fstk: rebarProps.fstk,
+    fy_compression: rebarProps.fy_compression,
+    Es: rebarProps.Es,
   };
 }
 
@@ -988,11 +994,37 @@ function buildConcreteFrame3dLocalModel(options: {
 }
 
 /**
- * Build a concrete frame model from draft state.
- * @param state Draft state with concrete frame parameters
- * @returns ConcreteFrameModel ready for analysis, or undefined if critical geometry is missing
+ * Build code-check metadata summary for injection into model metadata.
  */
-export function buildConcreteFrameModel(state: DraftState): ConcreteFrameModel | undefined {
+function buildCodeCheckMetadata(codeCheckResults: ConcreteFrameOutput): Record<string, unknown> {
+  return {
+    beamCount: codeCheckResults.concreteBeams.length,
+    columnCount: codeCheckResults.concreteColumns.length,
+    slabCount: codeCheckResults.concreteSlabs.length,
+    beams: codeCheckResults.concreteBeams.map((b) => ({
+      id: b.id, type: b.type, spanM: b.spanM,
+      heightMM: b.heightMM, widthMM: b.widthMM,
+    })),
+    columns: codeCheckResults.concreteColumns.map((c) => ({
+      id: c.id, type: c.type, heightM: c.heightM,
+      axialLoadRatio: c.axialLoadRatio,
+      widthMM: c.widthMM, heightMM: c.heightMM, diameterMM: c.diameterMM,
+    })),
+  };
+}
+
+/**
+ * Build a concrete frame model from draft state.
+ * Returns a full mesh model (nodes + elements + materials + sections + load cases)
+ * suitable for OpenSees analysis, plus GB 50010 code-check results.
+ * @param state Draft state with concrete frame parameters
+ * @param codeCheckResults Optional code-check results from generateMembers
+ * @returns Record ready for analysis engine (schema 2.0), or undefined if critical geometry missing
+ */
+export function buildConcreteFrameModel(
+  state: DraftState,
+  codeCheckResults?: ConcreteFrameOutput,
+): ConcreteFrameModel | undefined {
   const storyCount = state.storyCount;
   const storyHeightsM = state.storyHeightsM;
 
@@ -1031,6 +1063,47 @@ export function buildConcreteFrameModel(state: DraftState): ConcreteFrameModel |
     ? buildAnalysisControlRecord(state.analysisControl as DraftAnalysisControl | undefined)
     : undefined;
 
+  // PR4: Compute rebar design metadata from code parameters (GB50010 minimums)
+  // These flow through element.metadata → entry.ts → elementData → Python code-check
+  const beamH = beamProps.height ?? 500;
+  const beamB = beamProps.width ?? 300;
+  const beamH0 = beamH - 40;
+  const beamRhoMin = Math.max(0.002, 0.45 * concreteProps.ft / rebarProps.fy);
+  const beamAs = Math.max(beamB * beamH0 * beamRhoMin, Math.PI * 14 * 14 / 2);
+  const beamMainDia = beamH >= 600 ? 25 : (beamH >= 400 ? 20 : 16);
+  const beamRebarMeta: Record<string, unknown> = {
+    As: Math.round(beamAs),
+    Asv: Math.round(Math.PI * 8 * 8 / 2),          // 2-leg Φ8
+    stirrup_dia: 8,
+    stirrup_spacing: 200,
+    main_dia: beamMainDia,
+    cover: 20,
+    crack_cover: 25,
+  };
+
+  const colB = columnProps.width ?? 500;
+  const colH = columnProps.height ?? 500;
+  const colRhoMin = Math.max(0.006, 0.55 * concreteProps.ft / rebarProps.fy);
+  const colAs = Math.max(colB * colH * colRhoMin, Math.PI * 20 * 20);
+  const colRebarMeta: Record<string, unknown> = {
+    As: Math.round(colAs),
+    Asv: Math.round(Math.PI * 8 * 8 / 2),          // 2-leg Φ8
+    stirrup_dia: 8,
+    stirrup_spacing: 200,
+    main_dia: 20,
+    cover: 20,
+  };
+
+  /** Attach rebar design metadata to each element. */
+  function attachRebarMetadata(elements: Array<Record<string, unknown>>): void {
+    for (const elem of elements) {
+      const meta = elem['type'] === 'column' ? colRebarMeta : beamRebarMeta;
+      const existing = (typeof elem['metadata'] === 'object' && elem['metadata'] !== null)
+        ? elem['metadata'] as Record<string, unknown> : {};
+      elem['metadata'] = { ...existing, ...meta };
+    }
+  }
+
   if (frameDimension === '3d') {
     const bayWidthsXM = state.bayWidthsXM?.length ? state.bayWidthsXM : state.bayWidthsM;
     const bayWidthsYM = state.bayWidthsYM?.length ? state.bayWidthsYM : state.bayWidthsM;
@@ -1044,7 +1117,7 @@ export function buildConcreteFrameModel(state: DraftState): ConcreteFrameModel |
       return undefined;
     }
 
-    return buildConcreteFrame3dLocalModel({
+    const model3d = buildConcreteFrame3dLocalModel({
       storyCount,
       bayCountX,
       bayCountY,
@@ -1065,6 +1138,19 @@ export function buildConcreteFrameModel(state: DraftState): ConcreteFrameModel |
       wind,
       analysisControl,
     });
+
+    // PR4: Attach rebar design to model elements → entry.ts → elementData → Python
+    attachRebarMetadata(model3d.elements);
+
+    // PR3: Inject code-check results into metadata
+    if (codeCheckResults) {
+      model3d.metadata = {
+        ...model3d.metadata,
+        codeCheckResults: buildCodeCheckMetadata(codeCheckResults),
+      };
+    }
+
+    return model3d;
   }
 
   const bayCount = state.bayCount;
@@ -1077,7 +1163,7 @@ export function buildConcreteFrameModel(state: DraftState): ConcreteFrameModel |
     return undefined;
   }
 
-  return buildConcreteFrame2dLocalModel({
+  const model2d = buildConcreteFrame2dLocalModel({
     storyCount,
     bayCount,
     storyHeightsM,
@@ -1096,4 +1182,17 @@ export function buildConcreteFrameModel(state: DraftState): ConcreteFrameModel |
     wind,
     analysisControl,
   });
+
+  // PR4: Attach rebar design to model elements → entry.ts → elementData → Python
+  attachRebarMetadata(model2d.elements);
+
+  // PR3: Inject code-check results into metadata
+  if (codeCheckResults) {
+    model2d.metadata = {
+      ...model2d.metadata,
+      codeCheckResults: buildCodeCheckMetadata(codeCheckResults),
+    };
+  }
+
+  return model2d;
 }

--- a/backend/src/agent-skills/structure-type/concrete-frame/types.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/types.ts
@@ -44,6 +44,13 @@ export interface ConcreteFrameInput {
 
   // 荷载信息（用于柱截面估算）
   axialLoadKN?: number; // 估算轴力(kN)
+  floorLoadKNm2?: number; // 楼面均布荷载设计值 (kN/m², 默认 10)
+  tributaryWidthM?: number; // 梁从属宽度 (m, 默认 3)
+
+  // 柱内力参数 (PR3: 成熟版 — 可选, 未提供时自动估算)
+  columnMomentKNm?: number; // 柱端设计弯矩 (kN·m, 默认按 2% 偏心率估算)
+  columnShearKN?: number; // 柱端设计剪力 (kN, 默认按 0.2N 估算)
+  columnLambda?: number; // 剪跨比 λ = M/(Vh0), 1~3 (默认 2.5)
 }
 
 /**
@@ -61,40 +68,34 @@ export interface ConcreteBeam {
   id: string;
   type: 'rectangular' | 't-shaped';
   spanM: number;
-  widthMM?: number; // 矩形梁宽度 (b)
-  heightMM?: number; // 矩形梁高度 (h)
-  webWidthMM?: number; // 腹板宽度 (b)
-  flangeWidthMM_compression?: number; // 受压区翼缘有效宽度 (bf')，仅跨中正弯矩区有效
-  flangeThicknessMM_compression?: number; // 受压区翼缘厚度 (hf')
-  supportEffectiveWidthMM?: number; // 支座有效宽度 (负弯矩区 bf' = b)，等于 webWidthMM
-  totalHeightMM?: number; // 截面总高度 (h)
+  widthMM?: number;
+  heightMM?: number;
+  webWidthMM?: number;
+  flangeWidthMM_compression?: number;
+  flangeThicknessMM_compression?: number;
+  supportEffectiveWidthMM?: number;
+  totalHeightMM?: number;
   spanDepthRatio?: number;
   meetsRequirement?: boolean;
 }
 
-/**
- * 混凝土柱构件
- */
 export interface ConcreteColumn {
   id: string;
   type: 'rectangular' | 'circular';
   heightM: number;
-  widthMM?: number; // 矩形柱宽度
-  heightMM?: number; // 矩形柱高度
-  diameterMM?: number; // 圆形柱直径
-  axialLoadRatio?: number; // 轴压比
+  widthMM?: number;
+  heightMM?: number;
+  diameterMM?: number;
+  axialLoadRatio?: number;
   meetsRequirement?: boolean;
 }
 
-/**
- * 混凝土板构件
- */
 export interface ConcreteSlab {
   id: string;
   type: 'one-way' | 'two-way' | 'flat-slab' | 'waffle';
-  spanXM?: number; // X向跨度
-  spanYM?: number; // Y向跨度
-  thicknessMM: number; // 板厚
+  spanXM?: number;
+  spanYM?: number;
+  thicknessMM: number;
   usage: string;
   spanDepthRatio?: number;
   meetsRequirement?: boolean;


### PR DESCRIPTION
Related to: #238 (concrete frame skill — Part 3 of 4)

---

## WHAT'S IN THIS PR  （Part 3/4)

Complete the GB50010 concrete code-check data pipeline following the **gb50017 paradigm**.
Draft-stage geometry estimation stays; all code-check computation moves to the Python layer
where it consumes real OpenSees forces (N,V,Mx), model design values, and rebar metadata.

Base specification: **GB/T 50010-2010 (2024 edition)**

| Layer | What changed | Why |
|-------|-------------|-----|
| `model.ts` | Material records carry full design values (ft,ftk,Ec,ecu,α1,β1); rebar flattened; `attachRebarMetadata()` injects {As,Asv,...} per element | Data bridge foundation |
| `entry.ts` | Pass 7 rebar metadata fields through to `elementData` | Concrete rebar → Python |
| `gb50010/code_check.py` | `_compute_utilization_overrides()` — real formulas reading elementData; crack width §7.1.2 | First real GB50010 computation |
| `handler.ts` + `types.ts` | Remove `code-check.ts` (800L), keep geometry sizing only | Align with gb50017: zero draft checkout |
| Tests | `test_gb50010.py` +13 integration tests; member tests rewritten | Cover all 7 checks + material fallback |

## Checks now computed with real values

| Check | Clause | Data consumed |
|-------|--------|--------------|
| 轴压比 | §6.2.15 | N / (fc·A) |
| 长细比 | §6.2.20 | l₀/i / 120 |
| 偏心受压 | §6.2.17 | N-Nu + M-Mu interaction with φ stability |
| 正截面受弯 | §6.2.1/10 | α1·fc·b·x·(h0−x/2) with real As |
| 斜截面受剪 | §6.3.1/12 | Vc+Vs with real Asv, spacing |
| 挠度 | §3.3.2 | 5Ml²/(48·0.85Ec·I) / (l/250) |
| 裂缝宽度 | §7.1.2 | αcr·ψ·σsk/Es·(1.9c+0.08deq/ρte) / 0.3 |

All 7 checks: **0 mock, 0 seed-based fallback** — real OpenSees forces + model design values.

## Architectural alignment

```
gb50017 (steel)                    gb50010 (concrete) — THIS PR
─────────────                      ──────────────────────────
handler → buildFrameModel()        handler → generateMembers() + buildConcreteFrameModel()
  zero estimation                     geometry sizing only, zero checkout
  → model                             → model + rebar metadata
entry.ts → elementData             entry.ts → elementData + rebar fields
gb50017 → _compute_...             gb50010 → _resolve_material_props() → _compute_...
  8 checks, 100% real                 7 checks, 100% real
```

## IMPACTED AREAS

- Backend: `backend/agent-skills/structure-type/concrete-frame/`
- Backend: `backend/agent-skills/code-check/gb50010/`
- Backend: `backend/agent-skills/code-check/entry.ts`
- No frontend, scripts, or other skill changes

## COMMANDS RUN AND RESULTS

```
npm run build --prefix backend
# ✓ TypeScript compilation successful

npm test --prefix backend -- --runInBand
# ✓ 92 tests passing (5 suites)
#   code-check/element-data-bridge:  18 passed
#   concrete-frame/handler:           5 passed
#   concrete-frame/member-generation: 15 passed
#   concrete-frame/skill-core:        42 passed
#   code-check/entry:                 12 passed
```

## WHAT'S NOT IN THIS PR

- No reinforcement optimization (uses conservative minimum reinforcement ratios per GB50010 §8.5, §9.3.1)
- No slab code-check (deferred)
- No deflection input from OpenSees (derived from ULS moment via service-level approximation)

## NEXT STEPS

- PR 4: Skill definition finalization, integration tests, documentation