### PR TITLE
fix(backend): build and analyze panelized truss models

### DIFF
--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -527,6 +527,10 @@ export function buildModelToolSummary(
     nodeCount,
     elementCount,
     schemaVersion,
+    nextAction: 'run_analysis',
+    message: locale === 'zh'
+      ? '模型已构建完成。下一步必须调用 run_analysis 执行结构分析。'
+      : 'Model build is complete. Next, call run_analysis to execute the structural analysis.',
   };
 }
 

--- a/backend/src/agent-runtime/draft-guidance.ts
+++ b/backend/src/agent-runtime/draft-guidance.ts
@@ -2,6 +2,20 @@ import type { AppLocale } from '../services/locale.js';
 import type { DraftState } from './types.js';
 import { localize } from './plugin-helpers.js';
 
+function getInvalidDraftFields(state: DraftState): string[] {
+  const fields = state.skillState?.invalidDraftFields;
+  if (!Array.isArray(fields)) {
+    return [];
+  }
+  return fields.filter((field): field is string => typeof field === 'string');
+}
+
+function pushMissing(missing: string[], key: string): void {
+  if (!missing.includes(key)) {
+    missing.push(key);
+  }
+}
+
 export function computeMissingCriticalKeys(state: DraftState): string[] {
   const missing: string[] = [];
   if (state.inferredType === 'unknown') {
@@ -41,6 +55,23 @@ export function computeMissingCriticalKeys(state: DraftState): string[] {
     }
     if (!state.floorLoads?.length) {
       missing.push('floorLoads');
+    }
+    return missing;
+  }
+  if (state.inferredType === 'truss') {
+    if (state.lengthM === undefined) {
+      pushMissing(missing, 'lengthM');
+    }
+    if (state.bayCount === undefined) {
+      pushMissing(missing, 'bayCount');
+    }
+    if (state.loadKN === undefined) {
+      pushMissing(missing, 'loadKN');
+    }
+    for (const field of getInvalidDraftFields(state)) {
+      if (field === 'lengthM' || field === 'heightM' || field === 'bayCount' || field === 'loadKN' || field === 'trussTopology') {
+        pushMissing(missing, field);
+      }
     }
     return missing;
   }
@@ -104,7 +135,7 @@ export function mapMissingFieldLabels(missing: string[], locale: AppLocale): str
       case 'spanLengthM':
         return localize(locale, '门式刚架或双跨每跨跨度（m）', 'Span length per bay for the portal frame or double-span beam (m)');
       case 'heightM':
-        return localize(locale, '门式刚架柱高（m）', 'Portal-frame column height (m)');
+        return localize(locale, '高度（m）', 'Height (m)');
       case 'supportType':
         return localize(locale, '支座/边界条件（悬臂/简支/两端固结/固铰）', 'Support condition (cantilever / simply supported / fixed-fixed / fixed-pinned)');
       case 'frameDimension':
@@ -112,7 +143,9 @@ export function mapMissingFieldLabels(missing: string[], locale: AppLocale): str
       case 'storyCount':
         return localize(locale, '层数', 'Story count');
       case 'bayCount':
-        return localize(locale, '跨数', 'Bay count');
+        return localize(locale, '跨数/节间数', 'Bay / panel count');
+      case 'trussTopology':
+        return localize(locale, '桁架腹杆体系', 'Truss web system');
       case 'bayCountX':
         return localize(locale, 'X向跨数', 'Bay count in X');
       case 'bayCountY':

--- a/backend/src/agent-runtime/fallback.ts
+++ b/backend/src/agent-runtime/fallback.ts
@@ -343,11 +343,18 @@ export function mergeDraftState(existing: DraftState | undefined, patch: DraftEx
   const bayWidthsXM = patch.bayWidthsXM ?? existing?.bayWidthsXM;
   const bayWidthsYM = patch.bayWidthsYM ?? existing?.bayWidthsYM;
   const floorLoads = mergeFloorLoads(existing?.floorLoads, patch.floorLoads);
+  const skillState = existing?.skillState || patch.skillState
+    ? {
+      ...(existing?.skillState ?? {}),
+      ...(patch.skillState ?? {}),
+    }
+    : undefined;
 
   return {
     inferredType: mergedType,
     lengthM: mergedLength,
     spanLengthM,
+    skillState,
     heightM: patch.heightM ?? existing?.heightM,
     supportType: patch.supportType ?? existing?.supportType,
     frameDimension,

--- a/backend/src/agent-runtime/fallback.ts
+++ b/backend/src/agent-runtime/fallback.ts
@@ -343,10 +343,19 @@ export function mergeDraftState(existing: DraftState | undefined, patch: DraftEx
   const bayWidthsXM = patch.bayWidthsXM ?? existing?.bayWidthsXM;
   const bayWidthsYM = patch.bayWidthsYM ?? existing?.bayWidthsYM;
   const floorLoads = mergeFloorLoads(existing?.floorLoads, patch.floorLoads);
+  const existingInvalidFields = existing?.skillState?.invalidDraftFields;
+  const patchInvalidFields = patch.skillState?.invalidDraftFields;
+  const invalidDraftFields = Array.isArray(existingInvalidFields) || Array.isArray(patchInvalidFields)
+    ? Array.from(new Set([
+      ...(Array.isArray(existingInvalidFields) ? existingInvalidFields : []),
+      ...(Array.isArray(patchInvalidFields) ? patchInvalidFields : []),
+    ].filter((field): field is string => typeof field === 'string')))
+    : undefined;
   const skillState = existing?.skillState || patch.skillState
     ? {
       ...(existing?.skillState ?? {}),
       ...(patch.skillState ?? {}),
+      ...(invalidDraftFields ? { invalidDraftFields } : {}),
     }
     : undefined;
 

--- a/backend/src/agent-runtime/legacy.ts
+++ b/backend/src/agent-runtime/legacy.ts
@@ -91,6 +91,30 @@ function mergeFloorLoadsLlmFirst(
   return Array.from(merged.values()).sort((left, right) => left.story - right.story);
 }
 
+function mergeSkillStateLlmFirst(
+  llmState: Record<string, unknown> | undefined,
+  ruleState: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!llmState && !ruleState) {
+    return undefined;
+  }
+
+  const llmInvalid = llmState?.invalidDraftFields;
+  const ruleInvalid = ruleState?.invalidDraftFields;
+  const invalidDraftFields = Array.isArray(llmInvalid) || Array.isArray(ruleInvalid)
+    ? Array.from(new Set([
+      ...(Array.isArray(ruleInvalid) ? ruleInvalid : []),
+      ...(Array.isArray(llmInvalid) ? llmInvalid : []),
+    ].filter((field): field is string => typeof field === 'string')))
+    : undefined;
+
+  return {
+    ...(ruleState ?? {}),
+    ...(llmState ?? {}),
+    ...(invalidDraftFields ? { invalidDraftFields } : {}),
+  };
+}
+
 export function mergeLegacyDraftPatchLlmFirst(
   llmPatch: DraftExtraction,
   rulePatch: DraftExtraction,
@@ -104,6 +128,13 @@ export function mergeLegacyDraftPatchLlmFirst(
   for (const key of keys) {
     if (key === 'floorLoads') {
       nextPatch.floorLoads = mergeFloorLoadsLlmFirst(llmPatch.floorLoads, rulePatch.floorLoads);
+      continue;
+    }
+    if (key === 'skillState') {
+      const skillState = mergeSkillStateLlmFirst(llmPatch.skillState, rulePatch.skillState);
+      if (skillState !== undefined) {
+        nextPatch.skillState = skillState;
+      }
       continue;
     }
     const llmValue = llmPatch[key];

--- a/backend/src/agent-runtime/legacy.ts
+++ b/backend/src/agent-runtime/legacy.ts
@@ -25,6 +25,13 @@ import {
 import type { AppLocale } from '../services/locale.js';
 import type { DraftExtraction, DraftFloorLoad, DraftState, InferredModelType } from './types.js';
 
+function normalizeSkillState(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  return { ...(value as Record<string, unknown>) };
+}
+
 export function normalizeLegacyDraftPatch(patch: Record<string, unknown> | null | undefined): DraftExtraction {
   if (!patch) {
     return {};
@@ -32,6 +39,7 @@ export function normalizeLegacyDraftPatch(patch: Record<string, unknown> | null 
   return {
     inferredType: normalizeInferredType(patch.inferredType),
     skillId: typeof patch.skillId === 'string' ? patch.skillId : undefined,
+    skillState: normalizeSkillState(patch.skillState),
     lengthM: normalizeNumber(patch.lengthM),
     spanLengthM: normalizeNumber(patch.spanLengthM),
     heightM: normalizeNumber(patch.heightM),

--- a/backend/src/agent-runtime/model-builder.ts
+++ b/backend/src/agent-runtime/model-builder.ts
@@ -321,6 +321,140 @@ function buildBeamLoads(
   return [{ node: targetNodeId, fz: -loadKN }];
 }
 
+function getTrussTopology(state: DraftState): string {
+  const topology = state.skillState?.trussTopology;
+  return typeof topology === 'string' ? topology : 'generic';
+}
+
+function getTrussLoadChord(state: DraftState): 'top' | 'bottom' {
+  return state.skillState?.trussLoadChord === 'bottom' ? 'bottom' : 'top';
+}
+
+function clampTrussPanelCount(value: number | undefined, span: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return Math.max(2, Math.min(30, Math.round(span / 3)));
+  }
+  return Math.max(2, Math.min(30, Math.round(value)));
+}
+
+function buildTrussTopElevation(topology: string, x: number, span: number, height: number): number {
+  if (topology === 'trapezoidal') {
+    return Math.max(height - Math.abs(x - span / 2) * 0.1, height * 0.4);
+  }
+  return height;
+}
+
+function buildTrussModel(state: DraftState, metadata: Record<string, unknown>): Record<string, unknown> {
+  const span = state.lengthM!;
+  const panelCount = clampTrussPanelCount(state.bayCount, span);
+  const height = state.heightM ?? span / 6;
+  const load = state.loadKN!;
+  const topology = getTrussTopology(state);
+  const panelLength = span / panelCount;
+  const fixed = [true, true, true, true, true, true];
+  const roller = [false, true, true, true, true, true];
+  const nodes: Array<Record<string, unknown>> = [];
+  const elements: Array<Record<string, unknown>> = [];
+
+  for (let i = 0; i <= panelCount; i += 1) {
+    const node: Record<string, unknown> = {
+      id: `B${i}`,
+      x: i * panelLength,
+      y: 0,
+      z: 0,
+    };
+    if (i === 0) {
+      node.restraints = fixed;
+    } else if (i === panelCount) {
+      node.restraints = roller;
+    }
+    nodes.push(node);
+  }
+
+  for (let i = 0; i <= panelCount; i += 1) {
+    const x = i * panelLength;
+    nodes.push({
+      id: `T${i}`,
+      x,
+      y: 0,
+      z: buildTrussTopElevation(topology, x, span, height),
+    });
+  }
+
+  for (let i = 0; i < panelCount; i += 1) {
+    elements.push({
+      id: `BC${i}`,
+      type: 'truss',
+      nodes: [`B${i}`, `B${i + 1}`],
+      material: '1',
+      section: '1',
+    });
+    elements.push({
+      id: `TC${i}`,
+      type: 'truss',
+      nodes: [`T${i}`, `T${i + 1}`],
+      material: '1',
+      section: '1',
+    });
+  }
+
+  for (let i = 0; i <= panelCount; i += 1) {
+    elements.push({
+      id: `WV${i}`,
+      type: 'truss',
+      nodes: [`B${i}`, `T${i}`],
+      material: '1',
+      section: '1',
+    });
+    if (i < panelCount) {
+      elements.push({
+        id: `WD${i}`,
+        type: 'truss',
+        nodes: [`B${i + 1}`, `T${i}`],
+        material: '1',
+        section: '1',
+      });
+    }
+  }
+
+  const loadChord = getTrussLoadChord(state);
+  const loadPrefix = loadChord === 'bottom' ? 'B' : 'T';
+  const loadNodeIndexes = state.loadPosition === 'middle-joint'
+    ? [Math.max(1, Math.min(panelCount - 1, Math.round(panelCount / 2)))]
+    : Array.from({ length: Math.max(0, panelCount - 1) }, (_, index) => index + 1);
+  const nodalLoads = loadNodeIndexes.map((index) => ({ node: `${loadPrefix}${index}`, fz: -load }));
+
+  return {
+    schema_version: '2.0.0',
+    unit_system: 'SI',
+    nodes,
+    elements,
+    materials: [
+      { id: '1', name: 'steel', E: 205000, nu: 0.3, rho: 7850, fy: 345 },
+    ],
+    sections: [
+      { id: '1', name: 'TRUSS_ROD', type: 'rod', properties: { A: 0.01 } },
+    ],
+    load_cases: [
+      { id: 'LC1', type: 'other', loads: nodalLoads },
+    ],
+    load_combinations: [{ id: 'ULS', factors: { LC1: 1.0 } }],
+    metadata: {
+      ...metadata,
+      trussTopology: topology,
+      loadChord,
+      panelCount,
+      panelCountDefaulted: state.bayCount === undefined,
+      heightDefaulted: state.heightM === undefined,
+      geometry: {
+        spanM: span,
+        heightM: height,
+        panelLengthM: panelLength,
+      },
+    },
+  };
+}
+
 export function buildModel(state: DraftState): Record<string, unknown> {
   const metadata = {
     source: 'markdown-skill-draft',
@@ -334,30 +468,7 @@ export function buildModel(state: DraftState): Record<string, unknown> {
     return buildFrame2dModel(state, metadata);
   }
   if (state.inferredType === 'truss') {
-    const length = state.lengthM!;
-    const load = state.loadKN!;
-    return {
-      schema_version: '2.0.0',
-      unit_system: 'SI',
-      nodes: [
-        { id: '1', x: 0, y: 0, z: 0, restraints: [true, true, true, true, true, true] },
-        { id: '2', x: length, y: 0, z: 0, restraints: [false, true, true, true, true, true] },
-      ],
-      elements: [
-        { id: '1', type: 'truss', nodes: ['1', '2'], material: '1', section: '1' },
-      ],
-      materials: [
-        { id: '1', name: 'steel', E: 205000, nu: 0.3, rho: 7850 },
-      ],
-      sections: [
-        { id: '1', name: 'T1', type: 'rod', properties: { A: 0.01 } },
-      ],
-      load_cases: [
-        { id: 'LC1', type: 'other', loads: [{ node: '2', fx: load }] },
-      ],
-      load_combinations: [{ id: 'ULS', factors: { LC1: 1.0 } }],
-      metadata,
-    };
+    return buildTrussModel(state, metadata);
   }
   if (state.inferredType === 'double-span-beam') {
     const span = state.spanLengthM!;

--- a/backend/src/agent-runtime/model-builder.ts
+++ b/backend/src/agent-runtime/model-builder.ts
@@ -407,10 +407,13 @@ function buildTrussModel(state: DraftState, metadata: Record<string, unknown>): 
       section: '1',
     });
     if (i < panelCount) {
+      const diagonalNodes = i < panelCount / 2
+        ? [`B${i}`, `T${i + 1}`]
+        : [`B${i + 1}`, `T${i}`];
       elements.push({
         id: `WD${i}`,
         type: 'truss',
-        nodes: [`B${i + 1}`, `T${i}`],
+        nodes: diagonalNodes,
         material: '1',
         section: '1',
       });

--- a/backend/src/agent-skills/analysis/opensees-static/runtime.py
+++ b/backend/src/agent-skills/analysis/opensees-static/runtime.py
@@ -51,6 +51,19 @@ class OpenSeesStaticAnalyzer(StaticAnalyzer):
 
 def run_analysis(model: StructureModelV2, parameters: Dict[str, Any]) -> Dict[str, Any]:
     analyzer = OpenSeesStaticAnalyzer(model)
+    if analyzer._can_run_2d_truss_solver():
+        try:
+            batch_cases = parameters.get("batchCases", [])
+            if analyzer._requires_3d_truss_solver():
+                if batch_cases:
+                    return analyzer._run_batch_cases(parameters, analyzer._run_linear_3d_truss)
+                return analyzer._run_linear_3d_truss(parameters)
+            if batch_cases:
+                return analyzer._run_batch_cases(parameters, analyzer._run_linear_2d_truss)
+            return analyzer._run_linear_2d_truss(parameters)
+        except Exception as error:
+            raise RuntimeError(f"OpenSees static truss analysis failed: {error}") from error
+
     executor = OpenSeesStaticExecutor(analyzer)
     try:
         import openseespy.opensees as ops  # noqa: F401

--- a/backend/src/agent-skills/structure-type/truss/__tests__/handler.test.mjs
+++ b/backend/src/agent-skills/structure-type/truss/__tests__/handler.test.mjs
@@ -115,6 +115,25 @@ describe('truss handler', () => {
     expect(handler.buildModel(state)).toBeUndefined();
   });
 
+  test('keeps rule-derived truss guardrails when llm returns an empty skill state', () => {
+    const patch = handler.extractDraft({
+      message: 'Please analyze a Pratt truss with no web members. It spans 15m, has 2.5m height, 5 panels, and 10kN nodal loads.',
+      llmDraftPatch: {
+        inferredType: 'truss',
+        skillState: {},
+      },
+    });
+    const state = handler.mergeState(undefined, patch);
+
+    expect(state.skillState).toEqual(expect.objectContaining({
+      trussTopology: 'pratt',
+      trussTopologyConflict: true,
+      invalidDraftFields: expect.arrayContaining(['trussTopology']),
+    }));
+    expect(handler.computeMissing(state, 'execution').critical).toContain('trussTopology');
+    expect(handler.buildModel(state)).toBeUndefined();
+  });
+
   test('treats ambiguous ton or kN load wording as a load clarification', () => {
     const patch = handler.extractDraft({
       message: 'This 15m truss has 5 panels and nodal loads of either 10 tons or 10kN; I am not sure.',

--- a/backend/src/agent-skills/structure-type/truss/__tests__/handler.test.mjs
+++ b/backend/src/agent-skills/structure-type/truss/__tests__/handler.test.mjs
@@ -12,9 +12,9 @@ describe('truss handler', () => {
     expect(match?.mappedType).toBe('truss');
   });
 
-  test('fills length from chinese span wording when llm omits it', () => {
+  test('fills truss geometry from chinese span wording when llm omits it', () => {
     const patch = handler.extractDraft({
-      message: '三角桁架，跨度12m，高3m，节点荷载20kN，做静力分析',
+      message: '三角桁架，跨度12m，高3m，4个节间，节点荷载20kN，做静力分析',
       llmDraftPatch: {
         inferredType: 'truss',
         loadKN: 20,
@@ -22,6 +22,108 @@ describe('truss handler', () => {
     });
 
     expect(patch.lengthM).toBe(12);
+    expect(patch.heightM).toBe(3);
+    expect(patch.bayCount).toBe(4);
     expect(patch.loadKN).toBe(20);
+  });
+
+  test('extracts english truss height, panels, and top chord loading', () => {
+    const patch = handler.extractDraft({
+      message: 'A Pratt truss spans 15m, has 2.5m height and 5 panels, with 10kN loads at top chord nodes.',
+      llmDraftPatch: { inferredType: 'truss' },
+    });
+
+    expect(patch.lengthM).toBe(15);
+    expect(patch.heightM).toBe(2.5);
+    expect(patch.bayCount).toBe(5);
+    expect(patch.loadKN).toBe(10);
+    expect(patch.loadType).toBe('point');
+    expect(patch.loadPosition).toBe('top-nodes');
+    expect(patch.skillState).toEqual(expect.objectContaining({
+      trussTopology: 'pratt',
+      trussLoadChord: 'top',
+    }));
+  });
+
+  test('builds a panelized planar truss model instead of a single bar', () => {
+    const patch = handler.extractDraft({
+      message: 'Pratt桁架，跨度15m，高2.5m，5个节间，每个上弦节点竖向荷载10kN，请分析',
+      llmDraftPatch: { inferredType: 'truss' },
+    });
+    const state = handler.mergeState(undefined, patch);
+    const model = handler.buildModel(state);
+
+    expect(model.nodes).toHaveLength(12);
+    expect(model.elements).toHaveLength(21);
+    expect(model.nodes.find((node) => node.id === 'B5')).toEqual(expect.objectContaining({ x: 15, z: 0 }));
+    expect(model.nodes.find((node) => node.id === 'T0')).toEqual(expect.objectContaining({ z: 2.5 }));
+    expect(model.load_cases[0].loads).toHaveLength(4);
+    expect(model.load_cases[0].loads.reduce((sum, load) => sum + Math.abs(load.fz), 0)).toBe(40);
+  });
+
+  test('defaults missing truss height from span while preserving model match scale', () => {
+    const patch = handler.extractDraft({
+      message: 'A triangular roof truss spans 15m with 5 panels and 10kN vertical nodal loads. Run static analysis.',
+      llmDraftPatch: { inferredType: 'truss' },
+    });
+    const state = handler.mergeState(undefined, patch);
+    const model = handler.buildModel(state);
+    const zValues = model.nodes.map((node) => node.z);
+
+    expect(state.heightM).toBeUndefined();
+    expect(Math.max(...zValues)).toBe(2.5);
+    expect(model.metadata).toEqual(expect.objectContaining({ heightDefaulted: true }));
+  });
+
+  test('invalid truss height blocks model generation and asks for correction', () => {
+    const patch = handler.extractDraft({
+      message: '三角桁架跨度15m，高度0m，5个节间，节点荷载10kN，请分析',
+      llmDraftPatch: { inferredType: 'truss' },
+    });
+    const state = handler.mergeState(undefined, patch);
+    const missing = handler.computeMissing(state, 'execution');
+
+    expect(missing.critical).toContain('heightM');
+    expect(handler.buildModel(state)).toBeUndefined();
+  });
+
+  test('correcting an invalid truss height clears the previous blocking field', () => {
+    const invalidPatch = handler.extractDraft({
+      message: '三角桁架跨度15m，高度0m，5个节间，节点荷载10kN，请分析',
+      llmDraftPatch: { inferredType: 'truss' },
+    });
+    const invalidState = handler.mergeState(undefined, invalidPatch);
+    const correctedPatch = handler.extractDraft({
+      message: '高度改为2.5m',
+      llmDraftPatch: { inferredType: 'truss', heightM: 2.5 },
+    });
+    const correctedState = handler.mergeState(invalidState, correctedPatch);
+
+    expect(handler.computeMissing(correctedState, 'execution').critical).toEqual([]);
+    expect(handler.buildModel(correctedState)?.metadata).toEqual(expect.objectContaining({ heightDefaulted: false }));
+  });
+
+  test('asks for clarification when a truss topology conflicts with missing web members', () => {
+    const patch = handler.extractDraft({
+      message: 'Please analyze a Pratt truss with no web members. It spans 15m, has 2.5m height, 5 panels, and 10kN nodal loads.',
+      llmDraftPatch: { inferredType: 'truss' },
+    });
+    const state = handler.mergeState(undefined, patch);
+    const missing = handler.computeMissing(state, 'execution');
+
+    expect(missing.critical).toContain('trussTopology');
+    expect(handler.buildModel(state)).toBeUndefined();
+  });
+
+  test('treats ambiguous ton or kN load wording as a load clarification', () => {
+    const patch = handler.extractDraft({
+      message: 'This 15m truss has 5 panels and nodal loads of either 10 tons or 10kN; I am not sure.',
+      llmDraftPatch: { inferredType: 'truss' },
+    });
+    const state = handler.mergeState(undefined, patch);
+    const missing = handler.computeMissing(state, 'execution');
+
+    expect(missing.critical).toContain('loadKN');
+    expect(handler.buildModel(state)).toBeUndefined();
   });
 });

--- a/backend/src/agent-skills/structure-type/truss/handler.ts
+++ b/backend/src/agent-skills/structure-type/truss/handler.ts
@@ -22,17 +22,165 @@ import type {
   SkillReportNarrativeInput,
 } from '../../../agent-runtime/types.js';
 
-const GEOMETRY_KEYS = ['lengthM'] as const;
+const GEOMETRY_KEYS = ['lengthM', 'heightM', 'bayCount'] as const;
 const LOAD_BOUNDARY_KEYS = ['loadKN', 'loadType', 'loadPosition'] as const;
-const ALLOWED_KEYS = combineDomainKeys(GEOMETRY_KEYS, LOAD_BOUNDARY_KEYS);
+const TRUSS_SPECIFIC_KEYS = ['trussTopology'] as const;
+const ALLOWED_KEYS = [...combineDomainKeys(GEOMETRY_KEYS, LOAD_BOUNDARY_KEYS), ...TRUSS_SPECIFIC_KEYS];
 
-function extractPositiveNumber(pattern: RegExp, message: string): number | undefined {
+function extractNumber(pattern: RegExp, message: string): number | undefined {
   const match = pattern.exec(message);
   if (!match?.[1]) {
     return undefined;
   }
   const value = Number(match[1]);
-  return Number.isFinite(value) && value > 0 ? value : undefined;
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function extractPositiveNumber(pattern: RegExp, message: string): number | undefined {
+  const value = extractNumber(pattern, message);
+  return value !== undefined && value > 0 ? value : undefined;
+}
+
+function extractPositiveInteger(pattern: RegExp, message: string): number | undefined {
+  const value = extractPositiveNumber(pattern, message);
+  if (value === undefined) {
+    return undefined;
+  }
+  const rounded = Math.round(value);
+  return rounded > 0 ? rounded : undefined;
+}
+
+function mergeTrussSkillState(
+  current: Record<string, unknown> | undefined,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...(current ?? {}),
+    ...patch,
+  };
+}
+
+function appendInvalidField(patch: DraftExtraction, field: string): void {
+  const current = Array.isArray(patch.skillState?.invalidDraftFields)
+    ? patch.skillState.invalidDraftFields.filter((item): item is string => typeof item === 'string')
+    : [];
+  if (!current.includes(field)) {
+    current.push(field);
+  }
+  patch.skillState = mergeTrussSkillState(patch.skillState, { invalidDraftFields: current });
+}
+
+function getInvalidFields(state: DraftState | DraftExtraction | undefined): string[] {
+  const fields = state?.skillState?.invalidDraftFields;
+  if (!Array.isArray(fields)) {
+    return [];
+  }
+  return fields.filter((item): item is string => typeof item === 'string');
+}
+
+function validPatchFields(patch: DraftExtraction): string[] {
+  const fields: string[] = [];
+  for (const field of ['lengthM', 'heightM', 'bayCount', 'loadKN'] as const) {
+    if (typeof patch[field] === 'number' && Number.isFinite(patch[field]) && patch[field] > 0) {
+      fields.push(field);
+    }
+  }
+  if (patch.skillState?.trussTopology && !patch.skillState.trussTopologyConflict) {
+    fields.push('trussTopology');
+  }
+  return fields;
+}
+
+function reconcileInvalidFields(state: DraftState, patch: DraftExtraction): DraftState {
+  const clearedFields = new Set(validPatchFields(patch));
+  if (clearedFields.size === 0) {
+    return state;
+  }
+  const invalidDraftFields = getInvalidFields(state).filter((field) => !clearedFields.has(field));
+  return {
+    ...state,
+    skillState: {
+      ...(state.skillState ?? {}),
+      invalidDraftFields,
+    },
+  };
+}
+
+function detectTrussTopology(message: string): string | undefined {
+  const text = message.toLowerCase();
+  if (text.includes('pratt') || text.includes('普拉特')) {
+    return 'pratt';
+  }
+  if (text.includes('warren') || text.includes('沃伦')) {
+    return 'warren';
+  }
+  if (text.includes('trapezoid') || text.includes('trapezoidal') || text.includes('梯形')) {
+    return 'trapezoidal';
+  }
+  if (text.includes('triangular') || text.includes('triangle') || text.includes('三角')) {
+    return 'triangular';
+  }
+  if (text.includes('roof truss') || text.includes('屋架')) {
+    return 'roof';
+  }
+  return undefined;
+}
+
+function hasTopologyConflict(message: string): boolean {
+  const text = message.toLowerCase();
+  return /\bno\s+(?:web\s+)?members?\b/.test(text)
+    || /\bwithout\s+(?:web\s+)?members?\b/.test(text)
+    || message.includes('无腹杆')
+    || message.includes('没有腹杆');
+}
+
+function hasLoadUnitAmbiguity(message: string): boolean {
+  const text = message.toLowerCase();
+  const hasTon = /\btons?\b|吨/.test(text);
+  const hasKN = /\bk\s*n\b|千牛/.test(text);
+  return hasTon && hasKN && (text.includes('either') || text.includes('or') || text.includes('not sure') || message.includes('不确定') || message.includes('还是'));
+}
+
+function applyTrussSanity(patch: DraftExtraction): DraftExtraction {
+  const next: DraftExtraction = { ...patch };
+
+  if (next.lengthM !== undefined && next.lengthM <= 0) {
+    next.lengthM = undefined;
+    appendInvalidField(next, 'lengthM');
+  }
+  if (next.heightM !== undefined && next.heightM <= 0) {
+    next.heightM = undefined;
+    appendInvalidField(next, 'heightM');
+  }
+  if (next.bayCount !== undefined && next.bayCount < 2) {
+    next.bayCount = undefined;
+    appendInvalidField(next, 'bayCount');
+  }
+  if (next.loadKN !== undefined && next.loadKN <= 0) {
+    next.loadKN = undefined;
+    appendInvalidField(next, 'loadKN');
+  }
+
+  if (next.lengthM !== undefined && next.heightM !== undefined) {
+    const spanToHeight = next.lengthM / next.heightM;
+    if (spanToHeight < 2 || spanToHeight > 20) {
+      next.heightM = undefined;
+      appendInvalidField(next, 'heightM');
+    }
+  }
+  if (next.lengthM !== undefined && next.bayCount !== undefined) {
+    const panelLength = next.lengthM / next.bayCount;
+    if (next.bayCount > 30 || panelLength < 0.25) {
+      next.bayCount = undefined;
+      appendInvalidField(next, 'bayCount');
+    }
+  }
+  if (next.loadKN !== undefined && next.loadKN > 5000) {
+    next.loadKN = undefined;
+    appendInvalidField(next, 'loadKN');
+  }
+
+  return next;
 }
 
 function buildNaturalTrussPatch(message: string): DraftExtraction {
@@ -41,19 +189,63 @@ function buildNaturalTrussPatch(message: string): DraftExtraction {
 
   const lengthM =
     extractPositiveNumber(/跨度\s*([0-9]+(?:\.[0-9]+)?)\s*(?:m|米)/i, message)
-    ?? extractPositiveNumber(/\bspan\s*([0-9]+(?:\.[0-9]+)?)\s*m\b/i, text);
+    ?? extractPositiveNumber(/\bspans?\s*([0-9]+(?:\.[0-9]+)?)\s*m\b/i, text);
   if (lengthM !== undefined) {
     patch.lengthM = lengthM;
   }
 
-  const loadKN =
-    extractPositiveNumber(/(?:节点荷载|节点力|荷载)\s*([0-9]+(?:\.[0-9]+)?)\s*k?n/i, message)
-    ?? extractPositiveNumber(/\b(?:node load|load)\s*([0-9]+(?:\.[0-9]+)?)\s*k?n\b/i, text);
-  if (loadKN !== undefined) {
-    patch.loadKN = loadKN;
+  const rawHeightM =
+    extractNumber(/高(?:度)?\s*([0-9]+(?:\.[0-9]+)?)\s*(?:m|米)/i, message)
+    ?? extractNumber(/\bheight\s*(?:of\s*)?([0-9]+(?:\.[0-9]+)?)\s*m\b/i, text)
+    ?? extractNumber(/\b([0-9]+(?:\.[0-9]+)?)\s*m\s*(?:height|high|rise)\b/i, text);
+  if (rawHeightM !== undefined) {
+    if (rawHeightM > 0) {
+      patch.heightM = rawHeightM;
+    } else {
+      appendInvalidField(patch, 'heightM');
+    }
   }
 
-  return patch;
+  const bayCount =
+    extractPositiveInteger(/([0-9]+(?:\.[0-9]+)?)\s*(?:个)?(?:节间|节|格|跨)/i, message)
+    ?? extractPositiveInteger(/\b([0-9]+(?:\.[0-9]+)?)\s*panels?\b/i, text);
+  if (bayCount !== undefined) {
+    patch.bayCount = bayCount;
+  }
+
+  const loadKN =
+    extractPositiveNumber(/(?:节点荷载|节点力|荷载)\s*([0-9]+(?:\.[0-9]+)?)\s*k?n/i, message)
+    ?? extractPositiveNumber(/([0-9]+(?:\.[0-9]+)?)\s*k?n\s*(?:节点荷载|节点力|荷载)/i, message)
+    ?? extractPositiveNumber(/\b(?:node load|nodal load|load)\s*([0-9]+(?:\.[0-9]+)?)\s*k?n\b/i, text)
+    ?? extractPositiveNumber(/\b([0-9]+(?:\.[0-9]+)?)\s*k?n\s+(?:vertical\s+)?(?:node loads?|nodal loads?|loads?)\b/i, text)
+    ?? extractPositiveNumber(/\b([0-9]+(?:\.[0-9]+)?)\s*k?n\s*(?:node loads?|nodal loads?|loads?)\b/i, text);
+  if (loadKN !== undefined) {
+    patch.loadKN = loadKN;
+    patch.loadType = 'point';
+    patch.loadPosition = 'top-nodes';
+  }
+
+  const topology = detectTrussTopology(message);
+  if (topology) {
+    patch.skillState = mergeTrussSkillState(patch.skillState, { trussTopology: topology });
+  }
+  if (hasTopologyConflict(message)) {
+    appendInvalidField(patch, 'trussTopology');
+    patch.skillState = mergeTrussSkillState(patch.skillState, { trussTopologyConflict: true });
+  }
+  if (text.includes('bottom chord') || message.includes('下弦')) {
+    patch.loadPosition = 'free-joint';
+    patch.skillState = mergeTrussSkillState(patch.skillState, { trussLoadChord: 'bottom' });
+  } else if (text.includes('top chord') || message.includes('上弦')) {
+    patch.loadPosition = 'top-nodes';
+    patch.skillState = mergeTrussSkillState(patch.skillState, { trussLoadChord: 'top' });
+  }
+  if (hasLoadUnitAmbiguity(message)) {
+    patch.loadKN = undefined;
+    appendInvalidField(patch, 'loadKN');
+  }
+
+  return applyTrussSanity(patch);
 }
 
 function toTrussPatch(patch: DraftExtraction): DraftExtraction {
@@ -62,7 +254,11 @@ function toTrussPatch(patch: DraftExtraction): DraftExtraction {
     geometryKeys: GEOMETRY_KEYS,
     loadBoundaryKeys: LOAD_BOUNDARY_KEYS,
   });
-  return restrictLegacyDraftPatch(domainPatch, 'truss', [...ALLOWED_KEYS]);
+  const nextPatch = restrictLegacyDraftPatch(domainPatch, 'truss', [...ALLOWED_KEYS]);
+  if (patch.skillState) {
+    nextPatch.skillState = patch.skillState;
+  }
+  return applyTrussSanity(nextPatch);
 }
 
 function buildTrussDefaultReason(paramKey: string, locale: AppLocale): string {
@@ -131,6 +327,33 @@ function buildTrussQuestions(
         suggestedValue: 'point',
       };
     }
+    if (question.paramKey === 'heightM') {
+      return {
+        ...question,
+        label: locale === 'zh' ? '桁架高度' : 'Truss height',
+        question: locale === 'zh'
+          ? '请确认桁架高度；若前面给出的高度为 0 或与跨度比例明显异常，请重新给出合理高度。'
+          : 'Please confirm the truss height. If the previous height was zero or clearly inconsistent with the span, provide a realistic height.',
+      };
+    }
+    if (question.paramKey === 'bayCount') {
+      return {
+        ...question,
+        label: locale === 'zh' ? '桁架节间数' : 'Truss panel count',
+        question: locale === 'zh'
+          ? '请确认桁架节间数；节间数应至少为 2，且单个节间长度应保持合理。'
+          : 'Please confirm the truss panel count. It should be at least 2 and keep each panel length realistic.',
+      };
+    }
+    if (question.paramKey === 'trussTopology') {
+      return {
+        ...question,
+        label: locale === 'zh' ? '桁架腹杆体系' : 'Truss web system',
+        question: locale === 'zh'
+          ? '请确认桁架腹杆布置；桁架通常需要腹杆形成稳定三角体系，若无腹杆应改按其他结构体系处理。'
+          : 'Please confirm the truss web layout. A truss normally needs web members to form a stable triangulated system; if there are no web members, use a different structural system.',
+      };
+    }
     if (question.paramKey === 'loadPosition') {
       return {
         ...question,
@@ -162,7 +385,7 @@ function buildTrussReportNarrative(input: SkillReportNarrativeInput): string {
 export const handler: SkillHandler = {
   detectStructuralType({ message, locale }) {
     const text = message.toLowerCase();
-    if (text.includes('truss') || text.includes('桁架')) {
+    if (text.includes('truss') || text.includes('桁架') || text.includes('屋架')) {
       return buildStructuralTypeMatch('truss', 'truss', 'truss', 'supported', locale);
     }
     return null;
@@ -179,7 +402,8 @@ export const handler: SkillHandler = {
     );
   },
   mergeState(existing, patch) {
-    return mergeLegacyState(existing, toTrussPatch(patch), 'truss', 'truss');
+    const trussPatch = toTrussPatch(patch);
+    return reconcileInvalidFields(mergeLegacyState(existing, trussPatch, 'truss', 'truss'), trussPatch);
   },
   computeMissing(state, phase) {
     return computeLegacyMissing({ ...state, inferredType: 'truss' }, phase, [...ALLOWED_KEYS]);

--- a/backend/src/utils/python-worker-runner.ts
+++ b/backend/src/utils/python-worker-runner.ts
@@ -51,6 +51,9 @@ export class PythonWorkerRunner<TInput extends object> {
     }
     const lookup = process.platform === 'win32' ? 'where.exe' : 'which';
     const result = spawnSync(lookup, [command], { stdio: 'ignore', windowsHide: true });
+    if (result.error) {
+      return true;
+    }
     return result.status === 0;
   }
 

--- a/backend/src/utils/python-worker-runner.ts
+++ b/backend/src/utils/python-worker-runner.ts
@@ -1,10 +1,10 @@
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { access } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
-import { config } from '../config/index.js';
+import { config, runtimeBaseDir } from '../config/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -45,21 +45,47 @@ export class PythonWorkerRunner<TInput extends object> {
     }
   }
 
+  private isCommandAvailable(command: string): boolean {
+    if (path.isAbsolute(command)) {
+      return existsSync(command);
+    }
+    const lookup = process.platform === 'win32' ? 'where.exe' : 'which';
+    const result = spawnSync(lookup, [command], { stdio: 'ignore', windowsHide: true });
+    return result.status === 0;
+  }
+
   private async resolvePythonCommand(): Promise<{ executable: string; args: string[] }> {
     const configured = config.analysisPythonBin?.trim();
     if (configured) {
       if (configured === 'python3' || configured === 'python') {
-        return { executable: configured, args: [] };
+        if (this.isCommandAvailable(configured)) {
+          return { executable: configured, args: [] };
+        }
       }
       if (configured === 'py' || configured === 'py.exe') {
-        return { executable: configured, args: ['-3'] };
+        if (this.isCommandAvailable(configured)) {
+          return { executable: configured, args: ['-3'] };
+        }
       }
       if (await this.isAccessibleExecutable(configured)) {
         return { executable: configured, args: [] };
       }
     }
 
+    const backendVenv = process.platform === 'win32'
+      ? path.resolve(__dirname, '../../.venv/Scripts/python.exe')
+      : path.resolve(__dirname, '../../.venv/bin/python');
+    const cwdBackendVenv = process.platform === 'win32'
+      ? path.resolve(process.cwd(), 'backend/.venv/Scripts/python.exe')
+      : path.resolve(process.cwd(), 'backend/.venv/bin/python');
+    const dataDirVenv = process.platform === 'win32'
+      ? path.join(runtimeBaseDir, '.venv', 'Scripts', 'python.exe')
+      : path.join(runtimeBaseDir, '.venv', 'bin', 'python');
+
     const candidates: Array<{ executable: string; args: string[] }> = [
+      { executable: backendVenv, args: [] },
+      { executable: cwdBackendVenv, args: [] },
+      { executable: dataDirVenv, args: [] },
       ...(process.platform === 'win32'
         ? [
             { executable: 'py', args: ['-3'] },
@@ -74,20 +100,14 @@ export class PythonWorkerRunner<TInput extends object> {
     ];
 
     for (const candidate of candidates) {
-      if (!path.isAbsolute(candidate.executable)) {
-        if (process.platform === 'win32' && candidate.executable === 'python') {
-          continue;
-        }
-        return candidate;
-      }
-      if (await this.isAccessibleExecutable(candidate.executable)) {
+      if (this.isCommandAvailable(candidate.executable)) {
         return candidate;
       }
     }
 
-    return process.platform === 'win32'
-      ? { executable: 'py', args: ['-3'] }
-      : { executable: 'python3', args: [] };
+    throw new Error(
+      'No Python executable found for StructureClaw analysis. Configure analysis.pythonBin or install the backend/.venv runtime.',
+    );
   }
 
   async invoke<T = unknown>(input: TInput, requestOptions?: { signal?: AbortSignal }): Promise<T> {

--- a/backend/tests/fallback.test.mjs
+++ b/backend/tests/fallback.test.mjs
@@ -497,6 +497,24 @@ describe('mergeDraftState', () => {
     expect(result.inferredType).toBe('truss');
   });
 
+  it('should merge invalid draft fields from existing and patch skill state', () => {
+    const existing = {
+      inferredType: 'truss',
+      skillState: { invalidDraftFields: ['heightM'], trussTopology: 'pratt' },
+      updatedAt: Date.now(),
+    };
+    const patch = {
+      skillState: { invalidDraftFields: ['bayCount'], trussLoadChord: 'top' },
+    };
+    const result = mergeDraftState(existing, patch);
+
+    expect(result.skillState).toEqual({
+      invalidDraftFields: ['heightM', 'bayCount'],
+      trussTopology: 'pratt',
+      trussLoadChord: 'top',
+    });
+  });
+
   it('should treat "unknown" inferredType in patch as absent', () => {
     const existing = {
       inferredType: 'beam',

--- a/backend/tests/model-builder.test.mjs
+++ b/backend/tests/model-builder.test.mjs
@@ -237,6 +237,10 @@ describe('buildModel - truss', () => {
     expect(model.elements[0]).toEqual({
       id: 'BC0', type: 'truss', nodes: ['B0', 'B1'], material: '1', section: '1',
     });
+    expect(model.elements.find((element) => element.id === 'WD0').nodes).toEqual(['B0', 'T1']);
+    expect(model.elements.find((element) => element.id === 'WD1').nodes).toEqual(['B1', 'T2']);
+    expect(model.elements.find((element) => element.id === 'WD2').nodes).toEqual(['B3', 'T2']);
+    expect(model.elements.find((element) => element.id === 'WD3').nodes).toEqual(['B4', 'T3']);
 
     expect(model.materials[0].name).toBe('steel');
     expect(model.sections[0].type).toBe('rod');

--- a/backend/tests/model-builder.test.mjs
+++ b/backend/tests/model-builder.test.mjs
@@ -208,11 +208,13 @@ describe('buildModel - beam', () => {
 // 2. Truss
 // ---------------------------------------------------------------------------
 describe('buildModel - truss', () => {
-  it('should build a two-node truss model with axial load', () => {
+  it('should build a panelized planar truss model with nodal vertical loads', () => {
     const state = makeState({
       inferredType: 'truss',
       lengthM: 12,
-      loadKN: 50,
+      heightM: 2,
+      bayCount: 4,
+      loadKN: 10,
     });
 
     const model = buildModel(state);
@@ -220,25 +222,30 @@ describe('buildModel - truss', () => {
     expect(model.schema_version).toBe('2.0.0');
     expect(model.metadata.inferredType).toBe('truss');
 
-    expect(model.nodes).toHaveLength(2);
+    expect(model.nodes).toHaveLength(10);
     expect(model.nodes[0]).toEqual({
-      id: '1', x: 0, y: 0, z: 0,
+      id: 'B0', x: 0, y: 0, z: 0,
       restraints: [true, true, true, true, true, true],
     });
-    expect(model.nodes[1]).toEqual({
-      id: '2', x: 12, y: 0, z: 0,
+    expect(model.nodes[4]).toEqual({
+      id: 'B4', x: 12, y: 0, z: 0,
       restraints: [false, true, true, true, true, true],
     });
+    expect(model.nodes[5]).toEqual({ id: 'T0', x: 0, y: 0, z: 2 });
 
-    expect(model.elements).toHaveLength(1);
+    expect(model.elements).toHaveLength(17);
     expect(model.elements[0]).toEqual({
-      id: '1', type: 'truss', nodes: ['1', '2'], material: '1', section: '1',
+      id: 'BC0', type: 'truss', nodes: ['B0', 'B1'], material: '1', section: '1',
     });
 
     expect(model.materials[0].name).toBe('steel');
     expect(model.sections[0].type).toBe('rod');
 
-    expect(model.load_cases[0].loads).toEqual([{ node: '2', fx: 50 }]);
+    expect(model.load_cases[0].loads).toEqual([
+      { node: 'T1', fz: -10 },
+      { node: 'T2', fz: -10 },
+      { node: 'T3', fz: -10 },
+    ]);
     expect(model.load_combinations).toEqual([{ id: 'ULS', factors: { LC1: 1.0 } }]);
   });
 });

--- a/backend/tests/python-worker-runner.abort.test.mjs
+++ b/backend/tests/python-worker-runner.abort.test.mjs
@@ -2,9 +2,11 @@ import { EventEmitter } from 'node:events';
 import { describe, expect, jest, test } from '@jest/globals';
 
 let spawnMock = jest.fn();
+let spawnSyncMock = jest.fn(() => ({ status: 0 }));
 
 jest.unstable_mockModule('node:child_process', () => ({
   spawn: (...args) => spawnMock(...args),
+  spawnSync: (...args) => spawnSyncMock(...args),
 }));
 
 const { PythonWorkerRunner } = await import('../dist/utils/python-worker-runner.js');

--- a/backend/tests/python-worker-runner.abort.test.mjs
+++ b/backend/tests/python-worker-runner.abort.test.mjs
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { describe, expect, jest, test } from '@jest/globals';
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
 let spawnMock = jest.fn();
 let spawnSyncMock = jest.fn(() => ({ status: 0 }));
@@ -12,6 +12,19 @@ jest.unstable_mockModule('node:child_process', () => ({
 const { PythonWorkerRunner } = await import('../dist/utils/python-worker-runner.js');
 
 describe('PythonWorkerRunner abort handling', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValue({ status: 0 });
+  });
+
+  test('does not reject a PATH command when lookup utility execution fails', () => {
+    spawnSyncMock.mockReturnValue({ error: new Error('lookup unavailable') });
+    const runner = new PythonWorkerRunner('/tmp/fake-worker.py');
+
+    expect(runner.isCommandAvailable('python3')).toBe(true);
+  });
+
   test('kills the worker process when AbortSignal is aborted', async () => {
     const stdout = new EventEmitter();
     stdout.setEncoding = jest.fn();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

* Problem: Truss requests could build a two-node single-bar model or fail during analysis instead of producing a usable panelized truss workflow.
* Why it matters: The truss skill should support standard executable benchmark scenarios through routing, model construction, analysis, and report generation.
* What changed: Added truss parameter guardrails, panelized 2D truss model generation, pure-truss solver dispatch, Python runtime resolution fallback, and regression coverage.
* What did NOT change (scope boundary): This does not redesign the skill architecture, rewrite benchmark ground-truth fixtures, or introduce a full topology-specific Pratt/Warren modeling engine.

## Change Type (select all)

* Bug fix
* Refactor required for the fix

## Scope (select all touched areas)

* Gateway / orchestration
* Skills / tool execution
* CI/CD / infra

## Linked Issue/PR

* Closes #
* Related #
* This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

* Root cause: The deterministic truss model builder still used a legacy two-node axial bar template, while pure truss analysis could be routed through the OpenSees frame execution path.
* Missing detection / guardrail: Existing tests did not require panelized truss geometry, realistic nodal loads, or a complete truss build/analyze workflow.
* Prior context (`git blame`, prior PR, issue, or refactor if known): Existing legacy structural model builder behavior for truss was too minimal for current benchmark scenarios.
* Why this regressed now: Newer benchmark scenarios exercise full truss workflows and exposed the old placeholder truss model path.
* If unknown, what was ruled out: LLM routing alone was not the only failure; direct runtime checks showed model construction and analysis dispatch also needed fixes.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

* Coverage level that should have caught this:
  * Unit test
  * Seam / integration test
  * End-to-end test
* Target test or file:
  * `backend/src/agent-skills/structure-type/truss/__tests__/handler.test.mjs`
  * `backend/tests/model-builder.test.mjs`
  * single-scenario LLM benchmark runs for truss standard and robust workflows
* Scenario the test should lock in: A Pratt/Warren-style truss request produces a multi-node/multi-element truss model and completes static analysis; unsafe or contradictory truss inputs ask for clarification.
* Why this is the smallest reliable guardrail: Unit tests lock deterministic model/handler behavior, while one benchmark scenario confirms the agent uses the tools in the expected order.
* Existing test that already covers this (if any): Existing backend model-builder tests covered only the old placeholder truss behavior and were updated.
* If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Truss analysis requests now build a panelized planar truss model with node loads and can complete static analysis. Invalid truss inputs such as zero height, extreme panel geometry, topology conflicts, or ambiguous load units are handled as clarification cases instead of blindly producing a model.

## Diagram (if applicable)

    Before:
    truss request -> two-node axial bar / frame-path analysis failure

    After:
    truss request -> truss skill draft -> panelized truss model -> truss solver -> report

## Security Impact (required)

* New permissions/capabilities? (`Yes/No`): No
* Secrets/tokens handling changed? (`Yes/No`): No
* New/changed network calls? (`Yes/No`): No
* Command/tool execution surface changed? (`Yes/No`): Yes
* Data access scope changed? (`Yes/No`): No
* If any `Yes`, explain risk + mitigation: Python analysis command resolution now checks configured/runtime Python candidates before falling back to PATH commands. It does not execute user-provided commands; it only selects an accessible Python executable from existing configured or known runtime locations.

## Repro + Verification

### Environment

* OS: Windows
* Runtime/container: local Node.js backend test runner and Python analysis runtime
* Model/provider: `glm-5-turbo` for benchmark SUT, `DeepSeek-V4-Pro` judge
* Integration/channel (if any): LLM benchmark runner
* Relevant config (redacted): API keys loaded from environment variables

### Steps

1. Run backend tests.
2. Run the standard Pratt truss benchmark scenario.
3. Run an interactive robustness truss topology-conflict scenario.
4. Run the Warren truss benchmark scenario.

### Expected

* Backend tests pass.
* Standard truss workflows produce computable truss models and analysis results.
* Robust conflicting truss input asks for clarification and does not analyze.

### Actual

* Backend tests passed.
* `truss-pratt-static` passed with 12 nodes, 21 elements, and analysis present.
* `robust-truss-conflicting-topology` passed with clarification, no bad model, and no analysis run.
* `truss-warren-en` passed with 14 nodes, 25 elements, and analysis present.

## Evidence

Attach at least one:

* Passing backend test command: `npm test --prefix backend -- --runInBand` -> 92 suites passed, 998 tests passed.
* Passing benchmark command: `npm run experiment -- --suite standard --scenario truss-pratt-static` -> 1/1 passed.
* Passing benchmark command: `npm run experiment -- --suite interactive --scenario robust-truss-conflicting-topology` -> 1/1 passed.
* Passing benchmark command: `npm run experiment -- --suite standard --scenario truss-warren-en` -> 1/1 passed.

## Human Verification (required)

What you personally verified (not just CI), and how:

* Verified scenarios: backend full Jest suite, Pratt truss standard benchmark, Warren truss standard benchmark, and truss topology-conflict robust benchmark.
* Edge cases checked: zero/invalid height, unrealistic geometry, ambiguous load units, missing/corrected invalid fields, pure truss solver dispatch, and Windows Python command resolution.
* What you did not verify: Full multimodal benchmark suite and a complete topology-specific Pratt/Warren engineering model comparison.

## Review Conversations

* I replied to or resolved every bot review conversation I addressed in this PR.
* I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

* Backward compatible? (`Yes/No`): Yes
* Config/env changes? (`Yes/No`): No
* Migration needed? (`Yes/No`): No
* If yes, exact upgrade steps: N/A

## Risks and Mitigations

* Risk: The current truss model remains a pragmatic generic panelized template rather than a fully topology-specific Pratt/Warren design generator.
  * Mitigation: The PR scopes this as a functional workflow fix, records topology metadata, and leaves full topology strategy work out of scope for a later dedicated change.
* Risk: Python command resolution changes can affect machines with unusual Python setup.
  * Mitigation: Resolution first honors configured `analysis.pythonBin`, then known project/runtime venvs, then verified PATH commands; backend tests and benchmark analysis were run locally.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model construction, draft validation, and analysis dispatch on a user-facing path; mitigated by expanded unit/integration tests and benchmark scenarios.
> 
> **Overview**
> Replaces the legacy **two-node axial bar** truss template with a **panelized planar truss** (top/bottom chords, verticals/diagonals, vertical nodal loads on top or bottom chord) and wires **OpenSees static** to the dedicated **2D/3D truss solver** when the model is pure truss.
> 
> The **truss skill** now extracts span, height, panel count, topology hints, and chord loading from natural language; applies **sanity checks** and tracks **`invalidDraftFields`** so bad geometry, topology conflicts (e.g. no webs), or ambiguous load units block **`build_model`** and drive **clarification** instead of silent bad models. Draft merge/normalization carries **`skillState`** through the runtime.
> 
> **`build_model`** tool responses now set **`nextAction: run_analysis`** so the agent is steered to analyze after a successful build. **Python worker** resolution prefers configured/`backend/.venv` interpreters and fails clearly when none exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6379bad62869698a8ce636125ddc05231fb9bc3b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
