### PR TITLE
fix(backend): normalize frame and generic model loads

### DIFF
--- a/backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs
@@ -8,14 +8,37 @@ const unknownFallbackMatch = {
 };
 
 describe("draft extraction preservation", () => {
-  test("prefers explicit tool messages over the raw last user message", async () => {
+  test("prefers the graph user message over generated tool arguments", async () => {
     const { resolveToolInputMessage } = await import("../../../dist/agent-langgraph/tools.js");
 
     expect(resolveToolInputMessage(
-      "荷载信息：楼面恒载4.5kN/m²，楼面活载2.0kN/m²",
-      "你说？",
-    )).toBe("荷载信息：楼面恒载4.5kN/m²，楼面活载2.0kN/m²");
-    expect(resolveToolInputMessage("", "继续")).toBe("继续");
+      "请分析这个混凝土框架",
+      "请分析这个钢框架",
+    )).toBe("请分析这个钢框架");
+    expect(resolveToolInputMessage(
+      "请分析这个混凝土框架",
+      "",
+      [{ role: "user", content: "请分析这个钢框架" }],
+    )).toBe("请分析这个钢框架");
+    expect(resolveToolInputMessage("直接工具调用消息", "")).toBe("直接工具调用消息");
+  });
+
+  test("strips benchmark retry feedback before structural extraction", async () => {
+    const { resolveRetryTaskMessage } = await import("../../../dist/agent-langgraph/tools.js");
+
+    expect(resolveRetryTaskMessage([
+      "上次尝试失败：structural_type 检查失败：期望 frame，实际得到 concrete-frame。",
+      "",
+      "2层单跨钢框架，层高3.6m，跨度6m，楼面荷载10kN/m，请进行静力分析。",
+    ].join("\n"))).toBe("2层单跨钢框架，层高3.6m，跨度6m，楼面荷载10kN/m，请进行静力分析。");
+
+    expect(resolveRetryTaskMessage([
+      "Previous attempt failed: structural_type check failed: expected frame, got concrete-frame.",
+      "",
+      "Analyze a two-story single-bay steel frame.",
+    ].join("\n"))).toBe("Analyze a two-story single-bay steel frame.");
+
+    expect(resolveRetryTaskMessage("请把这个结构改成混凝土框架")).toBe("请把这个结构改成混凝土框架");
   });
 
   test("detects when an unknown fallback should preserve an existing draft", async () => {

--- a/backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs
@@ -76,6 +76,23 @@ describe("draft extraction preservation", () => {
       conflictingMatch,
       "请把这个结构改成混凝土框架",
     )).toBe(false);
+
+    expect(shouldPreserveExistingDraftState(
+      {
+        inferredType: "beam",
+        skillId: "beam",
+        structuralTypeKey: "beam",
+        lengthM: 6,
+        updatedAt: 0,
+      },
+      {
+        key: "frame",
+        mappedType: "frame",
+        skillId: "frame",
+        supportLevel: "supported",
+      },
+      "上次尝试失败：模型类型应为 frame，请重新提取",
+    )).toBe(false);
   });
 
   test("preserves the previous stable draft but stays conservative without a plugin", async () => {

--- a/backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs
@@ -49,6 +49,35 @@ describe("draft extraction preservation", () => {
     })).toBe(false);
   });
 
+  test("preserves a stable draft when benchmark retry feedback contains a conflicting frame type", async () => {
+    const { shouldPreserveExistingDraftState } = await import("../../../dist/agent-langgraph/tools.js");
+    const existingState = {
+      inferredType: "frame",
+      skillId: "frame",
+      structuralTypeKey: "frame",
+      storyCount: 2,
+      updatedAt: 0,
+    };
+    const conflictingMatch = {
+      key: "concrete-frame",
+      mappedType: "frame",
+      skillId: "concrete-frame",
+      supportLevel: "supported",
+    };
+
+    expect(shouldPreserveExistingDraftState(
+      existingState,
+      conflictingMatch,
+      "上次尝试失败：structural_type 检查失败：期望 frame，实际得到 steel-frame",
+    )).toBe(true);
+
+    expect(shouldPreserveExistingDraftState(
+      existingState,
+      conflictingMatch,
+      "请把这个结构改成混凝土框架",
+    )).toBe(false);
+  });
+
   test("preserves the previous stable draft but stays conservative without a plugin", async () => {
     const { buildPreservedDraftExtractionResult } = await import("../../../dist/agent-langgraph/tools.js");
     const before = Date.now();

--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -39,12 +39,65 @@ function getToolCallId(config: LangGraphRunnableConfig): string {
   return id;
 }
 
-export function resolveToolInputMessage(inputMessage: string | undefined, lastUserMessage: string | undefined): string {
-  const explicitMessage = inputMessage?.trim();
-  if (explicitMessage) {
-    return explicitMessage;
+function messageRole(message: unknown): string | null {
+  if (!message || typeof message !== 'object') return null;
+  const record = message as Record<string, unknown>;
+  const getType = record._getType;
+  if (typeof getType === 'function') {
+    return String(getType.call(message));
   }
-  return lastUserMessage || '';
+  if (typeof record.role === 'string') return record.role;
+  if (typeof record.type === 'string') return record.type;
+  if (Array.isArray(record.id) && record.id.some((part) => String(part).includes('HumanMessage'))) {
+    return 'human';
+  }
+  return null;
+}
+
+function messageText(message: unknown): string {
+  if (!message || typeof message !== 'object') return '';
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((item) => {
+        if (typeof item === 'string') return item;
+        if (item && typeof item === 'object' && 'text' in item) {
+          return String((item as { text?: unknown }).text ?? '');
+        }
+        return '';
+      })
+      .join('');
+  }
+  return content == null ? '' : String(content);
+}
+
+function latestHumanMessageText(messages: unknown[] | undefined): string {
+  if (!Array.isArray(messages)) return '';
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const role = messageRole(messages[i]);
+    if (role === 'human' || role === 'user') {
+      return messageText(messages[i]).trim();
+    }
+  }
+  return '';
+}
+
+export function resolveToolInputMessage(
+  inputMessage: string | undefined,
+  lastUserMessage: string | undefined,
+  messages?: unknown[],
+): string {
+  const canonicalUserMessage = lastUserMessage?.trim();
+  if (canonicalUserMessage) {
+    return canonicalUserMessage;
+  }
+  const latestHumanMessage = latestHumanMessageText(messages);
+  if (latestHumanMessage) {
+    return latestHumanMessage;
+  }
+  const explicitMessage = inputMessage?.trim();
+  return explicitMessage || '';
 }
 
 const ANALYSIS_SKILL_ENGINE_IDS: Record<string, string> = {
@@ -195,6 +248,19 @@ function isRetryFeedbackMessage(message: string | undefined): boolean {
   const text = message?.trim();
   if (!text) return false;
   return /^上次尝试失败[:：]/.test(text) || /^Previous attempt failed[:：]/i.test(text);
+}
+
+export function resolveRetryTaskMessage(message: string | undefined): string {
+  const text = message?.trim();
+  if (!text || !isRetryFeedbackMessage(text)) {
+    return text || '';
+  }
+  const split = text.split(/\r?\n\s*\r?\n/);
+  if (split.length < 2) {
+    return text;
+  }
+  const taskMessage = split.slice(1).join('\n\n').trim();
+  return taskMessage || text;
 }
 
 function isConflictingStructuralType(
@@ -608,10 +674,11 @@ export function createDetectStructureTypeTool(skillRuntime: AgentSkillRuntime) {
       const toolCallId = getToolCallId(config);
       const skillIds = configurable.skillScope;
       const locale = (input.locale === 'en' ? 'en' : (state?.locale || 'zh')) as 'zh' | 'en';
-      const message = resolveToolInputMessage(input.message, state?.lastUserMessage);
+      const message = resolveToolInputMessage(input.message, state?.lastUserMessage, state?.messages);
+      const detectionMessage = resolveRetryTaskMessage(message);
       try {
         const match = await skillRuntime.detectStructuralType(
-          message,
+          detectionMessage,
           locale,
           undefined,
           skillIds,
@@ -660,16 +727,29 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
       const existingState = state?.draftState || undefined;
       const skillIds = configurable.skillScope;
       const locale = (input.locale === 'en' ? 'en' : (state?.locale || 'zh')) as 'zh' | 'en';
-      const message = resolveToolInputMessage(input.message, state?.lastUserMessage);
+      const message = resolveToolInputMessage(input.message, state?.lastUserMessage, state?.messages);
+      const extractionMessage = resolveRetryTaskMessage(message);
 
       try {
         // Step 1: Detect structural type
-        const match = await skillRuntime.detectStructuralType(
-          message, locale, existingState, skillIds,
+        log.debug({
+          hasLastUserMessage: !!state?.lastUserMessage,
+          messageCount: Array.isArray(state?.messages) ? state.messages.length : 0,
+          inputMessagePreview: input.message?.slice(0, 120),
+          resolvedMessagePreview: message.slice(0, 120),
+          extractionMessagePreview: extractionMessage.slice(0, 120),
+        }, 'extract_draft_params resolved message');
+        let match = await skillRuntime.detectStructuralType(
+          extractionMessage, locale, existingState, skillIds,
         );
-        const matchedPlugin = match.skillId
+        let matchedPlugin = match.skillId
           ? await skillRuntime.resolvePluginForType(match.skillId, skillIds)
           : null;
+        log.debug({
+          detectedKey: match.key,
+          detectedSkillId: match.skillId,
+          matchedPluginId: matchedPlugin?.id,
+        }, 'extract_draft_params structural match');
 
         if (shouldPreserveExistingDraftState(existingState, match, message)) {
           const preservationPlugin = await resolveExistingDraftPlugin(
@@ -765,11 +845,17 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
 
         // Step 3: Sub-agent extracts parameters (skill manifest driven)
         const { invokeParamExtractor } = await import('./param-extractor.js');
-        const draftPatch = await invokeParamExtractor({ message, existingState, locale, plugin });
+        const draftPatch = await invokeParamExtractor({
+          message: extractionMessage,
+          existingState,
+          locale,
+          plugin,
+          traceLogger: log,
+        });
 
         // Step 4: Handler pipeline (extractDraft → mergeState → computeMissing)
         const patch = plugin.handler.extractDraft({
-          message,
+          message: extractionMessage,
           locale,
           currentState: existingState,
           llmDraftPatch: draftPatch,

--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -180,10 +180,31 @@ function hasStableDraftType(state: DraftState | null | undefined): state is Draf
 export function shouldPreserveExistingDraftState(
   existingState: DraftState | null | undefined,
   structuralTypeMatch: StructuralTypeMatch,
+  message?: string,
 ): existingState is DraftState {
-  return hasStableDraftType(existingState)
-    && structuralTypeMatch.key === 'unknown'
-    && structuralTypeMatch.mappedType === 'unknown';
+  if (!hasStableDraftType(existingState)) {
+    return false;
+  }
+  if (structuralTypeMatch.key === 'unknown' && structuralTypeMatch.mappedType === 'unknown') {
+    return true;
+  }
+  return isRetryFeedbackMessage(message) && isConflictingStructuralType(existingState, structuralTypeMatch);
+}
+
+function isRetryFeedbackMessage(message: string | undefined): boolean {
+  const text = message?.trim();
+  if (!text) return false;
+  return /^上次尝试失败[:：]/.test(text) || /^Previous attempt failed[:：]/i.test(text);
+}
+
+function isConflictingStructuralType(
+  existingState: DraftState,
+  structuralTypeMatch: StructuralTypeMatch,
+): boolean {
+  const existingKey = existingState.structuralTypeKey ?? existingState.inferredType;
+  const nextKey = structuralTypeMatch.key;
+  if (!nextKey || nextKey === 'unknown') return false;
+  return nextKey !== existingKey;
 }
 
 function buildPreservedStructuralTypeMatch(
@@ -647,7 +668,7 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
           ? await skillRuntime.resolvePluginForType(match.skillId, skillIds)
           : null;
 
-        if (shouldPreserveExistingDraftState(existingState, match)) {
+        if (shouldPreserveExistingDraftState(existingState, match, message)) {
           const preservationPlugin = await resolveExistingDraftPlugin(
             skillRuntime,
             existingState,

--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -201,6 +201,9 @@ function isConflictingStructuralType(
   existingState: DraftState,
   structuralTypeMatch: StructuralTypeMatch,
 ): boolean {
+  if (structuralTypeMatch.mappedType !== existingState.inferredType) {
+    return false;
+  }
   const existingKey = existingState.structuralTypeKey ?? existingState.inferredType;
   const nextKey = structuralTypeMatch.key;
   if (!nextKey || nextKey === 'unknown') return false;

--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -739,10 +739,10 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
           resolvedMessagePreview: message.slice(0, 120),
           extractionMessagePreview: extractionMessage.slice(0, 120),
         }, 'extract_draft_params resolved message');
-        let match = await skillRuntime.detectStructuralType(
+        const match = await skillRuntime.detectStructuralType(
           extractionMessage, locale, existingState, skillIds,
         );
-        let matchedPlugin = match.skillId
+        const matchedPlugin = match.skillId
           ? await skillRuntime.resolvePluginForType(match.skillId, skillIds)
           : null;
         log.debug({

--- a/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
+++ b/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
@@ -11,6 +11,15 @@ import { buildElementReferenceVectors } from '../../../dist/agent-runtime/refere
 import { skillExecutionSchema } from '../../../dist/agent-runtime/schema.js';
 
 describe('agent runtime helper utilities', () => {
+  test('resolves structure type key aliases to the owning skill plugin', async () => {
+    const { AgentSkillRuntime } = await import('../../../dist/agent-runtime/index.js');
+    const runtime = new AgentSkillRuntime();
+
+    expect((await runtime.resolvePluginForType('frame'))?.id).toBe('frame');
+    expect((await runtime.resolvePluginForType('steel-frame'))?.id).toBe('frame');
+    expect((await runtime.resolvePluginForType('concrete-frame'))?.id).toBe('concrete-frame');
+  });
+
   test('dependency fingerprints are stable regardless of reference insertion order', () => {
     const left = computeDependencyFingerprint({
       analysis: { artifactId: 'analysis-1', revision: 3 },

--- a/backend/src/agent-runtime/registry.ts
+++ b/backend/src/agent-runtime/registry.ts
@@ -53,7 +53,10 @@ export class AgentSkillRegistry {
       return null;
     }
     const skills = await this.resolveEnabledPlugins(skillIds);
-    return skills.find((skill) => skill.id === identifier || skill.structureType === identifier) || null;
+    return skills.find((skill) => skill.id === identifier)
+      || skills.find((skill) => skill.manifest.structuralTypeKeys.includes(identifier as StructuralTypeKey))
+      || skills.find((skill) => skill.structureType === identifier)
+      || null;
   }
 
   async detectStructuralType(

--- a/backend/src/agent-skills/report-export/calculation-book/pkpm-calcbook/__tests__/test_runtime.py
+++ b/backend/src/agent-skills/report-export/calculation-book/pkpm-calcbook/__tests__/test_runtime.py
@@ -1,6 +1,8 @@
 """Tests for pkpm-calcbook runtime."""
 from __future__ import annotations
 
+import json
+import math
 import sys
 import types
 import re
@@ -16,6 +18,7 @@ _api = types.ModuleType("APIPyInterface")
 sys.modules.setdefault("APIPyInterface", _api)
 
 from runtime import (
+    _dump_worker_response,
     _extract_base_shear,
     _extract_beam_design,
     _extract_column_design,
@@ -115,6 +118,31 @@ class TestResolveJwsPath:
     def test_file_not_found(self):
         with pytest.raises(FileNotFoundError):
             _resolve_jws_path({}, {"jws_path": "/nonexistent/test.JWS"})
+
+
+class TestWorkerJson:
+    def test_replaces_non_finite_numbers_with_null(self):
+        text = _dump_worker_response({
+            "ok": True,
+            "data": {
+                "positive": math.inf,
+                "negative": -math.inf,
+                "nan": float("nan"),
+                "nested": [1.0, math.inf],
+            },
+        })
+
+        assert "Infinity" not in text
+        assert "NaN" not in text
+        assert json.loads(text) == {
+            "ok": True,
+            "data": {
+                "positive": None,
+                "negative": None,
+                "nan": None,
+                "nested": [1.0, None],
+            },
+        }
 
 
 class TestExtractModal:

--- a/backend/src/agent-skills/report-export/calculation-book/pkpm-calcbook/runtime.py
+++ b/backend/src/agent-skills/report-export/calculation-book/pkpm-calcbook/runtime.py
@@ -7,6 +7,8 @@ earthquake forces, displacements, member design, and code checks.
 """
 from __future__ import annotations
 
+import json
+import math
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -70,6 +72,20 @@ def _resolve_jws_path(model: Dict[str, Any], parameters: Dict[str, Any]) -> Path
     if not p.is_file():
         raise FileNotFoundError(f"JWS file not found: {jws}")
     return p
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {key: _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _dump_worker_response(payload: Dict[str, Any]) -> str:
+    return json.dumps(_json_safe(payload), ensure_ascii=False, allow_nan=False)
 
 
 # ── Main entry point ────────────────────────────────────────────────────
@@ -247,7 +263,6 @@ def run_analysis(model: Dict[str, Any], parameters: Dict[str, Any]) -> Dict[str,
 
 
 if __name__ == "__main__":
-    import json
     import sys
 
     CURRENT_DIR = Path(__file__).resolve().parent
@@ -259,7 +274,7 @@ if __name__ == "__main__":
 
     raw = sys.stdin.read().strip()
     if not raw:
-        print(json.dumps({"ok": False, "errorCode": "EMPTY_REQUEST", "message": "No input"}, ensure_ascii=False))
+        print(_dump_worker_response({"ok": False, "errorCode": "EMPTY_REQUEST", "message": "No input"}))
         raise SystemExit(1)
 
     try:
@@ -267,12 +282,12 @@ if __name__ == "__main__":
         model = payload.get("model", {})
         parameters = payload.get("parameters", {})
         result = run_analysis(model, parameters)
-        print(json.dumps({"ok": True, "data": result}, ensure_ascii=False))
+        print(_dump_worker_response({"ok": True, "data": result}))
     except Exception as exc:
-        print(json.dumps({
+        print(_dump_worker_response({
             "ok": False,
             "errorCode": "CALCBOOK_FAILED",
             "message": str(exc),
             "detail": {"type": type(exc).__name__},
-        }, ensure_ascii=False))
+        }))
         raise SystemExit(1)

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
@@ -341,6 +341,37 @@ describe('concrete-frame canonicalize core contract', () => {
     });
   });
 
+  test('normalizes duplicate concrete same-story floor loads without dropping signed gravity loads', () => {
+    const model = buildConcreteFrameModel({
+      inferredType: 'concrete-frame',
+      updatedAt: 0,
+      frameDimension: '2d',
+      storyCount: 1,
+      bayCount: 1,
+      storyHeightsM: [3.6],
+      bayWidthsM: [6],
+      floorLoads: [
+        { story: 1, verticalKN: -120 },
+        { story: 1, verticalKN: -120, liveLoadKN: 30 },
+      ],
+      frameBaseSupportType: 'fixed',
+      frameConcreteGrade: 'C30',
+      frameRebarGrade: 'HRB400',
+      frameColumnSection: '400X400',
+      frameBeamSection: '250X600',
+    });
+
+    expect(model).toBeDefined();
+    expect(model.floorLoads).toEqual([
+      { story: 1, verticalKN: -120, liveLoadKN: 30 },
+    ]);
+    expect(model.stories[0]).toMatchObject({ dead_load: 20, live_load: 5 });
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'D').loads).toHaveLength(2);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'D').loads.reduce((sum, load) => sum + load.fz, 0)).toBeCloseTo(-120);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'L').loads).toHaveLength(2);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'L').loads.reduce((sum, load) => sum + load.fz, 0)).toBeCloseTo(-30);
+  });
+
   test('builds a 3d concrete frame model with y-direction beams for YJK conversion', () => {
     const model = buildConcreteFrameModel({
       inferredType: 'concrete-frame',

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
@@ -331,6 +331,8 @@ describe('concrete-frame canonicalize core contract', () => {
       }),
     ]);
     expect(model.load_cases.map((loadCase) => loadCase.id)).toEqual(['D']);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'D').loads).toHaveLength(4);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'D').loads.reduce((sum, load) => sum + load.fz, 0)).toBeCloseTo(-200);
     expect(model.load_combinations[0]).toMatchObject({
       id: 'ULS',
       combination_type: 'uls',
@@ -374,6 +376,10 @@ describe('concrete-frame canonicalize core contract', () => {
       live_load: 2,
     });
     expect(model.load_cases.map((loadCase) => loadCase.id)).toEqual(['D', 'L', 'LAT']);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'D').loads).toHaveLength(12);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'D').loads.reduce((sum, load) => sum + load.fz, 0)).toBeCloseTo(-720);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'L').loads).toHaveLength(12);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'L').loads.reduce((sum, load) => sum + load.fz, 0)).toBeCloseTo(-240);
   });
 
   test('returns undefined when critical geometry is missing (H2 fix)', () => {

--- a/backend/src/agent-skills/structure-type/concrete-frame/model.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/model.ts
@@ -4,6 +4,7 @@ import {
 import { buildElementReferenceVectors } from '../../../agent-runtime/reference-vectors.js';
 import type {
   DraftAnalysisControl,
+  DraftFloorLoad,
   DraftSiteSeismicParams,
   DraftState,
   DraftWindParams,
@@ -506,7 +507,7 @@ function buildStoryGravityNodalLoads(
   totalLoadKN: number | undefined,
   loadKind: 'dead' | 'live',
 ): Array<Record<string, unknown>> {
-  if (typeof totalLoadKN !== 'number' || !Number.isFinite(totalLoadKN) || totalLoadKN <= 0 || nodeIds.length === 0) {
+  if (typeof totalLoadKN !== 'number' || !Number.isFinite(totalLoadKN) || totalLoadKN === 0 || nodeIds.length === 0) {
     return [];
   }
   const fzPerNode = -Math.abs(totalLoadKN) / nodeIds.length;
@@ -518,6 +519,22 @@ function buildStoryGravityNodalLoads(
     source: 'story_floor_loads',
     load_kind: loadKind,
   }));
+}
+
+function normalizeFloorLoadsByStory(floorLoads: DraftFloorLoad[]): DraftFloorLoad[] {
+  const merged = new Map<number, DraftFloorLoad>();
+  for (const load of floorLoads) {
+    if (typeof load.story !== 'number' || !Number.isFinite(load.story)) continue;
+    const current = merged.get(load.story);
+    merged.set(load.story, {
+      story: load.story,
+      verticalKN: load.verticalKN ?? current?.verticalKN,
+      liveLoadKN: load.liveLoadKN ?? current?.liveLoadKN,
+      lateralXKN: load.lateralXKN ?? current?.lateralXKN,
+      lateralYKN: load.lateralYKN ?? current?.lateralYKN,
+    });
+  }
+  return Array.from(merged.values()).sort((left, right) => left.story - right.story);
 }
 
 function buildConcreteLoadCaseBundle(
@@ -711,6 +728,7 @@ function buildConcreteFrame2dLocalModel(options: {
 }): ConcreteFrameModel {
   const xCoords = accumulateCoords(options.bayWidthsM);
   const zCoords = accumulateCoords(options.storyHeightsM);
+  const floorLoads = normalizeFloorLoadsByStory(options.floorLoads);
   const nodes: Array<Record<string, unknown>> = [];
   const elements: Array<Record<string, unknown>> = [];
   const deadLoads: Array<Record<string, unknown>> = [];
@@ -765,7 +783,7 @@ function buildConcreteFrame2dLocalModel(options: {
   }
 
   const levelNodeCount = xCoords.length;
-  for (const load of options.floorLoads) {
+  for (const load of floorLoads) {
     const storyIdx = load.story;
     if (storyIdx <= 0 || storyIdx >= zCoords.length) continue;
     const storyId = `F${storyIdx}`;
@@ -787,7 +805,7 @@ function buildConcreteFrame2dLocalModel(options: {
 
   const stories = options.storyHeightsM.map((height, index) => {
     const storyIdx = index + 1;
-    const fl = options.floorLoads.find((load) => load.story === storyIdx);
+    const fl = floorLoads.find((load) => load.story === storyIdx);
     const floorAreaM2 = Math.max(xCoords[xCoords.length - 1], 1);
     const deadLoad = fl?.verticalKN ? Math.abs(fl.verticalKN) / floorAreaM2 : undefined;
     const liveLoad = fl?.liveLoadKN ? Math.abs(fl.liveLoadKN) / floorAreaM2 : undefined;
@@ -832,7 +850,7 @@ function buildConcreteFrame2dLocalModel(options: {
     rebarProps: options.rebarProps,
     columnProps: options.columnProps,
     beamProps: options.beamProps,
-    floorLoads: options.floorLoads,
+    floorLoads,
     frameBaseSupportType: options.frameBaseSupportType,
   };
 }
@@ -861,6 +879,7 @@ function buildConcreteFrame3dLocalModel(options: {
   const xCoords = accumulateCoords(options.bayWidthsXM);
   const yCoords = accumulateCoords(options.bayWidthsYM);
   const zCoords = accumulateCoords(options.storyHeightsM);
+  const floorLoads = normalizeFloorLoadsByStory(options.floorLoads);
   const nodes: Array<Record<string, unknown>> = [];
   const elements: Array<Record<string, unknown>> = [];
   const deadLoads: Array<Record<string, unknown>> = [];
@@ -939,7 +958,7 @@ function buildConcreteFrame3dLocalModel(options: {
   }
 
   const levelNodeCount = xCoords.length * yCoords.length;
-  for (const load of options.floorLoads) {
+  for (const load of floorLoads) {
     const storyIdx = load.story;
     if (storyIdx <= 0 || storyIdx >= zCoords.length) continue;
     const storyId = `F${storyIdx}`;
@@ -966,7 +985,7 @@ function buildConcreteFrame3dLocalModel(options: {
   const elementReferenceVectors = buildElementReferenceVectors(elements, nodes);
   const stories = options.storyHeightsM.map((height, index) => {
     const storyIdx = index + 1;
-    const fl = options.floorLoads.find((load) => load.story === storyIdx);
+    const fl = floorLoads.find((load) => load.story === storyIdx);
     const floorAreaM2 = Math.max(xCoords[xCoords.length - 1], 1) * Math.max(yCoords[yCoords.length - 1], 1);
     const deadLoad = fl?.verticalKN ? Math.abs(fl.verticalKN) / floorAreaM2 : undefined;
     const liveLoad = fl?.liveLoadKN ? Math.abs(fl.liveLoadKN) / floorAreaM2 : undefined;
@@ -1019,7 +1038,7 @@ function buildConcreteFrame3dLocalModel(options: {
     rebarProps: options.rebarProps,
     columnProps: options.columnProps,
     beamProps: options.beamProps,
-    floorLoads: options.floorLoads,
+    floorLoads,
     frameBaseSupportType: options.frameBaseSupportType,
   };
 }

--- a/backend/src/agent-skills/structure-type/concrete-frame/model.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/model.ts
@@ -500,30 +500,39 @@ function buildStoryFloorLoadFields(deadLoad: number | undefined, liveLoad: numbe
   };
 }
 
-function storyHasFloorLoad(story: Record<string, unknown>, loadType: 'dead' | 'live'): boolean {
-  const field = loadType === 'dead' ? story.dead_load : story.live_load;
-  if (typeof field === 'number' && field > 0) return true;
-
-  const floorLoads = Array.isArray(story.floor_loads) ? story.floor_loads : [];
-  return floorLoads.some((entry) => {
-    if (!entry || typeof entry !== 'object') return false;
-    const record = entry as Record<string, unknown>;
-    return record.type === loadType && typeof record.value === 'number' && record.value > 0;
-  });
+function buildStoryGravityNodalLoads(
+  storyId: string,
+  nodeIds: string[],
+  totalLoadKN: number | undefined,
+  loadKind: 'dead' | 'live',
+): Array<Record<string, unknown>> {
+  if (typeof totalLoadKN !== 'number' || !Number.isFinite(totalLoadKN) || totalLoadKN <= 0 || nodeIds.length === 0) {
+    return [];
+  }
+  const fzPerNode = -Math.abs(totalLoadKN) / nodeIds.length;
+  return nodeIds.map((node) => ({
+    type: 'nodal',
+    node,
+    fz: fzPerNode,
+    story: storyId,
+    source: 'story_floor_loads',
+    load_kind: loadKind,
+  }));
 }
 
 function buildConcreteLoadCaseBundle(
-  stories: Array<Record<string, unknown>>,
+  deadLoads: Array<Record<string, unknown>>,
+  liveLoads: Array<Record<string, unknown>>,
   lateralLoads: Array<Record<string, unknown>>,
   options: { includeWind?: boolean; includeSeismic?: boolean; frameDimension?: '2d' | '3d' } = {},
 ): { load_cases: Array<Record<string, unknown>>; load_combinations: Array<Record<string, unknown>> } {
   const loadCases: Array<Record<string, unknown>> = [];
 
-  if (stories.some((story) => storyHasFloorLoad(story, 'dead'))) {
-    loadCases.push({ id: 'D', type: 'dead', loads: [], description: 'Dead floor loads from stories.floor_loads' });
+  if (deadLoads.length) {
+    loadCases.push({ id: 'D', type: 'dead', loads: deadLoads, description: 'Equivalent nodal dead loads from stories.floor_loads' });
   }
-  if (stories.some((story) => storyHasFloorLoad(story, 'live'))) {
-    loadCases.push({ id: 'L', type: 'live', loads: [], description: 'Live floor loads from stories.floor_loads' });
+  if (liveLoads.length) {
+    loadCases.push({ id: 'L', type: 'live', loads: liveLoads, description: 'Equivalent nodal live loads from stories.floor_loads' });
   }
   if (lateralLoads.length) {
     loadCases.push({ id: 'LAT', type: 'other', loads: lateralLoads, description: 'Lateral story loads' });
@@ -704,6 +713,8 @@ function buildConcreteFrame2dLocalModel(options: {
   const zCoords = accumulateCoords(options.storyHeightsM);
   const nodes: Array<Record<string, unknown>> = [];
   const elements: Array<Record<string, unknown>> = [];
+  const deadLoads: Array<Record<string, unknown>> = [];
+  const liveLoads: Array<Record<string, unknown>> = [];
   const lateralLoads: Array<Record<string, unknown>> = [];
   let elementId = 1;
 
@@ -757,11 +768,20 @@ function buildConcreteFrame2dLocalModel(options: {
   for (const load of options.floorLoads) {
     const storyIdx = load.story;
     if (storyIdx <= 0 || storyIdx >= zCoords.length) continue;
+    const storyId = `F${storyIdx}`;
+    const nodeIds = xCoords.map((_x, bayIdx) => n2dId(storyIdx, bayIdx));
+    deadLoads.push(...buildStoryGravityNodalLoads(storyId, nodeIds, load.verticalKN, 'dead'));
+    liveLoads.push(...buildStoryGravityNodalLoads(storyId, nodeIds, load.liveLoadKN, 'live'));
     const lPerNode = load.lateralXKN !== undefined ? load.lateralXKN / levelNodeCount : undefined;
     for (let bayIdx = 0; bayIdx < xCoords.length; bayIdx++) {
-      const nodeLoad: Record<string, unknown> = { node: n2dId(storyIdx, bayIdx) };
+      const nodeLoad: Record<string, unknown> = {
+        type: 'nodal',
+        node: n2dId(storyIdx, bayIdx),
+        story: storyId,
+        source: 'story_lateral_loads',
+      };
       if (lPerNode !== undefined) nodeLoad.fx = lPerNode;
-      if (Object.keys(nodeLoad).length > 1) lateralLoads.push(nodeLoad);
+      if (nodeLoad.fx !== undefined) lateralLoads.push(nodeLoad);
     }
   }
 
@@ -779,7 +799,7 @@ function buildConcreteFrame2dLocalModel(options: {
       ...buildStoryFloorLoadFields(deadLoad, liveLoad),
     };
   });
-  const loadCaseBundle = buildConcreteLoadCaseBundle(stories, lateralLoads, {
+  const loadCaseBundle = buildConcreteLoadCaseBundle(deadLoads, liveLoads, lateralLoads, {
     includeWind: options.wind !== undefined,
     includeSeismic: options.siteSeismic !== undefined,
     frameDimension: '2d',
@@ -843,6 +863,8 @@ function buildConcreteFrame3dLocalModel(options: {
   const zCoords = accumulateCoords(options.storyHeightsM);
   const nodes: Array<Record<string, unknown>> = [];
   const elements: Array<Record<string, unknown>> = [];
+  const deadLoads: Array<Record<string, unknown>> = [];
+  const liveLoads: Array<Record<string, unknown>> = [];
   const lateralLoads: Array<Record<string, unknown>> = [];
   let elementId = 1;
 
@@ -920,14 +942,23 @@ function buildConcreteFrame3dLocalModel(options: {
   for (const load of options.floorLoads) {
     const storyIdx = load.story;
     if (storyIdx <= 0 || storyIdx >= zCoords.length) continue;
+    const storyId = `F${storyIdx}`;
+    const nodeIds = xCoords.flatMap((_x, xIdx) => yCoords.map((_y, yIdx) => n3dId(storyIdx, xIdx, yIdx)));
+    deadLoads.push(...buildStoryGravityNodalLoads(storyId, nodeIds, load.verticalKN, 'dead'));
+    liveLoads.push(...buildStoryGravityNodalLoads(storyId, nodeIds, load.liveLoadKN, 'live'));
     const lxPerNode = load.lateralXKN !== undefined ? load.lateralXKN / levelNodeCount : undefined;
     const lyPerNode = load.lateralYKN !== undefined ? load.lateralYKN / levelNodeCount : undefined;
     for (let xIdx = 0; xIdx < xCoords.length; xIdx++) {
       for (let yIdx = 0; yIdx < yCoords.length; yIdx++) {
-        const nodeLoad: Record<string, unknown> = { node: n3dId(storyIdx, xIdx, yIdx) };
+        const nodeLoad: Record<string, unknown> = {
+          type: 'nodal',
+          node: n3dId(storyIdx, xIdx, yIdx),
+          story: storyId,
+          source: 'story_lateral_loads',
+        };
         if (lxPerNode !== undefined) nodeLoad.fx = lxPerNode;
         if (lyPerNode !== undefined) nodeLoad.fy = lyPerNode;
-        if (Object.keys(nodeLoad).length > 1) lateralLoads.push(nodeLoad);
+        if (nodeLoad.fx !== undefined || nodeLoad.fy !== undefined) lateralLoads.push(nodeLoad);
       }
     }
   }
@@ -947,7 +978,7 @@ function buildConcreteFrame3dLocalModel(options: {
       ...buildStoryFloorLoadFields(deadLoad, liveLoad),
     };
   });
-  const loadCaseBundle = buildConcreteLoadCaseBundle(stories, lateralLoads, {
+  const loadCaseBundle = buildConcreteLoadCaseBundle(deadLoads, liveLoads, lateralLoads, {
     includeWind: options.wind !== undefined,
     includeSeismic: options.siteSeismic !== undefined,
     frameDimension: '3d',

--- a/backend/src/agent-skills/structure-type/frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/frame/__tests__/skill-core.test.mjs
@@ -274,6 +274,30 @@ describe('frame canonicalize core contract', () => {
     expect(model.load_combinations[0]).toMatchObject({ id: 'ULS', factors: { D: 1, L: 1 } });
   });
 
+  test('normalizes duplicate same-story floor loads without dropping signed gravity loads', () => {
+    const model = buildFrameModel({
+      inferredType: 'frame',
+      updatedAt: 0,
+      frameDimension: '2d',
+      storyCount: 1,
+      bayCount: 1,
+      storyHeightsM: [3.6],
+      bayWidthsM: [6],
+      floorLoads: [
+        { story: 1, verticalKN: -120 },
+        { story: 1, verticalKN: -120, liveLoadKN: 30 },
+      ],
+      frameBaseSupportType: 'fixed',
+    });
+
+    expect(model).toBeDefined();
+    expect(model.stories[0]).toMatchObject({ dead_load: 20, live_load: 5 });
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'D').loads).toHaveLength(2);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'D').loads.reduce((sum, load) => sum + load.fz, 0)).toBeCloseTo(-120);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'L').loads).toHaveLength(2);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'L').loads.reduce((sum, load) => sum + load.fz, 0)).toBeCloseTo(-30);
+  });
+
   test('builds custom H sections with star separators', () => {
     const model = buildFrameModel({
       inferredType: 'frame',

--- a/backend/src/agent-skills/structure-type/frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/frame/__tests__/skill-core.test.mjs
@@ -267,6 +267,10 @@ describe('frame canonicalize core contract', () => {
     ]);
     expect(model.stories[0]).toMatchObject({ dead_load: 10, live_load: 2 });
     expect(model.load_cases.map((loadCase) => loadCase.id)).toEqual(['D', 'L']);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'D').loads).toHaveLength(4);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'D').loads.reduce((sum, load) => sum + load.fz, 0)).toBeCloseTo(-360);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'L').loads).toHaveLength(4);
+    expect(model.load_cases.find((loadCase) => loadCase.id === 'L').loads.reduce((sum, load) => sum + load.fz, 0)).toBeCloseTo(-72);
     expect(model.load_combinations[0]).toMatchObject({ id: 'ULS', factors: { D: 1, L: 1 } });
   });
 

--- a/backend/src/agent-skills/structure-type/frame/model.ts
+++ b/backend/src/agent-skills/structure-type/frame/model.ts
@@ -257,29 +257,38 @@ function buildStoryFloorLoadFields(deadLoad: number | undefined, liveLoad: numbe
   };
 }
 
-function storyHasFloorLoad(story: Record<string, unknown>, loadType: 'dead' | 'live'): boolean {
-  const field = loadType === 'dead' ? story.dead_load : story.live_load;
-  if (typeof field === 'number' && field > 0) return true;
-
-  const floorLoads = Array.isArray(story.floor_loads) ? story.floor_loads : [];
-  return floorLoads.some((entry) => {
-    if (!entry || typeof entry !== 'object') return false;
-    const record = entry as Record<string, unknown>;
-    return record.type === loadType && typeof record.value === 'number' && record.value > 0;
-  });
+function buildStoryGravityNodalLoads(
+  storyId: string,
+  nodeIds: string[],
+  totalLoadKN: number | undefined,
+  loadKind: 'dead' | 'live',
+): Array<Record<string, unknown>> {
+  if (typeof totalLoadKN !== 'number' || !Number.isFinite(totalLoadKN) || totalLoadKN <= 0 || nodeIds.length === 0) {
+    return [];
+  }
+  const fzPerNode = -Math.abs(totalLoadKN) / nodeIds.length;
+  return nodeIds.map((node) => ({
+    type: 'nodal',
+    node,
+    fz: fzPerNode,
+    story: storyId,
+    source: 'story_floor_loads',
+    load_kind: loadKind,
+  }));
 }
 
 function buildFrameLoadCaseBundle(
-  stories: Array<Record<string, unknown>>,
+  deadLoads: Array<Record<string, unknown>>,
+  liveLoads: Array<Record<string, unknown>>,
   lateralLoads: Array<Record<string, unknown>>,
 ): { load_cases: Array<Record<string, unknown>>; load_combinations: Array<Record<string, unknown>> } {
   const loadCases: Array<Record<string, unknown>> = [];
 
-  if (stories.some((story) => storyHasFloorLoad(story, 'dead'))) {
-    loadCases.push({ id: 'D', type: 'dead', loads: [], description: 'Dead floor loads from stories.floor_loads' });
+  if (deadLoads.length) {
+    loadCases.push({ id: 'D', type: 'dead', loads: deadLoads, description: 'Equivalent nodal dead loads from stories.floor_loads' });
   }
-  if (stories.some((story) => storyHasFloorLoad(story, 'live'))) {
-    loadCases.push({ id: 'L', type: 'live', loads: [], description: 'Live floor loads from stories.floor_loads' });
+  if (liveLoads.length) {
+    loadCases.push({ id: 'L', type: 'live', loads: liveLoads, description: 'Equivalent nodal live loads from stories.floor_loads' });
   }
   if (lateralLoads.length) {
     loadCases.push({ id: 'LAT', type: 'other', loads: lateralLoads, description: 'Lateral story loads' });
@@ -310,7 +319,9 @@ function buildFrame2dLocalModel(
   const zCoords = accumulateCoords(storyHeights);
   const nodes: Array<Record<string, unknown>> = [];
   const elements: Array<Record<string, unknown>> = [];
-  const loads: Array<Record<string, unknown>> = [];
+  const deadLoads: Array<Record<string, unknown>> = [];
+  const liveLoads: Array<Record<string, unknown>> = [];
+  const lateralLoads: Array<Record<string, unknown>> = [];
   let elementId = 1;
 
   for (let storyIdx = 0; storyIdx < zCoords.length; storyIdx++) {
@@ -345,11 +356,20 @@ function buildFrame2dLocalModel(
   for (const load of floorLoads) {
     const storyIdx = load.story;
     if (storyIdx <= 0 || storyIdx >= zCoords.length) continue;
+    const storyId = `F${storyIdx}`;
+    const nodeIds = xCoords.map((_x, bayIdx) => n2dId(storyIdx, bayIdx));
+    deadLoads.push(...buildStoryGravityNodalLoads(storyId, nodeIds, load.verticalKN, 'dead'));
+    liveLoads.push(...buildStoryGravityNodalLoads(storyId, nodeIds, load.liveLoadKN, 'live'));
     const lPerNode = load.lateralXKN !== undefined ? load.lateralXKN / levelNodeCount : undefined;
     for (let bayIdx = 0; bayIdx < xCoords.length; bayIdx++) {
-      const nodeLoad: Record<string, unknown> = { node: n2dId(storyIdx, bayIdx) };
+      const nodeLoad: Record<string, unknown> = {
+        type: 'nodal',
+        node: n2dId(storyIdx, bayIdx),
+        story: storyId,
+        source: 'story_lateral_loads',
+      };
       if (lPerNode !== undefined) nodeLoad.fx = lPerNode;
-      if (Object.keys(nodeLoad).length > 1) loads.push(nodeLoad);
+      if (nodeLoad.fx !== undefined) lateralLoads.push(nodeLoad);
     }
   }
 
@@ -367,7 +387,7 @@ function buildFrame2dLocalModel(
       ...buildStoryFloorLoadFields(deadLoad, liveLoad),
     };
   });
-  const loadCaseBundle = buildFrameLoadCaseBundle(stories, loads);
+  const loadCaseBundle = buildFrameLoadCaseBundle(deadLoads, liveLoads, lateralLoads);
 
   return {
     schema_version: '2.0.0',
@@ -415,7 +435,9 @@ function buildFrame3dLocalModel(
   const zCoords = accumulateCoords(storyHeights);
   const nodes: Array<Record<string, unknown>> = [];
   const elements: Array<Record<string, unknown>> = [];
-  const loads: Array<Record<string, unknown>> = [];
+  const deadLoads: Array<Record<string, unknown>> = [];
+  const liveLoads: Array<Record<string, unknown>> = [];
+  const lateralLoads: Array<Record<string, unknown>> = [];
   let elementId = 1;
 
   for (let storyIdx = 0; storyIdx < zCoords.length; storyIdx++) {
@@ -465,14 +487,23 @@ function buildFrame3dLocalModel(
   for (const load of floorLoads) {
     const storyIdx = load.story;
     if (storyIdx <= 0 || storyIdx >= zCoords.length) continue;
+    const storyId = `F${storyIdx}`;
+    const nodeIds = xCoords.flatMap((_x, xIdx) => yCoords.map((_y, yIdx) => n3dId(storyIdx, xIdx, yIdx)));
+    deadLoads.push(...buildStoryGravityNodalLoads(storyId, nodeIds, load.verticalKN, 'dead'));
+    liveLoads.push(...buildStoryGravityNodalLoads(storyId, nodeIds, load.liveLoadKN, 'live'));
     const lxPerNode = load.lateralXKN !== undefined ? load.lateralXKN / levelNodeCount : undefined;
     const lyPerNode = load.lateralYKN !== undefined ? load.lateralYKN / levelNodeCount : undefined;
     for (let xIdx = 0; xIdx < xCoords.length; xIdx++) {
       for (let yIdx = 0; yIdx < yCoords.length; yIdx++) {
-        const nodeLoad: Record<string, unknown> = { node: n3dId(storyIdx, xIdx, yIdx) };
+        const nodeLoad: Record<string, unknown> = {
+          type: 'nodal',
+          node: n3dId(storyIdx, xIdx, yIdx),
+          story: storyId,
+          source: 'story_lateral_loads',
+        };
         if (lxPerNode !== undefined) nodeLoad.fx = lxPerNode;
         if (lyPerNode !== undefined) nodeLoad.fy = lyPerNode;
-        if (Object.keys(nodeLoad).length > 1) loads.push(nodeLoad);
+        if (nodeLoad.fx !== undefined || nodeLoad.fy !== undefined) lateralLoads.push(nodeLoad);
       }
     }
   }
@@ -492,7 +523,7 @@ function buildFrame3dLocalModel(
       ...buildStoryFloorLoadFields(deadLoad, liveLoad),
     };
   });
-  const loadCaseBundle = buildFrameLoadCaseBundle(stories, loads);
+  const loadCaseBundle = buildFrameLoadCaseBundle(deadLoads, liveLoads, lateralLoads);
 
   return {
     schema_version: '2.0.0',

--- a/backend/src/agent-skills/structure-type/frame/model.ts
+++ b/backend/src/agent-skills/structure-type/frame/model.ts
@@ -3,7 +3,7 @@ import {
   STRUCTURAL_COORDINATE_SEMANTICS,
 } from '../../../agent-runtime/coordinate-semantics.js';
 import { buildElementReferenceVectors } from '../../../agent-runtime/reference-vectors.js';
-import type { DraftState } from '../../../agent-runtime/types.js';
+import type { DraftFloorLoad, DraftState } from '../../../agent-runtime/types.js';
 import { REQUIRED_KEYS } from './constants.js';
 
 type FrameMaterialCategory = 'steel' | 'concrete';
@@ -263,7 +263,7 @@ function buildStoryGravityNodalLoads(
   totalLoadKN: number | undefined,
   loadKind: 'dead' | 'live',
 ): Array<Record<string, unknown>> {
-  if (typeof totalLoadKN !== 'number' || !Number.isFinite(totalLoadKN) || totalLoadKN <= 0 || nodeIds.length === 0) {
+  if (typeof totalLoadKN !== 'number' || !Number.isFinite(totalLoadKN) || totalLoadKN === 0 || nodeIds.length === 0) {
     return [];
   }
   const fzPerNode = -Math.abs(totalLoadKN) / nodeIds.length;
@@ -275,6 +275,22 @@ function buildStoryGravityNodalLoads(
     source: 'story_floor_loads',
     load_kind: loadKind,
   }));
+}
+
+function normalizeFloorLoadsByStory(floorLoads: DraftFloorLoad[]): DraftFloorLoad[] {
+  const merged = new Map<number, DraftFloorLoad>();
+  for (const load of floorLoads) {
+    if (typeof load.story !== 'number' || !Number.isFinite(load.story)) continue;
+    const current = merged.get(load.story);
+    merged.set(load.story, {
+      story: load.story,
+      verticalKN: load.verticalKN ?? current?.verticalKN,
+      liveLoadKN: load.liveLoadKN ?? current?.liveLoadKN,
+      lateralXKN: load.lateralXKN ?? current?.lateralXKN,
+      lateralYKN: load.lateralYKN ?? current?.lateralYKN,
+    });
+  }
+  return Array.from(merged.values()).sort((left, right) => left.story - right.story);
 }
 
 function buildFrameLoadCaseBundle(
@@ -313,7 +329,7 @@ function buildFrame2dLocalModel(
 ): Record<string, unknown> {
   const bayWidths = state.bayWidthsM!;
   const storyHeights = state.storyHeightsM!;
-  const floorLoads = state.floorLoads!;
+  const floorLoads = normalizeFloorLoadsByStory(state.floorLoads!);
   const baseSupport = (state.frameBaseSupportType as string | undefined) ?? 'fixed';
   const xCoords = accumulateCoords(bayWidths);
   const zCoords = accumulateCoords(storyHeights);
@@ -428,7 +444,7 @@ function buildFrame3dLocalModel(
   const bayWidthsX = state.bayWidthsXM!;
   const bayWidthsY = state.bayWidthsYM!;
   const storyHeights = state.storyHeightsM!;
-  const floorLoads = state.floorLoads!;
+  const floorLoads = normalizeFloorLoadsByStory(state.floorLoads!);
   const baseSupport = (state.frameBaseSupportType as string | undefined) ?? 'fixed';
   const xCoords = accumulateCoords(bayWidthsX);
   const yCoords = accumulateCoords(bayWidthsY);

--- a/backend/src/agent-skills/structure-type/generic/__tests__/llm-model-builder.test.mjs
+++ b/backend/src/agent-skills/structure-type/generic/__tests__/llm-model-builder.test.mjs
@@ -33,7 +33,16 @@ describe('generic LLM model builder', () => {
               { id: 'E1', type: 'beam', nodes: ['N1', 'N2'], material: 'M1', section: 'S1' },
             ],
             load_cases: [
-              { id: 'LC1', type: 'other', loads: [{ type: 'nodal_force', node: 'N2', fz: -230000, unit: 'N' }] },
+              {
+                id: 'LC1',
+                type: 'other',
+                loads: [
+                  { type: 'nodal_force', node: 'N2', fz: -230000, unit: 'N' },
+                  { type: 'nodal_force', node: 'N2', fz: -230, unit: 'N' },
+                  { type: 'line_load', element: 'E1', wz: -20000, forceUnit: 'npermeter', units: 'N/m' },
+                  { type: 'nodal_force', node: 'N1', fz: '   ', unit: 'N' },
+                ],
+              },
             ],
           }),
         };
@@ -53,6 +62,26 @@ describe('generic LLM model builder', () => {
       type: 'nodal',
       node: 'N2',
       fz: -230,
+      unit: 'kN',
+    });
+    expect(model.load_cases[0].loads[1]).toMatchObject({
+      type: 'nodal',
+      node: 'N2',
+      fz: -230,
+      unit: 'kN',
+    });
+    expect(model.load_cases[0].loads[2]).toMatchObject({
+      type: 'distributed',
+      element: 'E1',
+      wz: -20,
+      unit: 'kN/m',
+    });
+    expect(model.load_cases[0].loads[2].forceUnit).toBeUndefined();
+    expect(model.load_cases[0].loads[2].units).toBeUndefined();
+    expect(model.load_cases[0].loads[3]).toMatchObject({
+      type: 'nodal',
+      node: 'N1',
+      fz: '   ',
       unit: 'kN',
     });
   });

--- a/backend/src/agent-skills/structure-type/generic/__tests__/llm-model-builder.test.mjs
+++ b/backend/src/agent-skills/structure-type/generic/__tests__/llm-model-builder.test.mjs
@@ -1,0 +1,59 @@
+import { describe, expect, test } from '@jest/globals';
+import { buildGenericModelPrompt } from '../../../../../dist/agent-skills/structure-type/generic/llm-model-prompt.js';
+import { tryBuildGenericModelWithLlm } from '../../../../../dist/agent-skills/structure-type/generic/llm-model-builder.js';
+
+describe('generic LLM model builder', () => {
+  test('prompts for StructureModel V2 and kN-based loads', () => {
+    const prompt = buildGenericModelPrompt(
+      'Build a 12m beam with 20kN/m uniform load',
+      { inferredType: 'beam', updatedAt: 0 },
+      'en',
+    );
+
+    expect(prompt).toContain('StructureModel V2');
+    expect(prompt).toContain('"schema_version":"2.0.0"');
+    expect(prompt).toContain('point forces are kN');
+    expect(prompt).toContain('distributed member loads are kN/m');
+    expect(prompt).not.toContain('StructureModel v1');
+    expect(prompt).not.toContain('-10000');
+  });
+
+  test('canonicalizes legacy schema and explicit newton load units from LLM output', async () => {
+    const fakeLlm = {
+      async invoke() {
+        return {
+          content: JSON.stringify({
+            schema_version: '1.0.0',
+            unit_system: 'SI',
+            nodes: [
+              { id: 'N1', x: 0, y: 0, z: 0 },
+              { id: 'N2', x: 12, y: 0, z: 0 },
+            ],
+            elements: [
+              { id: 'E1', type: 'beam', nodes: ['N1', 'N2'], material: 'M1', section: 'S1' },
+            ],
+            load_cases: [
+              { id: 'LC1', type: 'other', loads: [{ type: 'nodal_force', node: 'N2', fz: -230000, unit: 'N' }] },
+            ],
+          }),
+        };
+      },
+    };
+
+    const model = await tryBuildGenericModelWithLlm(
+      fakeLlm,
+      'Build a 12m beam with a 230kN point load',
+      { inferredType: 'beam', updatedAt: 0 },
+      'en',
+    );
+
+    expect(model.schema_version).toBe('2.0.0');
+    expect(model.unit_system).toBe('SI');
+    expect(model.load_cases[0].loads[0]).toMatchObject({
+      type: 'nodal',
+      node: 'N2',
+      fz: -230,
+      unit: 'kN',
+    });
+  });
+});

--- a/backend/src/agent-skills/structure-type/generic/llm-model-builder.ts
+++ b/backend/src/agent-skills/structure-type/generic/llm-model-builder.ts
@@ -59,13 +59,7 @@ export async function tryBuildGenericModelWithLlm(
         continue;
       }
 
-      if (typeof parsed.schema_version !== 'string') {
-        parsed.schema_version = '2.0.0';
-      }
-      if (typeof parsed.unit_system !== 'string') {
-        parsed.unit_system = 'SI';
-      }
-
+      canonicalizeGenericModel(parsed);
       stampCanonicalMetadata(parsed, state);
 
       logger.info({
@@ -94,6 +88,80 @@ export async function tryBuildGenericModelWithLlm(
   }, 'generic llm model exhausted all attempts without a valid model');
 
   return undefined;
+}
+
+function canonicalizeGenericModel(model: Record<string, unknown>): void {
+  model.schema_version = '2.0.0';
+  model.unit_system = 'SI';
+  model.load_cases = (model.load_cases as unknown[]).map((loadCase) => {
+    if (!loadCase || typeof loadCase !== 'object' || Array.isArray(loadCase)) {
+      return loadCase;
+    }
+    const record = loadCase as Record<string, unknown>;
+    return {
+      ...record,
+      loads: Array.isArray(record.loads)
+        ? record.loads.map((load) => normalizeLoadRecord(load))
+        : [],
+    };
+  });
+}
+
+function normalizeLoadRecord(load: unknown): unknown {
+  if (!load || typeof load !== 'object' || Array.isArray(load)) {
+    return load;
+  }
+
+  const record = { ...(load as Record<string, unknown>) };
+  if (record.type === 'nodal_force') {
+    record.type = 'nodal';
+  }
+
+  const unit = firstString(record.unit, record.forceUnit, record.force_unit, record.units);
+  if (unit && isNewtonUnit(unit)) {
+    const scale = 1 / 1000;
+    const numericFields = isDistributedLoad(record)
+      ? ['wx', 'wy', 'wz', 'qx', 'qy', 'qz', 'w', 'q', 'value', 'magnitude']
+      : ['fx', 'fy', 'fz', 'px', 'py', 'pz', 'mx', 'my', 'mz', 'value', 'magnitude'];
+    for (const field of numericFields) {
+      record[field] = scaleNumber(record[field], scale);
+    }
+    if (Array.isArray(record.forces)) {
+      record.forces = record.forces.map((value) => scaleNumber(value, scale));
+    }
+    record.unit = unit.replace(/\bN\b/g, 'kN').replace(/\bn\b/g, 'kN');
+  }
+
+  return record;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function isNewtonUnit(unit: string): boolean {
+  const normalized = unit.trim().toLowerCase().replace(/\s+/g, '');
+  return normalized === 'n' || normalized === 'n/m' || normalized === 'npermeter';
+}
+
+function isDistributedLoad(load: Record<string, unknown>): boolean {
+  return load.type === 'distributed' || load.element !== undefined || load.elementId !== undefined || load.element_id !== undefined;
+}
+
+function scaleNumber(value: unknown, scale: number): unknown {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value * scale;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value.trim());
+    return Number.isFinite(parsed) ? parsed * scale : value;
+  }
+  return value;
 }
 
 function parseJsonObject(content: string): Record<string, unknown> | null {

--- a/backend/src/agent-skills/structure-type/generic/llm-model-builder.ts
+++ b/backend/src/agent-skills/structure-type/generic/llm-model-builder.ts
@@ -93,7 +93,10 @@ export async function tryBuildGenericModelWithLlm(
 function canonicalizeGenericModel(model: Record<string, unknown>): void {
   model.schema_version = '2.0.0';
   model.unit_system = 'SI';
-  model.load_cases = (model.load_cases as unknown[]).map((loadCase) => {
+  if (!Array.isArray(model.load_cases)) {
+    return;
+  }
+  model.load_cases = model.load_cases.map((loadCase) => {
     if (!loadCase || typeof loadCase !== 'object' || Array.isArray(loadCase)) {
       return loadCase;
     }
@@ -115,6 +118,8 @@ function normalizeLoadRecord(load: unknown): unknown {
   const record = { ...(load as Record<string, unknown>) };
   if (record.type === 'nodal_force') {
     record.type = 'nodal';
+  } else if (record.type === 'line_load' || record.type === 'element_uniform_load' || record.type === 'uniform_load') {
+    record.type = 'distributed';
   }
 
   const unit = firstString(record.unit, record.forceUnit, record.force_unit, record.units);
@@ -123,14 +128,19 @@ function normalizeLoadRecord(load: unknown): unknown {
     const numericFields = isDistributedLoad(record)
       ? ['wx', 'wy', 'wz', 'qx', 'qy', 'qz', 'w', 'q', 'value', 'magnitude']
       : ['fx', 'fy', 'fz', 'px', 'py', 'pz', 'mx', 'my', 'mz', 'value', 'magnitude'];
-    for (const field of numericFields) {
-      record[field] = scaleNumber(record[field], scale);
+    if (shouldScaleNewtonValues(record, numericFields)) {
+      for (const field of numericFields) {
+        record[field] = scaleNumber(record[field], scale);
+      }
+      if (Array.isArray(record.forces)) {
+        record.forces = record.forces.map((value) => scaleNumber(value, scale));
+      }
     }
-    if (Array.isArray(record.forces)) {
-      record.forces = record.forces.map((value) => scaleNumber(value, scale));
-    }
-    record.unit = unit.replace(/\bN\b/g, 'kN').replace(/\bn\b/g, 'kN');
+    record.unit = canonicalNewtonUnit(unit);
   }
+  delete record.forceUnit;
+  delete record.force_unit;
+  delete record.units;
 
   return record;
 }
@@ -149,8 +159,28 @@ function isNewtonUnit(unit: string): boolean {
   return normalized === 'n' || normalized === 'n/m' || normalized === 'npermeter';
 }
 
+function canonicalNewtonUnit(unit: string): 'kN' | 'kN/m' {
+  const normalized = unit.trim().toLowerCase().replace(/\s+/g, '');
+  return normalized === 'n/m' || normalized === 'npermeter' ? 'kN/m' : 'kN';
+}
+
 function isDistributedLoad(load: Record<string, unknown>): boolean {
   return load.type === 'distributed' || load.element !== undefined || load.elementId !== undefined || load.element_id !== undefined;
+}
+
+function shouldScaleNewtonValues(record: Record<string, unknown>, fields: string[]): boolean {
+  const values = fields
+    .map((field) => toFiniteNumber(record[field]))
+    .filter((value): value is number => value !== null);
+  if (Array.isArray(record.forces)) {
+    for (const value of record.forces) {
+      const numeric = toFiniteNumber(value);
+      if (numeric !== null) {
+        values.push(numeric);
+      }
+    }
+  }
+  return values.some((value) => Math.abs(value) >= 1000);
 }
 
 function scaleNumber(value: unknown, scale: number): unknown {
@@ -158,7 +188,11 @@ function scaleNumber(value: unknown, scale: number): unknown {
     return value * scale;
   }
   if (typeof value === 'string') {
-    const parsed = Number(value.trim());
+    const trimmed = value.trim();
+    if (trimmed === '') {
+      return value;
+    }
+    const parsed = Number(trimmed);
     return Number.isFinite(parsed) ? parsed * scale : value;
   }
   return value;
@@ -249,7 +283,11 @@ function toFiniteNumber(value: unknown): number | null {
     return value;
   }
   if (typeof value === 'string') {
-    const parsed = Number(value.trim());
+    const trimmed = value.trim();
+    if (trimmed === '') {
+      return null;
+    }
+    const parsed = Number(trimmed);
     if (Number.isFinite(parsed)) {
       return parsed;
     }

--- a/backend/src/agent-skills/structure-type/generic/llm-model-prompt-fragments.ts
+++ b/backend/src/agent-skills/structure-type/generic/llm-model-prompt-fragments.ts
@@ -1,7 +1,7 @@
 import type { AppLocale } from '../../../services/locale.js';
 
-const STRUCTURE_MODEL_V1_TEMPLATE = JSON.stringify({
-  schema_version: '1.0.0',
+const STRUCTURE_MODEL_V2_TEMPLATE = JSON.stringify({
+  schema_version: '2.0.0',
   unit_system: 'SI',
   nodes: [
     { id: 'N1', x: 0, y: 0, z: 0, restraints: [true, true, true, false, false, false] },
@@ -18,8 +18,8 @@ const STRUCTURE_MODEL_V1_TEMPLATE = JSON.stringify({
   ],
   load_cases: [
     { id: 'LC1', type: 'other', loads: [
-      { type: 'nodal_force', node: 'N2', fx: 0, fy: 0, fz: -10, mx: 0, my: 0, mz: 0 },
-      { type: 'distributed', element: 'E1', wx: 0, wy: 0, wz: -10000 },
+      { type: 'nodal', node: 'N2', fx: 0, fy: 0, fz: -10, mx: 0, my: 0, mz: 0 },
+      { type: 'distributed', element: 'E1', wx: 0, wy: 0, wz: -10 },
     ] },
   ],
   load_combinations: [
@@ -28,19 +28,23 @@ const STRUCTURE_MODEL_V1_TEMPLATE = JSON.stringify({
 });
 
 const COMMON_CONSTRAINTS_EN = [
+  'Output StructureModel V2 with schema_version exactly "2.0.0" and unit_system exactly "SI".',
+  'All lengths are meters, point forces are kN, and distributed member loads are kN/m. Never output N or N/m values and never multiply kN values by 1000.',
   'Output only the fields shown in the template. load_case.type must be dead, live, wind, seismic, or other.',
   'Prohibited alternate field names: material_id->material, section_id->section, coordinates->x/y/z, boundary_conditions->restraints, elastic_modulus->E, poisson_ratio->nu, density->rho, yield_strength->fy.',
-  'For partial-span distributed loads, split the member into separate elements. Only use nodal_force and distributed as load types; do not use line_load, element_uniform_load, or uniform_load.',
+  'For partial-span distributed loads, split the member into separate elements. Only use nodal and distributed as load types; do not use nodal_force, line_load, element_uniform_load, or uniform_load.',
 ];
 
 const COMMON_CONSTRAINTS_ZH = [
+  '输出 StructureModel V2，schema_version 必须是 "2.0.0"，unit_system 必须是 "SI"。',
+  '所有长度使用 m，集中力使用 kN，构件均布荷载使用 kN/m。不要输出 N 或 N/m，也不要把 kN 数值乘以 1000。',
   '严格输出模板中的字段和层级。load_case.type 只能是 dead/live/wind/seismic/other。',
   '禁止替代字段名：material_id->material, section_id->section, coordinates->x/y/z, boundary_conditions->restraints, elastic_modulus->E, poisson_ratio->nu, density->rho, yield_strength->fy。',
-  '局部均布荷载不要在单元内设起止位置，应拆分单元后对目标单元施加 distributed 荷载。不要使用 line_load/element_uniform_load/uniform_load 等类型名。',
+  '局部均布荷载不要在单元内设起止位置，应拆分单元后对目标单元施加 distributed 荷载。只使用 nodal 和 distributed，不要使用 nodal_force/line_load/element_uniform_load/uniform_load 等类型名。',
 ];
 
 export function getStructureModelTemplate(): string {
-  return STRUCTURE_MODEL_V1_TEMPLATE;
+  return STRUCTURE_MODEL_V2_TEMPLATE;
 }
 
 export function getCommonConstraints(locale: AppLocale): string[] {

--- a/backend/src/agent-skills/structure-type/generic/llm-model-prompt-intents.ts
+++ b/backend/src/agent-skills/structure-type/generic/llm-model-prompt-intents.ts
@@ -1,7 +1,7 @@
 import type { AppLocale } from '../../../services/locale.js';
 import { getCommonConstraints, getStructureModelTemplate } from './llm-model-prompt-fragments.js';
 
-export type GenericModelPromptIntent = 'build-structure-model-v1';
+export type GenericModelPromptIntent = 'build-structure-model-v2';
 
 type PromptIntentConfig = {
   opening: (locale: AppLocale) => string[];
@@ -9,23 +9,23 @@ type PromptIntentConfig = {
 };
 
 const INTENT_CONFIGS: Record<GenericModelPromptIntent, PromptIntentConfig> = {
-  'build-structure-model-v1': {
+  'build-structure-model-v2': {
     opening: (locale) => {
       const template = getStructureModelTemplate();
       if (locale === 'zh') {
         return [
           '你是结构建模专家。',
-          '请根据用户描述输出可计算的 StructureModel v1 JSON。',
+          '请根据用户描述输出可计算的 StructureModel V2 JSON。',
           '只输出 JSON 对象，不要 Markdown。',
-          '以下 1.0.0 JSON 模板是核心格式，请严格遵循键名与层级。',
+          '以下 2.0.0 JSON 模板是核心格式，请严格遵循键名与层级。',
           `模板:\n${template}`,
         ];
       }
       return [
         'You are a structural modeling expert.',
-        'Generate a computable StructureModel v1 JSON from the user request.',
+        'Generate a computable StructureModel V2 JSON from the user request.',
         'Return JSON object only, without markdown.',
-        'The 1.0.0 JSON template below is the base format. Follow its keys and nesting strictly.',
+        'The 2.0.0 JSON template below is the base format. Follow its keys and nesting strictly.',
         `Template:\n${template}`,
       ];
     },

--- a/backend/src/agent-skills/structure-type/generic/llm-model-prompt.ts
+++ b/backend/src/agent-skills/structure-type/generic/llm-model-prompt.ts
@@ -23,7 +23,7 @@ export function buildGenericModelPrompt(
   conversationHistory?: string,
 ): string {
   const stateHint = buildCleanStateHint(state);
-  return composePromptByIntent('build-structure-model-v1', locale, stateHint, message, conversationHistory);
+  return composePromptByIntent('build-structure-model-v2', locale, stateHint, message, conversationHistory);
 }
 
 export function buildRetrySuffix(locale: AppLocale): string {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

* Problem: Frame and concrete-frame skills preserved floor loads in `stories.floor_loads`, but their `load_cases` did not expose equivalent executable loads. Generic fallback prompts also still used a v1-style model template that could encourage N/N/m load values.
* Why it matters: Analysis, model matching, and downstream tooling need one canonical model surface for loads; retry feedback should not accidentally switch a stable frame draft to a different frame skill.
* What changed: Added equivalent nodal D/L/LAT loads for steel and concrete frame models, moved generic fallback prompts to StructureModel V2/kN conventions, canonicalized explicit N-unit generic outputs, and guarded retry feedback from changing stable draft structure types.
* What did NOT change (scope boundary): Benchmark evaluator changes and llm-benchmark submodule changes are not included. PKPM/YJK story-floor-load fields remain intact.

## Change Type (select all)

* Bug fix
* Refactor required for the fix

## Scope (select all touched areas)

* Gateway / orchestration
* Skills / tool execution
* API / contracts

## Linked Issue/PR

* Closes #
* Related #
* This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

* Root cause: Frame skills had two load representations: `stories.floor_loads` for commercial-engine conversion and mostly-empty `load_cases` for canonical model consumers. Generic fallback still prompted for a v1-style model and example loads in N/m-scale values.
* Missing detection / guardrail: Unit tests checked load case IDs but did not assert that D/L cases carried equivalent executable loads or that generic LLM output was canonicalized.
* Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
* Why this regressed now: New benchmark/model-match coverage made the split load representation visible.
* If unknown, what was ruled out: Beam and truss specialist models already emitted executable `load_cases` and were not the source of the frame load gap.

## Regression Test Plan (if applicable)

* Coverage level that should have caught this:
  * Unit test
* Target test or file:
  * `backend/src/agent-skills/structure-type/frame/__tests__/skill-core.test.mjs`
  * `backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs`
  * `backend/src/agent-skills/structure-type/generic/__tests__/llm-model-builder.test.mjs`
  * `backend/src/agent-langgraph/__tests__/draft-preservation.test.mjs`
* Scenario the test should lock in: Frame skills emit non-empty equivalent nodal D/L loads with conserved total load; generic fallback emits/canonicalizes V2 SI kN models; retry feedback does not switch stable draft structure types.
* Why this is the smallest reliable guardrail: These are pure model-builder and orchestration-state behaviors and do not require full LLM or analysis engine execution.
* Existing test that already covers this (if any): Existing frame/concrete skill tests covered story load metadata and load case IDs, now extended to assert load contents and totals.
* If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Frame and concrete-frame generated models now include explicit equivalent nodal loads in `load_cases` in addition to existing `stories.floor_loads`. Generic fallback models are constrained and normalized to StructureModel V2 with kN-based load units.

## Diagram (if applicable)

    Before:
    frame draft -> stories.floor_loads + empty D/L load_cases -> downstream readers may see zero load

    After:
    frame draft -> stories.floor_loads + equivalent nodal D/L load_cases -> analysis/model consumers see the same load intent

## Security Impact (required)

* New permissions/capabilities? (`Yes/No`): No
* Secrets/tokens handling changed? (`Yes/No`): No
* New/changed network calls? (`Yes/No`): No
* Command/tool execution surface changed? (`Yes/No`): No
* Data access scope changed? (`Yes/No`): No
* If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

* OS: Windows
* Runtime/container: local Node/backend test runner
* Model/provider: N/A for unit tests
* Integration/channel (if any): backend agent runtime and structure-type skills
* Relevant config (redacted): N/A

### Steps

1. Build a steel or concrete frame draft with story floor loads.
2. Inspect generated `load_cases` and `stories`.
3. Run targeted backend tests and agent orchestration validation.

### Expected

* `stories.floor_loads` remains available for PKPM/YJK conversion.
* `load_cases` contains equivalent nodal D/L loads with conserved total load.
* Generic fallback prompt/output uses StructureModel V2 and kN/kN/m.
* Retry feedback does not change a stable draft's structure type.

### Actual

* Confirmed by updated unit tests and validation commands.

## Evidence

* `npm test --prefix backend -- --runInBand src/agent-skills/structure-type/frame/__tests__/skill-core.test.mjs`
* `npm test --prefix backend -- --runInBand src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs`
* `npm test --prefix backend -- --runInBand src/agent-skills/structure-type/generic/__tests__/llm-model-builder.test.mjs src/agent-langgraph/__tests__/draft-preservation.test.mjs`
* `node tests/runner.mjs validate validate-agent-orchestration`

## Human Verification (required)

* Verified scenarios: Steel frame, concrete frame 2D/3D model builders, generic fallback canonicalization, retry feedback preservation.
* Edge cases checked: Explicit N-unit generic loads convert to kN; normal user request to change a structure type is not blocked by retry preservation logic.
* What you did not verify: Full 50-case benchmark rerun and live PKPM/YJK commercial engine execution.

## Review Conversations

* I replied to or resolved every bot review conversation I addressed in this PR.
* I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

* Backward compatible? (`Yes/No`): Yes
* Config/env changes? (`Yes/No`): No
* Migration needed? (`Yes/No`): No
* If yes, exact upgrade steps: N/A

## Risks and Mitigations

* Risk: Explicit equivalent frame loads may change how generic consumers interpret frame load cases compared with relying only on `stories.floor_loads`.
  * Mitigation: The original story-floor-load fields are retained, and tests assert total load conservation in the generated load cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how frame gravity loads appear in load_cases (analysis consumers may see new nodal loads) and draft-preservation rules during retries; mitigated by conserved totals in tests and unchanged story floor-load fields.
> 
> **Overview**
> Aligns **frame model outputs** and **generic fallback** with a single executable load surface, and stops **benchmark retry messages** from flipping a stable draft’s structure type.
> 
> **Steel and concrete frame builders** now populate `load_cases` **D** / **L** (and lateral **LAT** where applicable) with **equivalent nodal gravity loads** split across story nodes, while **`stories.floor_loads`** stays for PKPM/YJK-style consumers. Lateral story loads are emitted as typed **`nodal`** entries with clearer metadata instead of bare node references.
> 
> **Generic LLM modeling** moves prompts and examples to **StructureModel V2** (**kN** / **kN/m**, `nodal` not `nodal_force`). Post-processing **canonicalizes** LLM JSON (schema **2.0.0**, **N → kN** when units are explicit).
> 
> **Draft extraction** extends preservation: besides unknown-type fallback, a stable draft is kept when the input looks like **retry feedback** and type detection disagrees with the existing draft—without blocking an explicit user request to change structure type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e90e8f848af93093f9f2e4edf5237fd21b4c4154. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->