### PR TITLE
fix(backend): persist PKPM steel frame material params

### DIFF
--- a/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
@@ -421,12 +421,29 @@ def _register_section(
     Register one V2 section entry.
     Returns (role, pm_section_idx) where role is "col" or "beam".
 
-    Uses SetUserSect with shape.Set_M(5/6) for steel/concrete material indication.
-    The element material grade is set separately via SetSteelGrade() or SetConcreteGrade().
+    Parametric shapes are preferred when present because they carry explicit
+    H/B/tw/tf geometry into SATWE.  Standard steel names are used only when no
+    shape is available; some APIPyInterface builds accept the standard-name
+    call but leave SATWE section dimensions empty.
     """
     std_name: str | None = sec.get("standard_steel_name")
     shape_dict: dict | None = sec.get("shape") or _shape_from_legacy_properties(sec)
     use_standard_steel = bool(std_name) and material_family == "steel" and not shape_dict
+
+    def _set_standard_steel(api_section: Any) -> Exception | None:
+        if not std_name:
+            return ValueError("standard steel section name is empty")
+        try:
+            api_section.SetStandSteelSect(std_name, APIPyInterface.SectionShape())
+            return None
+        except TypeError:
+            try:
+                api_section.SetStandSteelSect(std_name)
+                return None
+            except Exception as exc:
+                return exc
+        except Exception as exc:
+            return exc
 
     if inferred_role == "col":
         csec = APIPyInterface.ColumnSection()
@@ -434,7 +451,9 @@ def _register_section(
             _sec_kind, sh = _make_section_shape(shape_dict, material_family)
             csec.SetUserSect(_sec_kind, sh)
         elif use_standard_steel:
-            csec.SetStandSteelSect(std_name)
+            standard_error = _set_standard_steel(csec)
+            if standard_error is not None:
+                raise ValueError(f"Section '{sec['id']}' standard steel section failed: {standard_error}")
         else:
             raise ValueError(f"Section '{sec['id']}' has no usable PKPM section shape.")
         pm_idx = model.AddColumnSection(csec)
@@ -444,7 +463,9 @@ def _register_section(
             _sec_kind, sh = _make_section_shape(shape_dict, material_family)
             bsec.SetUserSect(_sec_kind, sh)
         elif use_standard_steel:
-            bsec.SetStandSteelSect(std_name)
+            standard_error = _set_standard_steel(bsec)
+            if standard_error is not None:
+                raise ValueError(f"Section '{sec['id']}' standard steel section failed: {standard_error}")
         else:
             raise ValueError(f"Section '{sec['id']}' has no usable PKPM section shape.")
         pm_idx = model.AddBeamSection(bsec)
@@ -744,6 +765,78 @@ def _elem_concrete_grade(elem: dict, mat_id_to_grade: dict[str, str]) -> Any:
     return _resolve_concrete_grade(grade)
 
 
+def _nonnegative_float(value: Any) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return number if number > 0 else 0.0
+
+
+def _story_dead_live_pair(story: dict[str, Any]) -> tuple[float, float]:
+    return (
+        _nonnegative_float(story.get("dead_load")),
+        _nonnegative_float(story.get("live_load")),
+    )
+
+
+def _copy_standard_floor(model: APIPyInterface.Model, source_floor_index: int) -> int:
+    """Copy an existing standard floor and return the new standard floor index."""
+    try:
+        new_index = model.AddStandFloor(source_floor_index)
+    except TypeError:
+        new_index = model.AddStandFloor()
+
+    if isinstance(new_index, int) and new_index > 0:
+        return new_index
+
+    try:
+        fallback_index = model.GetStandFloorCount()
+    except Exception as exc:
+        raise RuntimeError("PKPM AddStandFloor did not return a valid floor index.") from exc
+    if isinstance(fallback_index, int) and fallback_index > 0:
+        return fallback_index
+    raise RuntimeError("PKPM AddStandFloor did not return a valid floor index.")
+
+
+def _configure_story_standard_floor_loads(
+    model: APIPyInterface.Model,
+    stories: list[dict],
+) -> tuple[list[int], list[dict[str, Any]]]:
+    """Assign floor dead/live loads through per-load standard-floor copies.
+
+    PKPM stores floor dead/live loads on StandFloor, while RealFloor only points
+    to a standard-floor index.  Distinct story load pairs therefore need
+    distinct standard-floor copies that share the same plan geometry.
+    """
+    story_floor_indices: list[int] = []
+    load_to_standard_floor: dict[tuple[float, float], int] = {}
+    load_mapping: list[dict[str, Any]] = []
+
+    for story in stories:
+        load_pair = _story_dead_live_pair(story)
+        standard_floor_index = load_to_standard_floor.get(load_pair)
+        if standard_floor_index is None:
+            standard_floor_index = 1 if not load_to_standard_floor else _copy_standard_floor(model, 1)
+            model.SetCurrentStandFloor(standard_floor_index)
+            standard_floor = model.GetCurrentStandFloor()
+            dead_load, live_load = load_pair
+            if dead_load > 0 or live_load > 0:
+                standard_floor.SetDeadLive(dead_load, live_load)
+            load_to_standard_floor[load_pair] = standard_floor_index
+
+        story_floor_indices.append(standard_floor_index)
+        load_mapping.append({
+            "story": story.get("id"),
+            "stand_floor_index": standard_floor_index,
+            "dead_load": load_pair[0],
+            "live_load": load_pair[1],
+        })
+
+    model.SetCurrentStandFloor(1)
+    return story_floor_indices, load_mapping
+
+
 # ---------------------------------------------------------------------------
 # Main converter
 # ---------------------------------------------------------------------------
@@ -811,24 +904,11 @@ def convert_v2_to_jws(
     )
 
     # ---- Standard floor 1 (plan template) ----
-    # Do NOT call AddStandFloor() — it causes SavePMModel crash with beams.
     # The model already has floor 1 available by default after CreatNewModel.
+    # Extra standard floors are copied from this fully populated template only
+    # when story dead/live loads differ.
     model.SetCurrentStandFloor(1)
     floor = model.GetCurrentStandFloor()
-
-    # ---- Floor dead/live loads from stories ----
-    stories_for_load = data.get("stories", [])
-    agg_dead = 0.0
-    agg_live = 0.0
-    for st in stories_for_load:
-        dl = st.get("dead_load")
-        ll = st.get("live_load")
-        if dl is not None:
-            agg_dead = max(agg_dead, float(dl))
-        if ll is not None:
-            agg_live = max(agg_live, float(ll))
-    if agg_dead > 0 or agg_live > 0:
-        floor.SetDeadLive(agg_dead, agg_live)
 
     nodes = data.get("nodes", [])
     v2_to_pm, v2_to_xy = _build_plan_nodes(floor, nodes)
@@ -932,12 +1012,13 @@ def convert_v2_to_jws(
         data.get("stories", []),
         key=lambda s: float(s.get("elevation", 0)),
     )
+    story_standard_floor_indices, floor_load_mapping = _configure_story_standard_floor_loads(model, stories)
     m_to_mm = 1000.0
-    for st in stories:
+    for story_index, st in enumerate(stories):
         rf = APIPyInterface.RealFloor()
         rf.SetFloorHeight(float(st["height"]) * m_to_mm)
         rf.SetBottomElevation(float(st.get("elevation", 0)))
-        rf.SetStandFloorIndex(1)
+        rf.SetStandFloorIndex(story_standard_floor_indices[story_index])
         model.AddNaturalFloor(rf)
 
     # ---- Configure SATWE design parameters ----
@@ -953,6 +1034,7 @@ def convert_v2_to_jws(
         "stories": stories,
         "normalization": normalization,
         "material_family": material_family,
+        "floor_load_mapping": floor_load_mapping,
         "design_conditions": {
             "site_seismic": site_seismic,
             "wind": wind,

--- a/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/pkpm_converter.py
@@ -821,7 +821,7 @@ def _configure_story_standard_floor_loads(
             model.SetCurrentStandFloor(standard_floor_index)
             standard_floor = model.GetCurrentStandFloor()
             dead_load, live_load = load_pair
-            if dead_load > 0 or live_load > 0:
+            if standard_floor_index > 1 or dead_load > 0 or live_load > 0:
                 standard_floor.SetDeadLive(dead_load, live_load)
             load_to_standard_floor[load_pair] = standard_floor_index
 

--- a/backend/src/agent-skills/analysis/pkpm-static/runtime.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/runtime.py
@@ -99,6 +99,20 @@ def _read_project_para_int(para: Any, key: int) -> int | None:
         return None
 
 
+def _open_pm_model(model: Any, jws_path: Path) -> Any:
+    open_result = model.OpenPMModel(str(jws_path))
+    if open_result == 0 or open_result is False:
+        raise RuntimeError(f"Failed to open PKPM model: {jws_path}")
+    return open_result
+
+
+def _get_project_para(model: Any, jws_path: Path) -> Any:
+    para = model.GetProjectPara()
+    if para is None:
+        raise RuntimeError(f"Failed to read PKPM project parameters: {jws_path}")
+    return para
+
+
 def _reapply_project_material_params(jws_path: Path, material_family: str) -> dict[str, Any]:
     """Restore PKPM project parameters that JWSCYCLE clears after analysis."""
     import APIPyInterface
@@ -110,8 +124,8 @@ def _reapply_project_material_params(jws_path: Path, material_family: str) -> di
     }
 
     model = APIPyInterface.Model()
-    open_result = model.OpenPMModel(str(jws_path))
-    para = model.GetProjectPara()
+    open_result = _open_pm_model(model, jws_path)
+    para = _get_project_para(model, jws_path)
     before = {str(key): _read_project_para_int(para, key) for key in target_values}
 
     for key, value in target_values.items():
@@ -119,9 +133,12 @@ def _reapply_project_material_params(jws_path: Path, material_family: str) -> di
     model.SaveProjectPara()
     model.SavePMModel()
 
+    del para
+    del model
+
     verify_model = APIPyInterface.Model()
-    verify_model.OpenPMModel(str(jws_path))
-    verify_para = verify_model.GetProjectPara()
+    verify_open_result = _open_pm_model(verify_model, jws_path)
+    verify_para = _get_project_para(verify_model, jws_path)
     after = {str(key): _read_project_para_int(verify_para, key) for key in target_values}
 
     mismatches = {
@@ -135,6 +152,7 @@ def _reapply_project_material_params(jws_path: Path, material_family: str) -> di
     return {
         "material_family": material_family,
         "open_result": open_result,
+        "verify_open_result": verify_open_result,
         "target": {str(key): value for key, value in target_values.items()},
         "before": before,
         "after": after,

--- a/backend/src/agent-skills/analysis/pkpm-static/runtime.py
+++ b/backend/src/agent-skills/analysis/pkpm-static/runtime.py
@@ -72,10 +72,9 @@ def _import_apipyinterface() -> None:
 def _patch_material_label(work_dir: Path) -> None:
     """Replace 钢砼结构 with 钢结构 in JWSCYCLE output files.
 
-    JWSCYCLE always auto-detects the material type by scanning sections,
-    and custom sections via SetUserSect get classified as composite even
-    when Set_M(5) and KIND 103=10303 are set correctly.  This post-process
-    patch corrects the cosmetic label without affecting analysis results.
+    JWSCYCLE writes this label before we restore project material parameters
+    below, so this only keeps generated text reports aligned with the final
+    JWS project metadata.  It does not replace the project-parameter fix.
     """
     _OLD = "钢砼结构".encode("gbk")
     _NEW = "钢结构".encode("gbk")
@@ -87,6 +86,60 @@ def _patch_material_label(work_dir: Path) -> None:
         data = fpath.read_bytes()
         if _OLD in data:
             fpath.write_bytes(data.replace(_OLD, _NEW))
+
+
+def _read_project_para_int(para: Any, key: int) -> int | None:
+    try:
+        value = para.GetPara_Int(key)
+    except Exception:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _reapply_project_material_params(jws_path: Path, material_family: str) -> dict[str, Any]:
+    """Restore PKPM project parameters that JWSCYCLE clears after analysis."""
+    import APIPyInterface
+
+    target_material = 10303 if material_family == "steel" else 10301
+    target_values = {
+        101: 10101,  # 结构体系：框架结构
+        103: target_material,  # 结构材料信息
+    }
+
+    model = APIPyInterface.Model()
+    open_result = model.OpenPMModel(str(jws_path))
+    para = model.GetProjectPara()
+    before = {str(key): _read_project_para_int(para, key) for key in target_values}
+
+    for key, value in target_values.items():
+        para.SetParaInt(key, value)
+    model.SaveProjectPara()
+    model.SavePMModel()
+
+    verify_model = APIPyInterface.Model()
+    verify_model.OpenPMModel(str(jws_path))
+    verify_para = verify_model.GetProjectPara()
+    after = {str(key): _read_project_para_int(verify_para, key) for key in target_values}
+
+    mismatches = {
+        str(key): {"expected": value, "actual": after.get(str(key))}
+        for key, value in target_values.items()
+        if after.get(str(key)) != value
+    }
+    if mismatches:
+        raise RuntimeError(f"PKPM project material parameters were not persisted: {mismatches}")
+
+    return {
+        "material_family": material_family,
+        "open_result": open_result,
+        "target": {str(key): value for key, value in target_values.items()},
+        "before": before,
+        "after": after,
+        "changed": before != after,
+    }
 
 
 def _run_jws_cycle(cycle_path: Path, work_dir: Path, timeout: int = 600) -> None:
@@ -546,7 +599,10 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     timeout = int(parameters.get("timeout", 600))
     _run_jws_cycle(cycle_path, work_dir, timeout=timeout)
 
-    # ---- Phase 2.5: Post-process output files ----
+    # ---- Phase 2.5: Restore project metadata that JWSCYCLE rewrites ----
+    project_parameter_reapply = _reapply_project_material_params(jws_path, material_family)
+
+    # ---- Phase 2.6: Post-process output files ----
     if material_family == "steel":
         _patch_material_label(work_dir)
 
@@ -576,6 +632,7 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
     beams = extracted.get("beams", [])
     columns = extracted.get("columns", [])
     design_conditions = converter_mappings.get("design_conditions", {})
+    floor_load_mapping = converter_mappings.get("floor_load_mapping", [])
 
     # ---- Build V2 node → PKPM (floor, pmid) mapping ----
     v2_to_pm: Dict[str, int] = converter_mappings.get("v2_to_pm", {})
@@ -918,6 +975,8 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
             "beam_count": extracted.get("beam_count", 0),
             "column_count": extracted.get("column_count", 0),
             "designConditions": design_conditions,
+            "floorLoadMapping": floor_load_mapping,
+            "projectParameterReapply": project_parameter_reapply,
             **pkpm_summary,
         },
         "pkpm_detailed": {
@@ -930,6 +989,8 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
             "bearing_shear": extracted.get("bearing_shear", []),
             "satwe_params": extracted.get("satwe_params", {}),
             "input_design_conditions": design_conditions,
+            "input_floor_load_mapping": floor_load_mapping,
+            "project_parameter_reapply": project_parameter_reapply,
         },
         "caseResults": case_results,
         "envelopeTables": {

--- a/backend/src/agent-skills/code-check/__tests__/element-data-bridge.test.mjs
+++ b/backend/src/agent-skills/code-check/__tests__/element-data-bridge.test.mjs
@@ -302,6 +302,101 @@ describe('elementData bridge', () => {
     expect(f['Mx']).toBe(3500000); // abs(n2) > abs(n1)
   });
 
+  test('converts PKPM force units before GB50017 elementData consumption', () => {
+    const model = {
+      elements: [
+        { id: 'B1', type: 'beam', nodes: ['N1', 'N2'], material: '1', section: '1' },
+      ],
+      sections: [
+        {
+          id: '1',
+          properties: {
+            A: 0.00487,
+            Iy: 0.0000721,
+            Wx: 0.00048,
+            S: 0.000286,
+            tw: 0.0065,
+            As: 0.001833,
+            G: 79000,
+          },
+        },
+      ],
+      materials: [{ id: '1', E: 206000, fy: 355 }],
+      nodes: [
+        { id: 'N1', x: 0, y: 0, z: 3.6 },
+        { id: 'N2', x: 6, y: 0, z: 3.6 },
+      ],
+    };
+
+    const input = buildCodeCheckInput({
+      traceId: 'test-trace',
+      designCode: 'GB50017',
+      model,
+      analysis: {
+        data: {
+          analysisMode: 'pkpm-satwe',
+          forces: {
+            B1: { N: 8, V: 36, M: 54 },
+          },
+        },
+      },
+      analysisParameters: {},
+    });
+
+    const forces = input.context['elementData']['B1']['forces'];
+    expect(forces['N']).toBe(8000);
+    expect(forces['V']).toBe(36000);
+    expect(forces['Mx']).toBe(54000000);
+  });
+
+  test('converts OpenSees force units before GB50017 elementData consumption', () => {
+    const model = {
+      elements: [
+        { id: 'B1', type: 'beam', nodes: ['N1', 'N2'], material: '1', section: '1' },
+      ],
+      sections: [
+        {
+          id: '1',
+          properties: {
+            A: 0.00487,
+            Iy: 0.0000721,
+            Wx: 0.00048,
+            S: 0.000286,
+            tw: 0.0065,
+            As: 0.001833,
+            G: 79000,
+          },
+        },
+      ],
+      materials: [{ id: '1', E: 206000, fy: 355 }],
+      nodes: [
+        { id: 'N1', x: 0, y: 0, z: 3.6 },
+        { id: 'N2', x: 6, y: 0, z: 3.6 },
+      ],
+    };
+
+    const input = buildCodeCheckInput({
+      traceId: 'test-trace',
+      designCode: 'GB50017',
+      model,
+      analysis: {
+        meta: { analysisAdapterKey: 'builtin-opensees' },
+        data: {
+          analysisMode: 'opensees_3d_frame',
+          forces: {
+            B1: { n1: { N: 8, V: 36, M: 54 } },
+          },
+        },
+      },
+      analysisParameters: {},
+    });
+
+    const forces = input.context['elementData']['B1']['forces'];
+    expect(forces['N']).toBe(8000);
+    expect(forces['V']).toBe(36000);
+    expect(forces['Mx']).toBe(54000000);
+  });
+
   test('derives Wnx/S/As/tw from H-section shape when props missing', () => {
     const input = buildCodeCheckInput({
       traceId: 'test-trace',
@@ -326,6 +421,33 @@ describe('elementData bridge', () => {
     expect(section['S']).toBeGreaterThan(0);     // derived from H/B/tw/tf
     expect(section['tw']).toBeCloseTo(6.5, 0);   // 0.0065m → 6.5mm
     expect(section['As']).toBeGreaterThan(0);    // tw × hw
+  });
+
+  test('derives Wnx/S/As/tw from H-section shape expressed in millimeters', () => {
+    const input = buildCodeCheckInput({
+      traceId: 'test-trace',
+      designCode: 'GB50017',
+      model: {
+        elements: [{ id: 'E1', type: 'beam', nodes: ['N1', 'N2'], material: '1', section: '1' }],
+        sections: [{
+          id: '1', name: 'HN300X150', type: 'H', purpose: 'beam',
+          shape: { kind: 'H', H: 300, B: 150, tw: 6.5, tf: 9 },
+          properties: { A: 0.00487, Iy: 0.0000721, Iz: 0.00000508, G: 79000 },
+        }],
+        materials: [{ id: '1', E: 206000, fy: 235 }],
+        nodes: [{ id: 'N1', x: 0, y: 0, z: 0 }, { id: 'N2', x: 0, y: 0, z: 3 }],
+      },
+      analysis: { data: { forces: {} } },
+      analysisParameters: {},
+    });
+
+    const ed = input.context['elementData'];
+    const section = ed['E1']['section'];
+    expect(section['Wx']).toBeCloseTo(480667, -2); // Iy/(H/2), with H already in mm
+    expect(section['S']).toBeGreaterThan(250000);
+    expect(section['S']).toBeLessThan(270000);
+    expect(section['tw']).toBeCloseTo(6.5, 0);
+    expect(section['As']).toBeCloseTo(1833, -1);
   });
 
   test('adds f and fv fallback when material has fy but no f/fv', () => {

--- a/backend/src/agent-skills/code-check/entry.ts
+++ b/backend/src/agent-skills/code-check/entry.ts
@@ -147,13 +147,54 @@ function envelopeAbs(a: unknown, b: unknown): number | undefined {
   return va >= vb ? va : vb;
 }
 
+function isPkpmAnalysisResult(analysis: Record<string, unknown>, data: Record<string, unknown>): boolean {
+  const meta = asRecord(analysis['meta']);
+  return data['analysisMode'] === 'pkpm-satwe'
+    || meta['analysisAdapterKey'] === 'builtin-pkpm'
+    || meta['engineId'] === 'builtin-pkpm';
+}
+
+function usesKilonewtonAnalysisForceUnits(analysis: Record<string, unknown>, data: Record<string, unknown>): boolean {
+  const meta = asRecord(analysis['meta']);
+  return isPkpmAnalysisResult(analysis, data)
+    || meta['analysisAdapterKey'] === 'builtin-opensees'
+    || meta['engineId'] === 'builtin-opensees';
+}
+
+function scaleFiniteNumber(value: unknown, factor: number): unknown {
+  return typeof value === 'number' && Number.isFinite(value) ? value * factor : value;
+}
+
+function convertKilonewtonForcesToCodeCheckUnits(forceRecord: Record<string, unknown>): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...forceRecord };
+  for (const key of ['N', 'V', 'Vy', 'Vz']) {
+    if (key in next) next[key] = scaleFiniteNumber(next[key], 1000);
+  }
+  for (const key of ['M', 'Mx', 'My', 'Mz', 'T']) {
+    if (key in next) next[key] = scaleFiniteNumber(next[key], 1000000);
+  }
+  for (const key of ['n1', 'n2']) {
+    const nested = asRecord(next[key]);
+    if (Object.keys(nested).length > 0) {
+      next[key] = convertKilonewtonForcesToCodeCheckUnits(nested);
+    }
+  }
+  return next;
+}
+
+function sectionShapeDimensionToMm(value: unknown, sourceUnit: 'm' | 'mm'): number {
+  const numeric = Number(value ?? 0);
+  if (!Number.isFinite(numeric) || numeric <= 0) return 0;
+  return sourceUnit === 'mm' ? numeric : numeric * 1000;
+}
+
 /**
  * 从模型和分析结果中提取 elementData，供 Python code-check 层消费。
  *
  * 合并三项数据源:
  *   1. model.elements[] — 构件类型、截面/材料 ID、始末节点
  *   2. model.sections[] / model.materials[] — 截面/材料属性
- *   3. analysisResult.data.forces[] — OpenSees 计算的每构件内力
+ *   3. analysisResult.data.forces[] — 每构件内力；PKPM/OpenSees 的 kN/kN·m 会转为 N/N·mm
  *
  * 返回格式与 gb50017 `_compute_utilization_overrides()` 期望的 elementData 一致。
  */
@@ -168,15 +209,20 @@ function extractElementDataForCodeCheck(
   const materials = Array.isArray(model['materials']) ? model['materials'] as Record<string, unknown>[] : [];
   const nodes = Array.isArray(model['nodes']) ? model['nodes'] as Record<string, unknown>[] : [];
 
-  // unwrap OpenSees AnalysisResponse: { data: { forces: { ... } } }
-  const analysis = analysisResult as Record<string, unknown> | undefined;
-  const data = analysis?.['data'] as Record<string, unknown> | undefined;
+  // unwrap AnalysisResponse: { data: { forces: { ... } } }; direct result objects are also accepted.
+  const analysis = asRecord(analysisResult);
+  const dataObject = asRecord(analysis['data']);
+  const data = Object.keys(dataObject).length > 0 ? dataObject : analysis;
   const rawForces = data?.['forces'] as Record<string, unknown> | undefined;
+  const shouldConvertForceUnits = usesKilonewtonAnalysisForceUnits(analysis, data);
   const forces: Record<string, Record<string, unknown>> = {};
   if (rawForces) {
     for (const [elemId, value] of Object.entries(rawForces)) {
       if (value && typeof value === 'object') {
-        forces[elemId] = value as Record<string, unknown>;
+        const forceRecord = value as Record<string, unknown>;
+        forces[elemId] = shouldConvertForceUnits
+          ? convertKilonewtonForcesToCodeCheckUnits(forceRecord)
+          : forceRecord;
       }
     }
   }
@@ -268,13 +314,14 @@ function extractElementDataForCodeCheck(
     let derivedTw_mm = tw_mm;
     let derivedAs_mm2 = As_mm2;
     if (sectionShape && sectionShape['kind'] === 'H') {
-      const H = Number(sectionShape['H'] ?? 0);
-      const B = Number(sectionShape['B'] ?? 0);
-      const tw = Number(sectionShape['tw'] ?? 0);
-      const tf = Number(sectionShape['tf'] ?? 0);
-      if (H > 0 && B > 0 && tw > 0 && tf > 0) {
-        // convert m → mm
-        const Hmm = H * 1000, Bmm = B * 1000, twmm = tw * 1000, tfmm = tf * 1000;
+      const rawH = Number(sectionShape['H'] ?? 0);
+      const rawB = Number(sectionShape['B'] ?? 0);
+      const shapeUnit = rawH > 10 || rawB > 10 ? 'mm' : 'm';
+      const Hmm = sectionShapeDimensionToMm(sectionShape['H'], shapeUnit);
+      const Bmm = sectionShapeDimensionToMm(sectionShape['B'], shapeUnit);
+      const twmm = sectionShapeDimensionToMm(sectionShape['tw'], shapeUnit);
+      const tfmm = sectionShapeDimensionToMm(sectionShape['tf'], shapeUnit);
+      if (Hmm > 0 && Bmm > 0 && twmm > 0 && tfmm > 0) {
         const hw = Hmm - 2 * tfmm;
         if (derivedWnxMm3 <= 0) {
           // Iy = (tw*hw³)/12 + 2*B*tf*((hw+tf)/2)² — already have Iy_mm4 from props

--- a/backend/tests/analysis-pkpm-frame-flow.test.mjs
+++ b/backend/tests/analysis-pkpm-frame-flow.test.mjs
@@ -326,11 +326,20 @@ function runPkpmRuntime(model, options = {}) {
       'runtime._patch_material_label = lambda work_dir: patch_calls.append(str(work_dir))',
       'def fake_jws_cycle(cycle_path, work_dir, timeout=600):',
       '    run_calls.append({"cycle_path": str(cycle_path), "work_dir": str(work_dir), "timeout": timeout})',
-      '    for jws_path, params in APIPyInterface.project_params.items():',
-      '        if Path(jws_path).parent == Path(work_dir):',
-      '            params[101] = 0',
-      '            params[103] = 0',
+      '    for params in APIPyInterface.project_params.values():',
+      '        params[101] = 0',
+      '        params[103] = 0',
       'runtime._run_jws_cycle = fake_jws_cycle',
+      ...(
+        options.failOpenPmModel
+          ? [
+            'def fail_open_pm_model(self, jws_path):',
+            '    APIPyInterface.calls.append({"method": "Model.OpenPMModel", "jws_path": jws_path, "forcedFailure": True})',
+            '    return 0',
+            'APIPyInterface.Model.OpenPMModel = fail_open_pm_model',
+          ]
+          : []
+      ),
       'def fake_extract(jws_path, material_family="steel"):',
       ...(
         options.createPdbMismatchDuringExtract
@@ -762,7 +771,7 @@ describe('PKPM frame analysis flow', () => {
     });
   });
 
-  test('maps different story dead/live loads to separate PKPM standard floors', () => {
+  test('maps distinct story dead/live loads to separate PKPM standard floors', () => {
     const model = buildRcUserScenarioModel();
     model.stories[0] = {
       ...model.stories[0],
@@ -772,16 +781,16 @@ describe('PKPM frame analysis flow', () => {
     };
     model.stories[1] = {
       ...model.stories[1],
-      dead_load: 5,
-      live_load: 1,
-      floor_loads: [{ type: 'dead', value: 5 }, { type: 'live', value: 1 }],
+      dead_load: 0,
+      live_load: 0,
+      floor_loads: [{ type: 'dead', value: 0 }, { type: 'live', value: 0 }],
     };
 
     const payload = runPkpmRuntime(model);
 
     expect(findCalls(payload, 'StandFloor.SetDeadLive')).toEqual([
       expect.objectContaining({ floor: 1, dead: 10, live: 2 }),
-      expect.objectContaining({ floor: 2, dead: 5, live: 1 }),
+      expect.objectContaining({ floor: 2, dead: 0, live: 0 }),
     ]);
     expect(findCalls(payload, 'Model.AddStandFloor')).toEqual([
       expect.objectContaining({ source: 1, index: 2 }),
@@ -789,8 +798,21 @@ describe('PKPM frame analysis flow', () => {
     expect(findCalls(payload, 'RealFloor.SetStandFloorIndex').map((call) => call.index)).toEqual([1, 2]);
     expect(payload.result.summary.floorLoadMapping).toEqual([
       expect.objectContaining({ story: 'F1', stand_floor_index: 1, dead_load: 10, live_load: 2 }),
-      expect.objectContaining({ story: 'F2', stand_floor_index: 2, dead_load: 5, live_load: 1 }),
+      expect.objectContaining({ story: 'F2', stand_floor_index: 2, dead_load: 0, live_load: 0 }),
     ]);
+  });
+
+  test('fails clearly when final PKPM model cannot be reopened for material parameter persistence', () => {
+    const payload = runPkpmRuntime(buildRcUserScenarioModel(), {
+      expectFailure: true,
+      failOpenPmModel: true,
+    });
+
+    expect(payload.errorType).toBe('RuntimeError');
+    expect(payload.error).toContain('Failed to open PKPM model');
+    expect(findCalls(payload, 'Model.OpenPMModel')).toEqual(expect.arrayContaining([
+      expect.objectContaining({ forcedFailure: true }),
+    ]));
   });
 
   test('keeps PKPM result when PDB version warning is present but core results are readable', () => {

--- a/backend/tests/analysis-pkpm-frame-flow.test.mjs
+++ b/backend/tests/analysis-pkpm-frame-flow.test.mjs
@@ -106,7 +106,10 @@ function writePkpmApiStub(stubsDir) {
   writeFile(
     path.join(stubsDir, 'APIPyInterface.py'),
     [
+      'import os',
+      '',
       'calls = []',
+      'project_params = {}',
       '',
       'class SteelGrade:',
       '    Q235 = "Q235"',
@@ -169,10 +172,16 @@ function writePkpmApiStub(stubsDir) {
       '        calls.append({"method": "BeamSection.SetStandSteelSect", "name": name})',
       '',
       'class ProjectPara:',
+      '    def __init__(self, values=None):',
+      '        self.values = dict(values or {})',
       '    def SetParaInt(self, key, value):',
+      '        self.values[int(key)] = int(value)',
       '        calls.append({"method": "ProjectPara.SetParaInt", "key": key, "value": value})',
       '    def SetParaDouble(self, key, value):',
       '        calls.append({"method": "ProjectPara.SetParaDouble", "key": key, "value": value})',
+      '    def GetPara_Int(self, key):',
+      '        calls.append({"method": "ProjectPara.GetPara_Int", "key": key})',
+      '        return self.values.get(int(key), 0)',
       '',
       'class Node:',
       '    def __init__(self, node_id): self.node_id = node_id',
@@ -196,12 +205,13 @@ function writePkpmApiStub(stubsDir) {
       '    def GetPmid(self): return self.pmid',
       '',
       'class StandFloor:',
-      '    def __init__(self):',
+      '    def __init__(self, floor_index=1):',
+      '        self.floor_index = floor_index',
       '        self.next_node = 1',
       '        self.next_net = 1',
       '        self.next_column = 1000',
       '        self.next_beam = 2000',
-      '    def SetDeadLive(self, dead, live): calls.append({"method": "StandFloor.SetDeadLive", "dead": dead, "live": live})',
+      '    def SetDeadLive(self, dead, live): calls.append({"method": "StandFloor.SetDeadLive", "floor": self.floor_index, "dead": dead, "live": live})',
       '    def AddNode(self, x, y):',
       '        node = Node(self.next_node)',
       '        self.next_node += 1',
@@ -229,9 +239,14 @@ function writePkpmApiStub(stubsDir) {
       '    def SetStandFloorIndex(self, index): calls.append({"method": "RealFloor.SetStandFloorIndex", "index": index})',
       '',
       'class Model:',
-      '    def __init__(self): self.floor = StandFloor(); self.next_col_sec = 1; self.next_beam_sec = 1; self.para = ProjectPara(); self.design_params = [0.0] * 128',
-      '    def CreatNewModel(self, work_dir, project_name): calls.append({"method": "Model.CreatNewModel", "work_dir": work_dir, "project_name": project_name})',
-      '    def OpenPMModel(self, jws_path): calls.append({"method": "Model.OpenPMModel", "jws_path": jws_path})',
+      '    def __init__(self): self.floors = {1: StandFloor(1)}; self.current_floor = 1; self.next_col_sec = 1; self.next_beam_sec = 1; self.para = ProjectPara(); self.design_params = [0.0] * 128; self.jws_path = None',
+      '    def CreatNewModel(self, work_dir, project_name):',
+      '        self.jws_path = os.path.join(work_dir, project_name + ".JWS")',
+      '        calls.append({"method": "Model.CreatNewModel", "work_dir": work_dir, "project_name": project_name})',
+      '    def OpenPMModel(self, jws_path):',
+      '        self.jws_path = jws_path',
+      '        self.para = ProjectPara(project_params.get(jws_path, {}))',
+      '        calls.append({"method": "Model.OpenPMModel", "jws_path": jws_path})',
       '    def AddColumnSection(self, section):',
       '        idx = self.next_col_sec',
       '        self.next_col_sec += 1',
@@ -242,8 +257,10 @@ function writePkpmApiStub(stubsDir) {
       '        self.next_beam_sec += 1',
       '        calls.append({"method": "Model.AddBeamSection", "idx": idx, "section": section.user or {"standard": section.standard}})',
       '        return idx',
-      '    def SetCurrentStandFloor(self, index): calls.append({"method": "Model.SetCurrentStandFloor", "index": index})',
-      '    def GetCurrentStandFloor(self): return self.floor',
+      '    def SetCurrentStandFloor(self, index):',
+      '        self.current_floor = index',
+      '        calls.append({"method": "Model.SetCurrentStandFloor", "index": index})',
+      '    def GetCurrentStandFloor(self): return self.floors[self.current_floor]',
       '    def AddNaturalFloor(self, floor): calls.append({"method": "Model.AddNaturalFloor"})',
       '    def GetProjectPara(self): return self.para',
       '    def GetAllDesignPara(self):',
@@ -253,9 +270,17 @@ function writePkpmApiStub(stubsDir) {
       '        self.design_params = list(values)',
       '        calls.append({"method": "Model.SetAllDesignPara", "values": list(values)})',
       '    def SetOneDesignParaValue(self, index, value): calls.append({"method": "Model.SetOneDesignParaValue", "index": index, "value": value})',
-      '    def AddStandFloor(self): calls.append({"method": "Model.AddStandFloor"})',
+      '    def AddStandFloor(self, source=None):',
+      '        new_index = max(self.floors.keys()) + 1',
+      '        self.floors[new_index] = StandFloor(new_index)',
+      '        calls.append({"method": "Model.AddStandFloor", "source": source, "index": new_index})',
+      '        return new_index',
+      '    def GetStandFloorCount(self): return len(self.floors)',
       '    def SaveProjectPara(self): calls.append({"method": "Model.SaveProjectPara"})',
-      '    def SavePMModel(self): calls.append({"method": "Model.SavePMModel"})',
+      '    def SavePMModel(self):',
+      '        if self.jws_path:',
+      '            project_params[self.jws_path] = dict(self.para.values)',
+      '        calls.append({"method": "Model.SavePMModel"})',
       '',
       'class ResultData:',
       '    def InitialResult(self, jws_path): calls.append({"method": "ResultData.InitialResult", "jws_path": jws_path}); return 1',
@@ -299,7 +324,13 @@ function runPkpmRuntime(model, options = {}) {
       'runtime._check_pkpm_available = lambda: Path("JWSCYCLE.exe")',
       'runtime._import_apipyinterface = lambda: None',
       'runtime._patch_material_label = lambda work_dir: patch_calls.append(str(work_dir))',
-      'runtime._run_jws_cycle = lambda cycle_path, work_dir, timeout=600: run_calls.append({"cycle_path": str(cycle_path), "work_dir": str(work_dir), "timeout": timeout})',
+      'def fake_jws_cycle(cycle_path, work_dir, timeout=600):',
+      '    run_calls.append({"cycle_path": str(cycle_path), "work_dir": str(work_dir), "timeout": timeout})',
+      '    for jws_path, params in APIPyInterface.project_params.items():',
+      '        if Path(jws_path).parent == Path(work_dir):',
+      '            params[101] = 0',
+      '            params[103] = 0',
+      'runtime._run_jws_cycle = fake_jws_cycle',
       'def fake_extract(jws_path, material_family="steel"):',
       ...(
         options.createPdbMismatchDuringExtract
@@ -731,6 +762,37 @@ describe('PKPM frame analysis flow', () => {
     });
   });
 
+  test('maps different story dead/live loads to separate PKPM standard floors', () => {
+    const model = buildRcUserScenarioModel();
+    model.stories[0] = {
+      ...model.stories[0],
+      dead_load: 10,
+      live_load: 2,
+      floor_loads: [{ type: 'dead', value: 10 }, { type: 'live', value: 2 }],
+    };
+    model.stories[1] = {
+      ...model.stories[1],
+      dead_load: 5,
+      live_load: 1,
+      floor_loads: [{ type: 'dead', value: 5 }, { type: 'live', value: 1 }],
+    };
+
+    const payload = runPkpmRuntime(model);
+
+    expect(findCalls(payload, 'StandFloor.SetDeadLive')).toEqual([
+      expect.objectContaining({ floor: 1, dead: 10, live: 2 }),
+      expect.objectContaining({ floor: 2, dead: 5, live: 1 }),
+    ]);
+    expect(findCalls(payload, 'Model.AddStandFloor')).toEqual([
+      expect.objectContaining({ source: 1, index: 2 }),
+    ]);
+    expect(findCalls(payload, 'RealFloor.SetStandFloorIndex').map((call) => call.index)).toEqual([1, 2]);
+    expect(payload.result.summary.floorLoadMapping).toEqual([
+      expect.objectContaining({ story: 'F1', stand_floor_index: 1, dead_load: 10, live_load: 2 }),
+      expect.objectContaining({ story: 'F2', stand_floor_index: 2, dead_load: 5, live_load: 1 }),
+    ]);
+  });
+
   test('keeps PKPM result when PDB version warning is present but core results are readable', () => {
     const payload = runPkpmRuntime(buildRcUserScenarioModel(), {
       createPdbMismatchDuringExtract: true,
@@ -924,6 +986,13 @@ describe('PKPM frame analysis flow', () => {
 
     expect(payload.result.summary.materialFamily).toBe('steel');
     expect(payload.patchCalls).toHaveLength(1);
+    expect(payload.result.summary.projectParameterReapply).toMatchObject({
+      material_family: 'steel',
+      target: { 101: 10101, 103: 10303 },
+      before: { 101: 0, 103: 0 },
+      after: { 101: 10101, 103: 10303 },
+      changed: true,
+    });
     expect(payload.calls).toContainEqual(expect.objectContaining({
       method: 'ProjectPara.SetParaInt',
       key: 103,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

* Problem: PKPM/SATWE clears JWS project parameters `101` and `103` after `JWSCYCLE.exe`, so a completed steel frame project can reopen with material/system parameters reset even though the model was intended as steel.
* Why it matters: users can see reinforced-concrete or unset material metadata in PKPM parameter definitions after analysis, which undermines confidence that the steel frame was modeled correctly.
* What changed: restore and verify JWS project parameters after SATWE (`101=10101`, `103=10303` for steel), keep SATWE text outputs aligned, preserve explicit steel H-section geometry, and include reapply before/after details in analysis output.
* What did NOT change (scope boundary): no frontend UI changes, no PKPM installation/config changes, and no attempt to replace SATWE result extraction with a different parser.

## Change Type (select all)

* Bug fix
* Refactor required for the fix

## Scope (select all touched areas)

* Skills / tool execution
* Integrations
* API / contracts

## Linked Issue/PR

* Closes # N/A
* Related # N/A
* This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

* Root cause: `convert_v2_to_jws` wrote steel project metadata before analysis, but `JWSCYCLE.exe` reset JWS `ProjectPara` fields `101` and `103` to `0` after the SATWE run.
* Missing detection / guardrail: existing tests did not simulate SATWE clearing project parameters or verify the final persisted JWS parameter values after analysis.
* Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
* Why this regressed now: the PKPM integration depended on pre-analysis project parameter writes and a cosmetic OUT-file material label patch, without a post-SATWE persistence check.
* If unknown, what was ruled out: standard steel section registration alone was ruled out; in the local PKPM API it accepted `SetStandSteelSect` but left SATWE section dimensions empty, so explicit parametric H-section geometry remains the safer path.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

* Coverage level that should have caught this:
  * Seam / integration test
* Target test or file: `backend/tests/analysis-pkpm-frame-flow.test.mjs`
* Scenario the test should lock in: PKPM steel-frame flow where `JWSCYCLE` clears project parameters, runtime reopens the final JWS, writes `101/103`, persists them, and records before/after values.
* Why this is the smallest reliable guardrail: the bug occurs at the converter/runtime boundary after external SATWE execution, so a seam test with an APIPyInterface stub is enough to reproduce the contract without requiring PKPM in CI.
* Existing test that already covers this (if any): none before this PR.
* If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Completed PKPM steel-frame analyses now leave the final JWS project metadata as steel frame/steel structure when reopened in PKPM parameter definitions. Analysis JSON also includes `summary.projectParameterReapply` and `pkpm_detailed.project_parameter_reapply` for auditability.

## Diagram (if applicable)

    Before:
    V2 steel frame -> JWS steel params -> JWSCYCLE clears 101/103 -> final JWS shows unset/wrong material metadata

    After:
    V2 steel frame -> JWS steel params -> JWSCYCLE clears 101/103 -> runtime rewrites/verifies 101/103 -> final JWS stays steel

## Security Impact (required)

* New permissions/capabilities? (`Yes/No`): No
* Secrets/tokens handling changed? (`Yes/No`): No
* New/changed network calls? (`Yes/No`): No
* Command/tool execution surface changed? (`Yes/No`): No
* Data access scope changed? (`Yes/No`): No
* If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

* OS: Windows
* Runtime/container: local Node backend + local Python worker
* Model/provider: N/A
* Integration/channel (if any): PKPM 2025R2.5 via `JWSCYCLE.exe` and `APIPyInterface`
* Relevant config (redacted): `SCLAW_DATA_DIR=G:\sclaw_data`, `pkpm.cyclePath=G:\PKPM2025R2.5\PkpmCycle\JWSCYCLE.exe`

### Steps

1. Build a 3-story Q355 steel frame model with H columns and HN beams.
2. Run PKPM/SATWE analysis through `builtin-pkpm`.
3. Run GB50017 code check and generate report/calcbook.
4. Reopen the final JWS through APIPyInterface and read `ProjectPara` fields `101` and `103`.

### Expected

* Final JWS has `101=10101` and `103=10303`.
* SATWE params show steel (`steel_structure_flag=1`).
* H-section geometry and Q355 grade are present in PKPM output.
* GB50017 checks run against the steel member data.

### Actual

* Verified final JWS parameters: `101=10101`, `103=10303`.
* Runtime recorded `before: {101: 0, 103: 0}` and `after: {101: 10101, 103: 10303}`.
* SATWE params included `steel_structure_flag=1`.
* GB50017 result: 39/39 passed, max utilization 0.94, controlling element `BY39`.

## Evidence

Attach at least one:

* Passing tests:
  * `npm test --prefix backend -- --runInBand tests/analysis-pkpm-frame-flow.test.mjs src/agent-skills/code-check/__tests__/element-data-bridge.test.mjs`
  * `npm run lint --prefix backend`
* Real PKPM run output:
  * Report dir: `G:\sclaw_data\reports\pkpm-steel-frame-design-20260610122523`
  * JWS: `G:\sclaw_data\analysis\pkpm\sc_72076913\sc_72076913.JWS`
  * Final project params: `101=10101`, `103=10303`
  * Code check summary: total 39, passed 39, failed 0, max utilization 0.94

## Human Verification (required)

What you personally verified (not just CI), and how:

* Verified scenarios: full local PKPM/SATWE run, final JWS parameter readback, GB50017 code check, report and PKPM calcbook generation.
* Edge cases checked: `JWSCYCLE` clearing `101/103` after analysis; standard steel section API leaving SATWE section dimensions empty in local PKPM, so explicit shape geometry remains preferred.
* What you did not verify: non-steel PKPM projects on a live PKPM installation after this change.

## Review Conversations

* I replied to or resolved every bot review conversation I addressed in this PR.
* I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

* Backward compatible? (`Yes/No`): Yes
* Config/env changes? (`Yes/No`): No
* Migration needed? (`Yes/No`): No
* If yes, exact upgrade steps: N/A

## Risks and Mitigations

* Risk: PKPM API behavior may vary across installed versions.
  * Mitigation: post-SATWE project parameter writes are verified by reopening the JWS and comparing persisted values; section registration keeps explicit parametric geometry when present.
