### PR TITLE
fix: Use LLM-first structural routing

### DIFF
--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -345,6 +345,7 @@ function buildPreservedStructuralTypeMatch(
     skillId: state.skillId ?? plugin?.id,
     supportLevel: state.supportLevel ?? 'supported',
     supportNote: state.supportNote,
+    routingSource: 'current-state',
   };
 }
 
@@ -361,7 +362,7 @@ export function buildPreservedDraftExtractionResult(args: {
   const mergedState = plugin
     ? plugin.handler.mergeState(args.existingState, {})
     : args.existingState;
-  const nextState = { ...mergedState, updatedAt: Date.now() };
+  const nextState = { ...mergedState, routingSource: 'current-state' as const, updatedAt: Date.now() };
   const missing = plugin
     ? plugin.handler.computeMissing(nextState, 'execution')
     : { critical: ['skillPlugin'], optional: [] };
@@ -385,6 +386,7 @@ export function buildPreservedDraftExtractionResult(args: {
       structuralTypeMatch: preservedMatch,
       rejectedStructuralTypeMatch: args.structuralTypeMatch,
       skillId: preservedMatch.skillId,
+      routingSource: preservedMatch.routingSource,
       extractionMode: 'preserved',
       preservationWarning,
       ...progress,
@@ -750,6 +752,7 @@ export function createDetectStructureTypeTool(skillRuntime: AgentSkillRuntime) {
           key: match.key,
           mappedType: match.mappedType,
           skillId: match.skillId,
+          routingSource: match.routingSource,
           supportLevel: match.supportLevel,
           supportNote: match.supportNote,
           nextAction: 'extract_draft_params',
@@ -759,7 +762,7 @@ export function createDetectStructureTypeTool(skillRuntime: AgentSkillRuntime) {
         };
         const stateUpdate: Partial<AgentState> = {};
         if (match.key) stateUpdate.structuralTypeKey = match.key;
-        logToolCall(log, { tool: 'detect_structure_type', durationMs: Date.now() - start, extra: { matchedKey: match.key, skillId: match.skillId } });
+        logToolCall(log, { tool: 'detect_structure_type', durationMs: Date.now() - start, extra: { matchedKey: match.key, skillId: match.skillId, routingSource: match.routingSource } });
         return toolResult(toolCallId, 'detect_structure_type', JSON.stringify(result), stateUpdate);
       } catch (error) {
         logToolCall(log, { tool: 'detect_structure_type', durationMs: Date.now() - start, success: false, extra: { error: error instanceof Error ? error.message : String(error) } });
@@ -815,6 +818,7 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
         log.debug({
           detectedKey: match.key,
           detectedSkillId: match.skillId,
+          routingSource: match.routingSource,
           matchedPluginId: matchedPlugin?.id,
         }, 'extract_draft_params structural match');
 
@@ -839,6 +843,7 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
               previousSkillId: existingState.skillId,
               rejectedSkillId: match.skillId,
               rejectedKey: match.key,
+              rejectedRoutingSource: match.routingSource,
             },
           });
           return toolResult(
@@ -856,6 +861,7 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
             structuralTypeKey: match.key,
             supportLevel: match.supportLevel,
             supportNote: match.supportNote,
+            routingSource: match.routingSource,
             updatedAt: Date.now(),
           };
           const responseJson = {
@@ -865,19 +871,22 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
             clarificationQuestions: [],
             structuralTypeMatch: match,
             skillId: undefined,
+            routingSource: match.routingSource,
             extractionMode: 'deterministic',
             ...buildDraftProgress(locale, ['inferredType']),
           };
           const stateUpdate: Partial<AgentState> = { draftState: nextState };
           if (match.key) stateUpdate.structuralTypeKey = match.key;
-          logToolCall(log, { tool: 'extract_draft_params', durationMs: Date.now() - start, extra: { skillId: undefined, criticalMissing: 1 } });
+          logToolCall(log, { tool: 'extract_draft_params', durationMs: Date.now() - start, extra: { skillId: undefined, criticalMissing: 1, routingSource: match.routingSource } });
           return toolResult(toolCallId, 'extract_draft_params', JSON.stringify(responseJson), stateUpdate);
         }
 
         // Step 2: Resolve plugin
         const plugin = matchedPlugin;
         if (!plugin) {
-          const nextState = existingState || { inferredType: 'unknown' as const, updatedAt: Date.now() };
+          const nextState: DraftState = existingState == null
+            ? { inferredType: 'unknown' as const, routingSource: match.routingSource, updatedAt: Date.now() }
+            : Object.assign({}, existingState, { routingSource: match.routingSource, updatedAt: Date.now() });
           const responseJson = {
             nextState,
             criticalMissing: ['inferredType'],
@@ -885,10 +894,11 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
             clarificationQuestions: [],
             structuralTypeMatch: match,
             skillId: undefined,
+            routingSource: match.routingSource,
             extractionMode: 'deterministic',
             ...buildDraftProgress(locale, ['inferredType']),
           };
-          logToolCall(log, { tool: 'extract_draft_params', durationMs: Date.now() - start, extra: { skillId: match.skillId, pluginResolved: false } });
+          logToolCall(log, { tool: 'extract_draft_params', durationMs: Date.now() - start, extra: { skillId: match.skillId, pluginResolved: false, routingSource: match.routingSource } });
           return toolResult(toolCallId, 'extract_draft_params', JSON.stringify(responseJson), { draftState: nextState });
         }
 
@@ -905,11 +915,12 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
             clarificationQuestions: buildClarificationQuestions(plugin, missing.critical, missing.optional, nextState, locale),
             structuralTypeMatch: match,
             skillId: plugin.id,
+            routingSource: match.routingSource,
             extractionMode: 'deterministic',
             ...buildDraftProgress(locale, missing.critical),
           };
           const stateUpdate: Partial<AgentState> = { draftState: nextState, structuralTypeKey: match.key };
-          logToolCall(log, { tool: 'extract_draft_params', durationMs: Date.now() - start, extra: { skillId: plugin.id, extractionMode: 'deterministic', criticalMissing: missing.critical.length } });
+          logToolCall(log, { tool: 'extract_draft_params', durationMs: Date.now() - start, extra: { skillId: plugin.id, extractionMode: 'deterministic', criticalMissing: missing.critical.length, routingSource: match.routingSource } });
           return toolResult(toolCallId, 'extract_draft_params', JSON.stringify(responseJson), stateUpdate);
         }
 
@@ -972,6 +983,7 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
           clarificationQuestions: buildClarificationQuestions(plugin, missing.critical, missing.optional, nextState, locale),
           structuralTypeMatch: match,
           skillId: plugin.id,
+          routingSource: match.routingSource,
           extractionMode,
           llmDraftPatch: draftPatch ?? null,
           engineeringDraft: nextState.engineeringDraft ?? patch.engineeringDraft ?? null,
@@ -985,7 +997,7 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
         if (nextState) stateUpdate.draftState = nextState;
         if (match.key) stateUpdate.structuralTypeKey = match.key;
 
-        logToolCall(log, { tool: 'extract_draft_params', durationMs: Date.now() - start, extra: { skillId: plugin.id, extractionMode: responseJson.extractionMode, criticalMissing: missing.critical.length } });
+        logToolCall(log, { tool: 'extract_draft_params', durationMs: Date.now() - start, extra: { skillId: plugin.id, extractionMode: responseJson.extractionMode, criticalMissing: missing.critical.length, routingSource: match.routingSource } });
         return toolResult(
           toolCallId,
           'extract_draft_params',

--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -23,6 +23,7 @@ import { createChatModel } from '../utils/llm.js';
 import type { AgentState } from './state.js';
 import type { AgentConfigurable } from './configurable.js';
 import type { AgentSkillPlugin, DraftState, InteractionQuestion, StructuralTypeMatch } from '../agent-runtime/types.js';
+import { isFreshGenericStructuralRoute } from '../agent-runtime/plugin-helpers.js';
 import { runPkpmCalcbook } from '../agent-skills/report-export/calculation-book/pkpm-calcbook/runner.js';
 // ---------------------------------------------------------------------------
 // Helpers
@@ -932,7 +933,11 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
         const stableExistingState = hasStableDraftType(existingState) ? existingState : undefined;
         if (plugin.id === 'generic' && stableExistingState) {
           const { withStructuralTypeState } = await import('../agent-runtime/plugin-helpers.js');
-          const nextState = withStructuralTypeState(plugin.handler.mergeState(stableExistingState, {}), match);
+          const resetToGeneric = isFreshGenericStructuralRoute(match);
+          const nextState = withStructuralTypeState(
+            plugin.handler.mergeState(resetToGeneric ? undefined : stableExistingState, resetToGeneric ? { inferredType: 'unknown' } : {}),
+            match,
+          );
           const missing = plugin.handler.computeMissing(nextState, 'execution');
           const responseJson = {
             nextState,

--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -912,7 +912,7 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
         if (!plugin) {
           const nextState: DraftState = existingState == null
             ? { inferredType: 'unknown' as const, routingSource: match.routingSource, updatedAt: Date.now() }
-            : Object.assign({}, existingState, { routingSource: match.routingSource, updatedAt: Date.now() });
+            : { ...(existingState as DraftState), routingSource: match.routingSource, updatedAt: Date.now() };
           const responseJson = {
             nextState,
             criticalMissing: ['inferredType'],

--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -19,6 +19,7 @@ import { Command, interrupt } from '@langchain/langgraph';
 import { ToolMessage } from '@langchain/core/messages';
 import { logger } from '../utils/logger.js';
 import { getLogger, logToolCall } from '../utils/agent-logger.js';
+import { createChatModel } from '../utils/llm.js';
 import type { AgentState } from './state.js';
 import type { AgentConfigurable } from './configurable.js';
 import type { AgentSkillPlugin, DraftState, InteractionQuestion, StructuralTypeMatch } from '../agent-runtime/types.js';
@@ -295,6 +296,9 @@ export function shouldPreserveExistingDraftState(
   message?: string,
 ): existingState is DraftState {
   if (!hasStableDraftType(existingState)) {
+    return false;
+  }
+  if (structuralTypeMatch.routingSource === 'llm-suggested') {
     return false;
   }
   if (structuralTypeMatch.key === 'unknown' && structuralTypeMatch.mappedType === 'unknown') {
@@ -729,6 +733,25 @@ async function resolveExistingDraftPlugin(
 // Engineering tools (wrap AgentSkillRuntime)
 // ---------------------------------------------------------------------------
 
+function detectStructuralTypeWithConfiguredLlm(
+  skillRuntime: AgentSkillRuntime,
+  args: {
+    message: string;
+    locale: 'zh' | 'en';
+    currentState?: DraftState;
+    skillIds?: string[];
+  },
+): Promise<StructuralTypeMatch> {
+  const routerLlm = createChatModel(0, { disableStreaming: true });
+  return skillRuntime.detectStructuralTypeWithLlm(
+    routerLlm,
+    args.message,
+    args.locale,
+    args.currentState,
+    args.skillIds,
+  );
+}
+
 export function createDetectStructureTypeTool(skillRuntime: AgentSkillRuntime) {
   return tool(
     async (input: { message?: string; locale?: string }, config: LangGraphRunnableConfig) => {
@@ -742,12 +765,12 @@ export function createDetectStructureTypeTool(skillRuntime: AgentSkillRuntime) {
       const message = resolveToolInputMessage(input.message, state?.lastUserMessage, state?.messages);
       const detectionMessage = resolveRetryTaskMessage(message);
       try {
-        const match = await skillRuntime.detectStructuralType(
-          detectionMessage,
+        const match = await detectStructuralTypeWithConfiguredLlm(skillRuntime, {
+          message: detectionMessage,
           locale,
-          state?.draftState || undefined,
+          currentState: state?.draftState || undefined,
           skillIds,
-        );
+        });
         const result = {
           key: match.key,
           mappedType: match.mappedType,
@@ -809,9 +832,12 @@ export function createExtractDraftParamsTool(skillRuntime: AgentSkillRuntime) {
           resolvedMessagePreview: message.slice(0, 120),
           extractionMessagePreview: extractionMessage.slice(0, 120),
         }, 'extract_draft_params resolved message');
-        const match = await skillRuntime.detectStructuralType(
-          extractionMessage, locale, existingState, skillIds,
-        );
+        const match = await detectStructuralTypeWithConfiguredLlm(skillRuntime, {
+          message: extractionMessage,
+          locale,
+          currentState: existingState,
+          skillIds,
+        });
         const matchedPlugin = match.skillId
           ? await skillRuntime.resolvePluginForType(match.skillId, skillIds)
           : null;

--- a/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
+++ b/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
@@ -42,12 +42,12 @@ describe('agent runtime helper utilities', () => {
     });
   });
 
-  test('routes broad building and column-grid descriptions to generic fallback', async () => {
+  test('routes broad building descriptions without material or system cues to generic fallback', async () => {
     const { AgentSkillRuntime } = await import('../../../dist/agent-runtime/index.js');
     const runtime = new AgentSkillRuntime();
 
     const match = await runtime.detectStructuralType(
-      '办公楼，混凝土柱网，三层',
+      '办公楼，三层',
       'zh',
     );
 

--- a/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
+++ b/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
@@ -108,6 +108,80 @@ describe('agent runtime helper utilities', () => {
     });
   });
 
+  test('uses LLM router decision instead of locking broad new requests to the current draft', async () => {
+    const { AgentSkillRuntime } = await import('../../../dist/agent-runtime/index.js');
+    const runtime = new AgentSkillRuntime();
+    const fakeRouterLlm = {
+      invoke: async () => ({
+        content: JSON.stringify({
+          action: 'generic',
+          skillId: 'generic',
+          structuralTypeKey: 'unknown',
+          mappedType: 'unknown',
+          supportLevel: 'fallback',
+          confidence: 0.88,
+          reason: '新的办公楼柱网描述不应继续旧梁草稿',
+        }),
+      }),
+    };
+
+    const match = await runtime.detectStructuralTypeWithLlm(
+      fakeRouterLlm,
+      '办公楼，混凝土柱网，三层',
+      'zh',
+      {
+        inferredType: 'beam',
+        structuralTypeKey: 'beam',
+        skillId: 'beam',
+        supportLevel: 'supported',
+        lengthM: 6,
+        updatedAt: 0,
+      },
+    );
+
+    expect(match).toMatchObject({
+      key: 'unknown',
+      mappedType: 'unknown',
+      skillId: 'generic',
+      supportLevel: 'fallback',
+      routingSource: 'llm-suggested',
+    });
+  });
+
+  test('requires an LLM for LLM-first structural routing', async () => {
+    const { AgentSkillRuntime } = await import('../../../dist/agent-runtime/index.js');
+    const runtime = new AgentSkillRuntime();
+
+    await expect(runtime.detectStructuralTypeWithLlm(
+      null,
+      '简支梁跨度6m',
+      'zh',
+    )).rejects.toThrow('LLM 未配置');
+  });
+
+  test('does not preserve old draft over an LLM-suggested generic route', async () => {
+    const { shouldPreserveExistingDraftState } = await import('../../../dist/agent-langgraph/tools.js');
+
+    expect(shouldPreserveExistingDraftState(
+      {
+        inferredType: 'beam',
+        structuralTypeKey: 'beam',
+        skillId: 'beam',
+        supportLevel: 'supported',
+        lengthM: 6,
+        updatedAt: 0,
+      },
+      {
+        key: 'unknown',
+        mappedType: 'unknown',
+        skillId: 'generic',
+        supportLevel: 'fallback',
+        routingSource: 'llm-suggested',
+      },
+      '办公楼，混凝土柱网，三层',
+    )).toBe(false);
+  });
+
   test('dependency fingerprints are stable regardless of reference insertion order', () => {
     const left = computeDependencyFingerprint({
       analysis: { artifactId: 'analysis-1', revision: 3 },

--- a/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
+++ b/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
@@ -148,6 +148,91 @@ describe('agent runtime helper utilities', () => {
     });
   });
 
+  test('falls back to rule hints without re-locking the current draft when LLM routing is unusable', async () => {
+    const { AgentSkillRuntime } = await import('../../../dist/agent-runtime/index.js');
+    const runtime = new AgentSkillRuntime();
+    const fakeRouterLlm = {
+      invoke: async () => ({
+        content: JSON.stringify({
+          action: 'continue_current',
+          confidence: 0.1,
+          reason: '低置信度，不能继续沿用旧梁',
+        }),
+      }),
+    };
+
+    const match = await runtime.detectStructuralTypeWithLlm(
+      fakeRouterLlm,
+      '五层混凝土办公楼，柱网8m×8m，层高3.6m',
+      'zh',
+      {
+        inferredType: 'beam',
+        structuralTypeKey: 'beam',
+        skillId: 'beam',
+        supportLevel: 'supported',
+        lengthM: 6,
+        updatedAt: 0,
+      },
+    );
+
+    expect(match).toMatchObject({
+      key: 'concrete-frame',
+      mappedType: 'frame',
+      skillId: 'concrete-frame',
+      supportLevel: 'supported',
+      routingSource: 'explicit-keyword',
+    });
+  });
+
+  test('resets stale draft state when the LLM routes a stable draft to generic', async () => {
+    const { AgentSkillRuntime } = await import('../../../dist/agent-runtime/index.js');
+    const runtime = new AgentSkillRuntime();
+    const fakeRouterLlm = {
+      invoke: async () => ({
+        content: JSON.stringify({
+          action: 'generic',
+          skillId: 'generic',
+          structuralTypeKey: 'unknown',
+          mappedType: 'unknown',
+          supportLevel: 'fallback',
+          confidence: 0.9,
+          reason: '新输入需要重新澄清结构类型',
+        }),
+      }),
+    };
+
+    const result = await runtime.extractDraftParameters(
+      fakeRouterLlm,
+      '办公楼，三层',
+      {
+        inferredType: 'beam',
+        structuralTypeKey: 'beam',
+        skillId: 'beam',
+        supportLevel: 'supported',
+        lengthM: 6,
+        supportType: 'simply-supported',
+        loadKN: 20,
+        updatedAt: 0,
+      },
+      'zh',
+    );
+
+    expect(result.structuralTypeMatch).toMatchObject({
+      key: 'unknown',
+      mappedType: 'unknown',
+      skillId: 'generic',
+      routingSource: 'llm-suggested',
+    });
+    expect(result.nextState).toMatchObject({
+      inferredType: 'unknown',
+      structuralTypeKey: 'unknown',
+      skillId: 'generic',
+      routingSource: 'llm-suggested',
+    });
+    expect(result.missing.critical).toContain('inferredType');
+    expect(result.extractionMode).toBe('deterministic');
+  });
+
   test('requires an LLM for LLM-first structural routing', async () => {
     const { AgentSkillRuntime } = await import('../../../dist/agent-runtime/index.js');
     const runtime = new AgentSkillRuntime();

--- a/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
+++ b/backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs
@@ -38,6 +38,73 @@ describe('agent runtime helper utilities', () => {
       mappedType: 'frame',
       skillId: 'frame',
       supportLevel: 'supported',
+      routingSource: 'explicit-keyword',
+    });
+  });
+
+  test('routes broad building and column-grid descriptions to generic fallback', async () => {
+    const { AgentSkillRuntime } = await import('../../../dist/agent-runtime/index.js');
+    const runtime = new AgentSkillRuntime();
+
+    const match = await runtime.detectStructuralType(
+      '办公楼，混凝土柱网，三层',
+      'zh',
+    );
+
+    expect(match).toMatchObject({
+      key: 'unknown',
+      mappedType: 'unknown',
+      skillId: 'generic',
+      supportLevel: 'fallback',
+      routingSource: 'generic-fallback',
+    });
+  });
+
+  test('keeps stable current draft when a follow-up does not explicitly switch type', async () => {
+    const { AgentSkillRuntime } = await import('../../../dist/agent-runtime/index.js');
+    const runtime = new AgentSkillRuntime();
+
+    const match = await runtime.detectStructuralType(
+      '柱顶荷载增加20kN',
+      'zh',
+      {
+        inferredType: 'frame',
+        structuralTypeKey: 'concrete-frame',
+        skillId: 'concrete-frame',
+        supportLevel: 'supported',
+        updatedAt: 0,
+      },
+    );
+
+    expect(match).toMatchObject({
+      key: 'concrete-frame',
+      mappedType: 'frame',
+      skillId: 'concrete-frame',
+      routingSource: 'current-state',
+    });
+  });
+
+  test('allows explicit structure-type switches over current draft state', async () => {
+    const { AgentSkillRuntime } = await import('../../../dist/agent-runtime/index.js');
+    const runtime = new AgentSkillRuntime();
+
+    const match = await runtime.detectStructuralType(
+      '改成简支梁跨度6m',
+      'zh',
+      {
+        inferredType: 'frame',
+        structuralTypeKey: 'concrete-frame',
+        skillId: 'concrete-frame',
+        supportLevel: 'supported',
+        updatedAt: 0,
+      },
+    );
+
+    expect(match).toMatchObject({
+      key: 'beam',
+      mappedType: 'beam',
+      skillId: 'beam',
+      routingSource: 'explicit-keyword',
     });
   });
 
@@ -170,10 +237,12 @@ describe('agent runtime helper utilities', () => {
       }],
       stage: 'model',
       supportLevel: 'supported',
+      routingSource: 'explicit-keyword',
       skillId: 'beam',
     });
 
     expect(parsed.stage).toBe('model');
+    expect(parsed.routingSource).toBe('explicit-keyword');
     expect(parsed.questions?.[0].critical).toBe(true);
     expect(() => skillExecutionSchema.parse({ stage: 'design' })).toThrow();
   });

--- a/backend/src/agent-runtime/fallback.ts
+++ b/backend/src/agent-runtime/fallback.ts
@@ -11,6 +11,7 @@ import type {
   FrameDimension,
   InferredModelType,
   InteractionQuestion,
+  RoutingSource,
   StructuralTypeMatch,
   StructuralTypeKey,
 } from './types.js';
@@ -335,12 +336,14 @@ function buildUnsupportedStructuralType(
   key: StructuralTypeKey,
   noteZh: string,
   noteEn: string,
+  routingSource: RoutingSource = 'explicit-keyword',
 ): StructuralTypeMatch {
   return {
     key,
     mappedType: 'unknown',
     supportLevel: 'unsupported',
     supportNote: localize(locale, noteZh, noteEn),
+    routingSource,
   };
 }
 
@@ -349,7 +352,8 @@ export function buildUnknownStructuralType(locale: AppLocale): StructuralTypeMat
     locale,
     'unknown',
     '我还没有从当前描述中稳定细化出可直接补参的结构草稿。请先说明你希望按梁、桁架、门式刚架还是规则框架这类结构继续处理。',
-    'I have not yet refined the current description into a stable structural draft for follow-up guidance. Please tell me whether you want to proceed as a beam, truss, portal frame, or regular frame.'
+    'I have not yet refined the current description into a stable structural draft for follow-up guidance. Please tell me whether you want to proceed as a beam, truss, portal frame, or regular frame.',
+    'generic-fallback',
   );
 }
 

--- a/backend/src/agent-runtime/index.ts
+++ b/backend/src/agent-runtime/index.ts
@@ -9,6 +9,7 @@ import type { CodeCheckClient } from '../agent-skills/code-check/rule.js';
 import { AgentSkillRegistry } from './registry.js';
 import { AgentSkillLoader } from './loader.js';
 import { AgentSkillExecutor } from './executor.js';
+import { invokeStructuralTypeRouter } from './llm-router.js';
 import { buildDefaultReportNarrative } from './report-template.js';
 import { withStructuralTypeState } from './plugin-helpers.js';
 import {
@@ -26,6 +27,15 @@ import type {
   SkillReportNarrativeInput,
   SkillManifest,
 } from './types.js';
+
+function requireStructuralRouterLlm(llm: ChatOpenAI | null, locale: AppLocale): ChatOpenAI {
+  if (llm) {
+    return llm;
+  }
+  throw new Error(locale === 'zh'
+    ? 'LLM 未配置，无法进行结构类型路由。请检查 LLM_API_KEY 设置。'
+    : 'LLM is not configured, so structural type routing cannot run. Please check LLM_API_KEY settings.');
+}
 
 export type {
   AgentSkillBundle,
@@ -430,7 +440,43 @@ export class AgentSkillRuntime {
     };
   }
 
+  /** Rule-only router used for guardrail hints and fallback; user-facing flows should prefer detectStructuralTypeWithLlm. */
   async detectStructuralType(message: string, locale: AppLocale, currentState?: DraftState, skillIds?: string[]): Promise<StructuralTypeMatch> {
+    return this.registry.detectStructuralType(message, locale, currentState, skillIds);
+  }
+
+  async detectStructuralTypeWithLlm(
+    llm: ChatOpenAI | null,
+    message: string,
+    locale: AppLocale,
+    currentState?: DraftState,
+    skillIds?: string[],
+    signal?: AbortSignal,
+  ): Promise<StructuralTypeMatch> {
+    const routerLlm = requireStructuralRouterLlm(llm, locale);
+
+    const ruleMatch = await this.registry.detectStructuralType(message, locale, undefined, skillIds);
+    if (ruleMatch.supportLevel === 'unsupported' && ruleMatch.key !== 'unknown') {
+      return ruleMatch;
+    }
+
+    const plugins = await this.registry.resolveEnabledPlugins(skillIds);
+    const currentPlugin = await this.registry.resolvePluginForState(currentState, skillIds);
+    const llmMatch = await invokeStructuralTypeRouter({
+      llm: routerLlm,
+      message,
+      locale,
+      currentState,
+      currentPlugin,
+      plugins,
+      ruleMatch,
+      signal,
+    });
+    if (llmMatch) {
+      return llmMatch;
+    }
+
+    // Fallback is allowed only after an available LLM failed to produce a usable routing decision.
     return this.registry.detectStructuralType(message, locale, currentState, skillIds);
   }
 
@@ -446,13 +492,14 @@ export class AgentSkillRuntime {
     skillIds?: string[],
     signal?: AbortSignal,
   ): Promise<DraftParameterExtractionResult> {
-    const structuralTypeMatch = await this.registry.detectStructuralType(message, locale, existingState, skillIds);
+    const structuralTypeMatch = await this.detectStructuralTypeWithLlm(llm, message, locale, existingState, skillIds, signal);
     if (!structuralTypeMatch.skillId) {
       const stateToPersist: DraftState = {
         ...(existingState || { inferredType: 'unknown' }),
         structuralTypeKey: structuralTypeMatch.key,
         supportLevel: structuralTypeMatch.supportLevel,
         supportNote: structuralTypeMatch.supportNote,
+        routingSource: structuralTypeMatch.routingSource,
         updatedAt: Date.now(),
       };
       return {
@@ -467,7 +514,9 @@ export class AgentSkillRuntime {
     const plugin = await this.registry.resolvePluginForIdentifier(structuralTypeMatch.skillId, skillIds);
     if (!plugin) {
       return {
-        nextState: existingState || { inferredType: 'unknown', updatedAt: Date.now() },
+        nextState: existingState
+          ? { ...existingState, routingSource: structuralTypeMatch.routingSource, updatedAt: Date.now() }
+          : { inferredType: 'unknown', routingSource: structuralTypeMatch.routingSource, updatedAt: Date.now() },
         missing: { critical: ['inferredType'], optional: [] },
         structuralTypeMatch,
         plugin: undefined,

--- a/backend/src/agent-runtime/index.ts
+++ b/backend/src/agent-runtime/index.ts
@@ -11,7 +11,7 @@ import { AgentSkillLoader } from './loader.js';
 import { AgentSkillExecutor } from './executor.js';
 import { invokeStructuralTypeRouter } from './llm-router.js';
 import { buildDefaultReportNarrative } from './report-template.js';
-import { withStructuralTypeState } from './plugin-helpers.js';
+import { isFreshGenericStructuralRoute, withStructuralTypeState } from './plugin-helpers.js';
 import {
   loadSkillManifestsFromDirectorySync,
   resolveBuiltinSkillManifestRoot,
@@ -477,7 +477,7 @@ export class AgentSkillRuntime {
     }
 
     // Fallback is allowed only after an available LLM failed to produce a usable routing decision.
-    return this.registry.detectStructuralType(message, locale, currentState, skillIds);
+    return ruleMatch;
   }
 
   async resolvePluginForType(skillId: string, skillIds?: string[]): Promise<AgentSkillPlugin | null> {
@@ -525,8 +525,9 @@ export class AgentSkillRuntime {
     }
 
     if (plugin.id === 'generic' && existingState?.inferredType && existingState.inferredType !== 'unknown') {
+      const resetToGeneric = isFreshGenericStructuralRoute(structuralTypeMatch);
       const nextState = withStructuralTypeState(
-        plugin.handler.mergeState(existingState, {}),
+        plugin.handler.mergeState(resetToGeneric ? undefined : existingState, resetToGeneric ? { inferredType: 'unknown' } : {}),
         structuralTypeMatch,
       );
       const missing = plugin.handler.computeMissing(nextState, 'execution');

--- a/backend/src/agent-runtime/llm-router.ts
+++ b/backend/src/agent-runtime/llm-router.ts
@@ -1,0 +1,335 @@
+import type { ChatOpenAI } from '@langchain/openai';
+import type { AppLocale } from '../services/locale.js';
+import { buildStructuralTypeMatch } from './plugin-helpers.js';
+import type {
+  AgentSkillPlugin,
+  DraftState,
+  InferredModelType,
+  StructuralTypeKey,
+  StructuralTypeMatch,
+  StructuralTypeSupportLevel,
+} from './types.js';
+
+type StructuralRouterAction = 'continue_current' | 'switch_skill' | 'generic' | 'ask';
+type RouterLlm = Pick<ChatOpenAI, 'invoke'>;
+
+interface StructuralRouterDecision {
+  action?: StructuralRouterAction;
+  skillId?: string;
+  structuralTypeKey?: StructuralTypeKey;
+  mappedType?: InferredModelType;
+  supportLevel?: StructuralTypeSupportLevel;
+  confidence?: number;
+  reason?: string;
+}
+
+export interface StructuralRouterInput {
+  llm: RouterLlm;
+  message: string;
+  locale: AppLocale;
+  currentState?: DraftState;
+  currentPlugin?: AgentSkillPlugin | null;
+  plugins: AgentSkillPlugin[];
+  ruleMatch?: StructuralTypeMatch;
+  signal?: AbortSignal;
+}
+
+const MIN_ROUTER_CONFIDENCE = 0.55;
+const ROUTER_OUTPUT_SCHEMA = '{ "action": "continue_current|switch_skill|generic|ask", "skillId": string, "structuralTypeKey": string, "mappedType": string, "supportLevel": "supported|fallback|unsupported", "confidence": number, "reason": string }';
+const PROMPT_METADATA_KEYS = new Set([
+  'updatedAt',
+  'coordinateSemantics',
+  'supportNote',
+  'routingSource',
+]);
+const STRUCTURAL_TYPE_KEYS = new Set<StructuralTypeKey>([
+  'beam',
+  'column',
+  'truss',
+  'portal-frame',
+  'double-span-beam',
+  'frame',
+  'steel-frame',
+  'concrete-frame',
+  'reinforced-concrete-frame',
+  'portal',
+  'girder',
+  'space-frame',
+  'plate-slab',
+  'shell',
+  'tower',
+  'bridge',
+  'unknown',
+]);
+const MODEL_TYPES = new Set<InferredModelType>([
+  'beam',
+  'column',
+  'truss',
+  'portal-frame',
+  'double-span-beam',
+  'frame',
+  'unknown',
+]);
+const SUPPORT_LEVELS = new Set<StructuralTypeSupportLevel>(['supported', 'fallback', 'unsupported']);
+const ACTIONS = new Set<StructuralRouterAction>(['continue_current', 'switch_skill', 'generic', 'ask']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseJsonObject(content: string): Record<string, unknown> | null {
+  const trimmed = content.trim();
+  const direct = tryParseJsonObject(trimmed);
+  if (direct) return direct;
+
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+  if (fenced?.[1]) {
+    const parsedFence = tryParseJsonObject(fenced[1]);
+    if (parsedFence) return parsedFence;
+  }
+
+  const first = trimmed.indexOf('{');
+  const last = trimmed.lastIndexOf('}');
+  if (first >= 0 && last > first) {
+    return tryParseJsonObject(trimmed.slice(first, last + 1));
+  }
+  return null;
+}
+
+function tryParseJsonObject(content: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(content);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function cleanStateForPrompt(value: unknown, keyPath: string[] = []): unknown {
+  if (value === undefined || value === null) return undefined;
+  if (Array.isArray(value)) {
+    const cleaned = value
+      .map((item) => cleanStateForPrompt(item, keyPath))
+      .filter((item) => item !== undefined);
+    return cleaned.length > 0 ? cleaned : undefined;
+  }
+  if (isRecord(value)) {
+    const key = keyPath[keyPath.length - 1];
+    const entries = Object.entries(value)
+      .filter(([entryKey]) => !PROMPT_METADATA_KEYS.has(entryKey))
+      .filter(([entryKey]) => !(key === 'skillState' && entryKey === 'invalidDraftFields'))
+      .map(([entryKey, item]) => [entryKey, cleanStateForPrompt(item, [...keyPath, entryKey])] as const)
+      .filter(([, item]) => item !== undefined);
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+  }
+  return value;
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function getConfidence(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0, Math.min(1, value));
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return Math.max(0, Math.min(1, parsed));
+    }
+  }
+  return 0;
+}
+
+function normalizeDecision(parsed: Record<string, unknown>): StructuralRouterDecision {
+  const actionValue = getString(parsed.action);
+  const keyValue = getString(parsed.structuralTypeKey ?? parsed.key);
+  const mappedTypeValue = getString(parsed.mappedType ?? parsed.inferredType);
+  const supportLevelValue = getString(parsed.supportLevel);
+  return {
+    action: actionValue && ACTIONS.has(actionValue as StructuralRouterAction)
+      ? actionValue as StructuralRouterAction
+      : undefined,
+    skillId: getString(parsed.skillId),
+    structuralTypeKey: keyValue && STRUCTURAL_TYPE_KEYS.has(keyValue as StructuralTypeKey)
+      ? keyValue as StructuralTypeKey
+      : undefined,
+    mappedType: mappedTypeValue && MODEL_TYPES.has(mappedTypeValue as InferredModelType)
+      ? mappedTypeValue as InferredModelType
+      : undefined,
+    supportLevel: supportLevelValue && SUPPORT_LEVELS.has(supportLevelValue as StructuralTypeSupportLevel)
+      ? supportLevelValue as StructuralTypeSupportLevel
+      : undefined,
+    confidence: getConfidence(parsed.confidence),
+    reason: getString(parsed.reason),
+  };
+}
+
+function pluginForDecision(decision: StructuralRouterDecision, plugins: AgentSkillPlugin[]): AgentSkillPlugin | undefined {
+  const key = decision.structuralTypeKey;
+  const skillId = decision.skillId;
+  return plugins.find((plugin) => plugin.id === skillId)
+    || (key ? plugins.find((plugin) => plugin.manifest.structuralTypeKeys.includes(key)) : undefined)
+    || (decision.mappedType ? plugins.find((plugin) => plugin.structureType === decision.mappedType) : undefined);
+}
+
+function buildCurrentStateMatch(
+  state: DraftState,
+  plugin: AgentSkillPlugin,
+  supportNote?: string,
+): StructuralTypeMatch {
+  return {
+    key: (state.structuralTypeKey ?? plugin.id) as StructuralTypeKey,
+    mappedType: state.inferredType,
+    skillId: plugin.id,
+    supportLevel: state.supportLevel ?? 'supported',
+    supportNote: supportNote ?? state.supportNote,
+    routingSource: 'llm-suggested',
+  };
+}
+
+function buildGenericMatch(locale: AppLocale, plugins: AgentSkillPlugin[], reason?: string): StructuralTypeMatch | null {
+  const genericPlugin = plugins.find((plugin) => plugin.id === 'generic');
+  if (!genericPlugin) return null;
+  return buildStructuralTypeMatch('unknown', 'unknown', 'generic', 'fallback', locale, {
+    zh: reason || '大模型判断当前描述不应被旧结构草稿锁定，先交给通用结构类型 skill 继续澄清。',
+    en: reason || 'The LLM router decided this request should not be locked to the prior draft, so it will continue through the generic structure-type skill.',
+  }, 'llm-suggested');
+}
+
+function resolveRouterMatch(
+  decision: StructuralRouterDecision,
+  input: StructuralRouterInput,
+): StructuralTypeMatch | null {
+  if ((decision.confidence ?? 0) < MIN_ROUTER_CONFIDENCE) {
+    return null;
+  }
+
+  const action = decision.action
+    ?? (decision.skillId || decision.structuralTypeKey ? 'switch_skill' : undefined);
+
+  if (action === 'continue_current') {
+    if (!input.currentState?.inferredType || input.currentState.inferredType === 'unknown' || !input.currentPlugin) {
+      return null;
+    }
+    return buildCurrentStateMatch(input.currentState, input.currentPlugin, decision.reason);
+  }
+
+  if (action === 'generic' || action === 'ask') {
+    return buildGenericMatch(input.locale, input.plugins, decision.reason);
+  }
+
+  if (action !== 'switch_skill') {
+    return null;
+  }
+
+  const plugin = pluginForDecision(decision, input.plugins);
+  if (!plugin) {
+    return null;
+  }
+  if (plugin.id === 'generic') {
+    return buildGenericMatch(input.locale, input.plugins, decision.reason);
+  }
+
+  const key = decision.structuralTypeKey
+    ?? plugin.manifest.structuralTypeKeys[0]
+    ?? plugin.structureType;
+  const mappedType = decision.mappedType ?? plugin.structureType;
+  const supportLevel = decision.supportLevel ?? 'supported';
+  return buildStructuralTypeMatch(
+    key as StructuralTypeKey,
+    mappedType,
+    plugin.id,
+    supportLevel,
+    input.locale,
+    decision.reason ? { zh: decision.reason, en: decision.reason } : undefined,
+    'llm-suggested',
+  );
+}
+
+function buildPluginSummary(plugin: AgentSkillPlugin): Record<string, unknown> {
+  return {
+    id: plugin.id,
+    structureType: plugin.structureType,
+    structuralTypeKeys: plugin.manifest.structuralTypeKeys,
+    name: plugin.name,
+    description: plugin.description,
+    triggers: plugin.triggers,
+  };
+}
+
+function buildRouterPrompt(input: StructuralRouterInput): string {
+  const stateJson = JSON.stringify(cleanStateForPrompt(input.currentState) ?? {}, null, 2);
+  const skillsJson = JSON.stringify(input.plugins.map(buildPluginSummary), null, 2);
+  const ruleMatchJson = JSON.stringify(input.ruleMatch ?? null, null, 2);
+  const currentSkill = input.currentPlugin
+    ? JSON.stringify(buildPluginSummary(input.currentPlugin), null, 2)
+    : 'null';
+
+  if (input.locale === 'zh') {
+    return [
+      '你是结构工程对话的结构类型路由器。请直接判断本轮用户消息应该继续当前 draft，切换到某个结构 skill，还是进入 generic 澄清。',
+      '',
+      '规则 hints 只是参考，不是最终裁判。不要因为存在 current draft 就自动继续；只有用户是在修改、补充、回答追问或明确引用当前模型时才 continue_current。',
+      '如果最新消息像一个新的结构描述，尤其是从构件级草稿转到办公楼、柱网、楼层、体系描述，不要被旧 draft 锁定。',
+      '“梁上荷载”里的梁通常是框架构件上下文，不一定要切到 beam；“柱网/柱距”里的柱通常不是单柱。',
+      '',
+      '只输出 JSON，不要 markdown。Schema:',
+      ROUTER_OUTPUT_SCHEMA,
+      '',
+      'action 说明：',
+      '- continue_current: 本轮是在继续修改已有 draft。',
+      '- switch_skill: 本轮明确应使用某个可用 structure-type skill。',
+      '- generic: 描述有结构意图，但不宜由具体 skill 硬判，先交给 generic。',
+      '- ask: 信息不足以稳定判断，交给 generic 追问。',
+      '',
+      '可用 skills:',
+      skillsJson,
+      '',
+      `当前 skill:\n${currentSkill}`,
+      '',
+      `当前 draftState:\n${stateJson}`,
+      '',
+      `规则 hint:\n${ruleMatchJson}`,
+      '',
+      `用户最新消息:\n${input.message}`,
+    ].join('\n');
+  }
+
+  return [
+    'You are the structural-type router for a structural engineering conversation. Decide whether the latest user message should continue the current draft, switch to a structure skill, or go to generic clarification.',
+    '',
+    'Rule hints are advisory, not authoritative. Do not continue the current draft just because it exists; continue only when the user is editing, supplementing, answering a clarification, or explicitly referring to the current model.',
+    'If the latest message looks like a new structural description, especially a shift from a member draft to a building/grid/story/system description, do not lock it to the old draft.',
+    'A beam mentioned in "load on the beam" may be member context inside a frame; a column mentioned in "column grid/spacing" is usually not a standalone column.',
+    '',
+    'Return JSON only, no markdown. Schema:',
+    ROUTER_OUTPUT_SCHEMA,
+    '',
+    'Available skills:',
+    skillsJson,
+    '',
+    `Current skill:\n${currentSkill}`,
+    '',
+    `Current draftState:\n${stateJson}`,
+    '',
+    `Rule hint:\n${ruleMatchJson}`,
+    '',
+    `Latest user message:\n${input.message}`,
+  ].join('\n');
+}
+
+export async function invokeStructuralTypeRouter(input: StructuralRouterInput): Promise<StructuralTypeMatch | null> {
+  try {
+    const result = await input.llm.invoke(buildRouterPrompt(input), { signal: input.signal });
+    const content = typeof result.content === 'string'
+      ? result.content
+      : JSON.stringify(result.content);
+    const parsed = parseJsonObject(content);
+    if (!parsed) return null;
+    return resolveRouterMatch(normalizeDecision(parsed), input);
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/agent-runtime/plugin-helpers.ts
+++ b/backend/src/agent-runtime/plugin-helpers.ts
@@ -44,6 +44,13 @@ export function withStructuralTypeState(state: DraftState, structuralTypeMatch: 
   };
 }
 
+export function isFreshGenericStructuralRoute(structuralTypeMatch: StructuralTypeMatch): boolean {
+  return structuralTypeMatch.routingSource === 'llm-suggested'
+    && structuralTypeMatch.key === 'unknown'
+    && structuralTypeMatch.mappedType === 'unknown'
+    && structuralTypeMatch.skillId === 'generic';
+}
+
 export function resolveLegacyStructuralStage(missingKeys: string[]): StructuralStage {
   if (missingKeys.includes('inferredType')) {
     return 'intent';

--- a/backend/src/agent-runtime/plugin-helpers.ts
+++ b/backend/src/agent-runtime/plugin-helpers.ts
@@ -1,5 +1,5 @@
 import type { AppLocale } from '../services/locale.js';
-import type { DraftState, StructuralTypeMatch, StructuralTypeSupportLevel } from './types.js';
+import type { DraftState, RoutingSource, StructuralTypeMatch, StructuralTypeSupportLevel } from './types.js';
 
 type StructuralStage = 'intent' | 'model' | 'loads' | 'analysis' | 'code_check' | 'report';
 
@@ -14,6 +14,7 @@ export function buildStructuralTypeMatch(
   supportLevel: StructuralTypeSupportLevel,
   locale: AppLocale,
   note?: { zh: string; en: string },
+  routingSource?: RoutingSource,
 ): StructuralTypeMatch {
   return {
     key,
@@ -21,6 +22,7 @@ export function buildStructuralTypeMatch(
     skillId,
     supportLevel,
     supportNote: note ? localize(locale, note.zh, note.en) : undefined,
+    routingSource,
   };
 }
 
@@ -37,6 +39,7 @@ export function withStructuralTypeState(state: DraftState, structuralTypeMatch: 
     structuralTypeKey,
     supportLevel: structuralTypeMatch.supportLevel,
     supportNote: structuralTypeMatch.supportNote,
+    routingSource: structuralTypeMatch.routingSource,
     updatedAt: Date.now(),
   };
 }

--- a/backend/src/agent-runtime/registry.ts
+++ b/backend/src/agent-runtime/registry.ts
@@ -3,22 +3,11 @@ import { listStructureModelingProviders } from '../agent-skills/structure-type/r
 import { AgentSkillLoader } from './loader.js';
 import { buildUnknownStructuralType, detectUnsupportedStructuralTypeByRules } from './fallback.js';
 import { localize } from './plugin-helpers.js';
+import { isExplicitStructuralSwitch } from './structural-routing.js';
 import type { AgentSkillBundle, AgentSkillPlugin, DraftState, InferredModelType, StructuralTypeMatch, StructuralTypeKey } from './types.js';
 
 function hasStableCurrentState(state: DraftState | undefined): state is DraftState {
   return !!state?.inferredType && state.inferredType !== 'unknown';
-}
-
-function isExplicitStructuralSwitch(message: string): boolean {
-  const text = message.toLowerCase();
-  return /(?:改为|改成|切换为|换成|按|作为|用)\s*(?:梁|桁架|门式刚架|门架|钢框架|混凝土框架|框架|柱)/u.test(message)
-    || /(?:change|switch|convert)\s+(?:to|into|as)\s+(?:(?:a|an|the)\s+)?(?:beam|truss|portal|frame|column)\b/i.test(text);
-}
-
-function looksLikeCurrentDraftUpdate(message: string): boolean {
-  const text = message.toLowerCase();
-  return /(?:刚才|当前|原来|继续|再|另外|同时|补充|考虑|增加|添加|调整|修改|改成|改为|改到|变成|换成|设为)/u.test(message)
-    || /\b(?:previous|current|same|continue|also|add|include|update|modify|change|adjust|set)\b/i.test(text);
 }
 
 function buildCurrentStateMatch(
@@ -31,6 +20,7 @@ function buildCurrentStateMatch(
     skillId: plugin.id,
     supportLevel: state.supportLevel ?? 'supported',
     supportNote: state.supportNote,
+    routingSource: 'current-state',
   };
 }
 
@@ -113,7 +103,6 @@ export class AgentSkillRegistry {
     if (
       currentPlugin
       && hasStableCurrentState(currentState)
-      && looksLikeCurrentDraftUpdate(message)
       && !explicitStructuralSwitch
     ) {
       return buildCurrentStateMatch(currentState, currentPlugin);

--- a/backend/src/agent-runtime/schema.ts
+++ b/backend/src/agent-runtime/schema.ts
@@ -30,6 +30,7 @@ export const skillExecutionSchema = z.object({
   stage: z.enum(['intent', 'model', 'loads', 'analysis', 'code_check', 'report']).optional(),
   supportLevel: z.enum(['supported', 'fallback', 'unsupported']).optional(),
   supportNote: z.string().optional(),
+  routingSource: z.enum(['explicit-keyword', 'current-state', 'llm-suggested', 'generic-fallback']).optional(),
   skillId: z.string().optional(),
 });
 

--- a/backend/src/agent-runtime/structural-routing.ts
+++ b/backend/src/agent-runtime/structural-routing.ts
@@ -17,6 +17,7 @@ const TEXT_SEPARATORS = [
   '，', '。', '；', '：', '！', '？', '（', '）', '【', '】', '、',
 ];
 const TEXT_SEPARATOR_PATTERN = /[\r\n\t ,.;:!?()[\]{}/\\，。；：！？（）【】、]+/g;
+const CONCRETE_GRADE_PATTERN = /\bc(?:20|25|30|35|40|45|50|55|60|65|70|75|80)\b/i;
 
 function normalizeForWords(message: string): string {
   return ` ${message.toLowerCase().replace(TEXT_SEPARATOR_PATTERN, ' ').trim()} `;
@@ -89,6 +90,7 @@ function hasConcreteCue(rawText: string, normalizedText: string): boolean {
     || rawText.includes('混凝土')
     || rawText.includes('钢筋砼')
     || rawText.includes('砼')
+    || CONCRETE_GRADE_PATTERN.test(rawText)
     || hasWord(normalizedText, 'rc');
 }
 

--- a/backend/src/agent-runtime/structural-routing.ts
+++ b/backend/src/agent-runtime/structural-routing.ts
@@ -1,0 +1,187 @@
+import type { InferredModelType, RoutingSource, StructuralTypeKey, StructuralTypeSupportLevel } from './types.js';
+
+type SwitchStrength = 'strong' | 'weak';
+
+export interface ConservativeStructuralRoute {
+  key: StructuralTypeKey;
+  mappedType: InferredModelType;
+  skillId: string;
+  supportLevel: StructuralTypeSupportLevel;
+  routingSource: RoutingSource;
+  switchStrength: SwitchStrength;
+}
+
+const TEXT_SEPARATORS = [
+  '\r', '\n', '\t',
+  ' ', ',', '.', ';', ':', '!', '?', '(', ')', '[', ']', '{', '}', '/', '\\',
+  '，', '。', '；', '：', '！', '？', '（', '）', '【', '】', '、',
+];
+
+function normalizeForWords(message: string): string {
+  let text = message.toLowerCase();
+  for (const separator of TEXT_SEPARATORS) {
+    text = text.split(separator).join(' ');
+  }
+  while (text.includes('  ')) {
+    text = text.split('  ').join(' ');
+  }
+  return ` ${text.trim()} `;
+}
+
+function hasWord(normalizedText: string, word: string): boolean {
+  return normalizedText.includes(` ${word} `);
+}
+
+function hasRawPhrase(rawText: string, phrases: string[]): boolean {
+  return phrases.some((phrase) => rawText.includes(phrase));
+}
+
+function hasEnglishPhrase(normalizedText: string, rawText: string, phrases: string[]): boolean {
+  return phrases.some((phrase) => normalizedText.includes(` ${phrase} `) || rawText.includes(phrase));
+}
+
+function isStandaloneChineseToken(message: string, token: string): boolean {
+  if (message.trim() === token) {
+    return true;
+  }
+  let start = 0;
+  while (start < message.length) {
+    const index = message.indexOf(token, start);
+    if (index < 0) {
+      return false;
+    }
+    const before = index === 0 ? ' ' : message[index - 1];
+    const afterIndex = index + token.length;
+    const after = afterIndex >= message.length ? ' ' : message[afterIndex];
+    if (TEXT_SEPARATORS.includes(before) && TEXT_SEPARATORS.includes(after)) {
+      return true;
+    }
+    start = index + token.length;
+  }
+  return false;
+}
+
+function route(
+  key: StructuralTypeKey,
+  mappedType: InferredModelType,
+  skillId: string,
+  supportLevel: StructuralTypeSupportLevel = 'supported',
+  switchStrength: SwitchStrength = 'strong',
+): ConservativeStructuralRoute {
+  return {
+    key,
+    mappedType,
+    skillId,
+    supportLevel,
+    routingSource: 'explicit-keyword',
+    switchStrength,
+  };
+}
+
+function isBeamLoadContext(rawText: string, normalizedText: string): boolean {
+  return rawText.includes('梁上')
+    || normalizedText.includes(' beam load ')
+    || normalizedText.includes(' load on the beam ');
+}
+
+function isColumnGridContext(rawText: string, normalizedText: string): boolean {
+  return rawText.includes('柱网')
+    || rawText.includes('柱距')
+    || normalizedText.includes(' column grid ');
+}
+
+export function matchConservativeStructuralRoute(message: string): ConservativeStructuralRoute | null {
+  const rawText = message.toLowerCase();
+  const normalizedText = normalizeForWords(message);
+
+  if (
+    hasEnglishPhrase(normalizedText, rawText, ['reinforced concrete frame', 'reinforced-concrete-frame', 'concrete frame', 'concrete-frame', 'rc frame', 'rc-frame'])
+    || hasRawPhrase(rawText, ['钢筋混凝土框架', '钢筋砼框架', '混凝土框架', '砼框架', 'rc框架'])
+  ) {
+    return route('concrete-frame', 'frame', 'concrete-frame');
+  }
+
+  if (
+    hasEnglishPhrase(normalizedText, rawText, ['steel frame', 'steel-frame'])
+    || hasRawPhrase(rawText, ['钢框架', '钢结构框架'])
+  ) {
+    return route('steel-frame', 'frame', 'frame');
+  }
+
+  if (
+    hasEnglishPhrase(normalizedText, rawText, ['portal frame', 'portal-frame'])
+    || hasRawPhrase(rawText, ['门式刚架'])
+  ) {
+    return route('portal-frame', 'portal-frame', 'portal-frame');
+  }
+
+  if (hasWord(normalizedText, 'portal') || hasRawPhrase(rawText, ['门架'])) {
+    return route('portal', 'portal-frame', 'portal-frame', 'fallback');
+  }
+
+  if (
+    hasWord(normalizedText, 'truss')
+    || hasWord(normalizedText, 'trusses')
+    || hasRawPhrase(rawText, ['桁架', '屋架'])
+  ) {
+    return route('truss', 'truss', 'truss');
+  }
+
+  if (
+    hasEnglishPhrase(normalizedText, rawText, ['double span beam', 'double-span beam', 'double-span-beam', 'two span beam', 'two-span beam', 'continuous beam'])
+    || hasRawPhrase(rawText, ['双跨梁', '双跨连续梁', '连续梁', '不等跨连续梁'])
+  ) {
+    return route('double-span-beam', 'double-span-beam', 'double-span-beam');
+  }
+
+  if (
+    hasWord(normalizedText, 'girder')
+    || hasRawPhrase(rawText, ['主梁', '大梁'])
+  ) {
+    return route('girder', 'beam', 'beam', 'fallback');
+  }
+
+  if (!isBeamLoadContext(rawText, normalizedText)) {
+    if (
+      hasWord(normalizedText, 'beam')
+      || hasRawPhrase(rawText, ['简支梁', '悬臂梁', '单跨梁', '钢梁', '混凝土梁', '梁结构', '梁跨度', '梁长'])
+    ) {
+      return route('beam', 'beam', 'beam');
+    }
+    if (isStandaloneChineseToken(message, '梁')) {
+      return route('beam', 'beam', 'beam', 'supported', 'weak');
+    }
+  }
+
+  if (!isColumnGridContext(rawText, normalizedText)) {
+    if (
+      hasRawPhrase(rawText, ['独立柱', '单根柱', '柱构件', '混凝土柱', '钢柱', '柱子'])
+    ) {
+      return route('column', 'column', 'column');
+    }
+    if (hasWord(normalizedText, 'column') || isStandaloneChineseToken(message, '柱')) {
+      return route('column', 'column', 'column', 'supported', 'weak');
+    }
+  }
+
+  if (hasWord(normalizedText, 'frame') || hasRawPhrase(rawText, ['框架'])) {
+    return route('frame', 'frame', 'frame');
+  }
+
+  return null;
+}
+
+export function isExplicitStructuralSwitch(message: string): boolean {
+  const matched = matchConservativeStructuralRoute(message);
+  if (!matched) {
+    return false;
+  }
+  if (matched.switchStrength === 'strong') {
+    return true;
+  }
+
+  const rawText = message.toLowerCase();
+  const normalizedText = normalizeForWords(message);
+  return hasRawPhrase(rawText, ['改成', '改为', '换成', '变成', '切换为', '转换为', '重新建模为'])
+    || hasEnglishPhrase(normalizedText, rawText, ['change to', 'switch to', 'convert to', 'model as', 'use as']);
+}

--- a/backend/src/agent-runtime/structural-routing.ts
+++ b/backend/src/agent-runtime/structural-routing.ts
@@ -16,16 +16,10 @@ const TEXT_SEPARATORS = [
   ' ', ',', '.', ';', ':', '!', '?', '(', ')', '[', ']', '{', '}', '/', '\\',
   '，', '。', '；', '：', '！', '？', '（', '）', '【', '】', '、',
 ];
+const TEXT_SEPARATOR_PATTERN = /[\r\n\t ,.;:!?()[\]{}/\\，。；：！？（）【】、]+/g;
 
 function normalizeForWords(message: string): string {
-  let text = message.toLowerCase();
-  for (const separator of TEXT_SEPARATORS) {
-    text = text.split(separator).join(' ');
-  }
-  while (text.includes('  ')) {
-    text = text.split('  ').join(' ');
-  }
-  return ` ${text.trim()} `;
+  return ` ${message.toLowerCase().replace(TEXT_SEPARATOR_PATTERN, ' ').trim()} `;
 }
 
 function hasWord(normalizedText: string, word: string): boolean {
@@ -90,6 +84,26 @@ function isColumnGridContext(rawText: string, normalizedText: string): boolean {
     || normalizedText.includes(' column grid ');
 }
 
+function hasConcreteCue(rawText: string, normalizedText: string): boolean {
+  return rawText.includes('concrete')
+    || rawText.includes('混凝土')
+    || rawText.includes('钢筋砼')
+    || rawText.includes('砼')
+    || hasWord(normalizedText, 'rc');
+}
+
+function hasConcreteFrameContext(rawText: string): boolean {
+  return rawText.includes('柱网')
+    || rawText.includes('办公楼')
+    || rawText.includes('住宅楼')
+    || rawText.includes('商住')
+    || rawText.includes('教学楼')
+    || rawText.includes('医院')
+    || /\d+层.*\d+跨/u.test(rawText)
+    || /\d+跨.*\d+层/u.test(rawText)
+    || (rawText.includes('层') && rawText.includes('跨'));
+}
+
 export function matchConservativeStructuralRoute(message: string): ConservativeStructuralRoute | null {
   const rawText = message.toLowerCase();
   const normalizedText = normalizeForWords(message);
@@ -98,6 +112,10 @@ export function matchConservativeStructuralRoute(message: string): ConservativeS
     hasEnglishPhrase(normalizedText, rawText, ['reinforced concrete frame', 'reinforced-concrete-frame', 'concrete frame', 'concrete-frame', 'rc frame', 'rc-frame'])
     || hasRawPhrase(rawText, ['钢筋混凝土框架', '钢筋砼框架', '混凝土框架', '砼框架', 'rc框架'])
   ) {
+    return route('concrete-frame', 'frame', 'concrete-frame');
+  }
+
+  if (hasConcreteCue(rawText, normalizedText) && hasConcreteFrameContext(rawText)) {
     return route('concrete-frame', 'frame', 'concrete-frame');
   }
 

--- a/backend/src/agent-runtime/types.ts
+++ b/backend/src/agent-runtime/types.ts
@@ -140,6 +140,7 @@ export type StructuralTypeKey =
   | 'bridge'
   | 'unknown';
 export type StructuralTypeSupportLevel = 'supported' | 'fallback' | 'unsupported';
+export type RoutingSource = 'explicit-keyword' | 'current-state' | 'llm-suggested' | 'generic-fallback';
 export type SkillStage = 'intent' | 'draft' | 'analysis' | 'design';
 
 export interface StructuralTypeMatch {
@@ -148,6 +149,7 @@ export interface StructuralTypeMatch {
   skillId?: string;
   supportLevel: StructuralTypeSupportLevel;
   supportNote?: string;
+  routingSource?: RoutingSource;
 }
 
 export interface DraftState {
@@ -156,6 +158,7 @@ export interface DraftState {
   structuralTypeKey?: StructuralTypeKey;
   supportLevel?: StructuralTypeSupportLevel;
   supportNote?: string;
+  routingSource?: RoutingSource;
   coordinateSemantics?: string;
   engineeringDraft?: EngineeringDraft;
   draftIssues?: DraftIssue[];

--- a/backend/src/agent-skills/structure-type/beam/handler.ts
+++ b/backend/src/agent-skills/structure-type/beam/handler.ts
@@ -12,6 +12,7 @@ import { combineDomainKeys, composeStructuralDomainPatch } from '../../../agent-
 import { buildStructuralTypeMatch, resolveLegacyStructuralStage } from '../../../agent-runtime/plugin-helpers.js';
 import { buildInteractionQuestions } from '../../../agent-runtime/fallback.js';
 import { buildDefaultReportNarrative } from '../../../agent-runtime/report-template.js';
+import { matchConservativeStructuralRoute } from '../../../agent-runtime/structural-routing.js';
 import type { AppLocale } from '../../../services/locale.js';
 import type {
   DraftExtraction,
@@ -165,29 +166,17 @@ function buildBeamReportNarrative(input: SkillReportNarrativeInput): string {
 
 export const handler: SkillHandler = {
   detectStructuralType({ message, locale }) {
-    const text = message.toLowerCase();
-    if (
-      text.includes('portal frame')
-      || text.includes('门式刚架')
-      || text.includes('桁架')
-      || text.includes('truss')
-      || text.includes('双跨梁')
-      || text.includes('连续梁')
-      || text.includes('double-span')
-      || text.includes('continuous beam')
-    ) {
+    const route = matchConservativeStructuralRoute(message);
+    if (route?.skillId !== 'beam') {
       return null;
     }
-    if (text.includes('girder') || text.includes('主梁') || text.includes('大梁')) {
+    if (route.key === 'girder') {
       return buildStructuralTypeMatch('girder', 'beam', 'beam', 'fallback', locale, {
         zh: '已将“主梁/大梁”先按梁模板处理；若实际是连续梁或更复杂体系，请继续说明。',
         en: '“Girder” has been normalized to the beam template for now. If the actual system is continuous or more complex, please clarify further.',
-      });
+      }, route.routingSource);
     }
-    if (text.includes('beam') || text.includes('梁') || text.includes('悬臂')) {
-      return buildStructuralTypeMatch('beam', 'beam', 'beam', 'supported', locale);
-    }
-    return null;
+    return buildStructuralTypeMatch('beam', 'beam', 'beam', route.supportLevel, locale, undefined, route.routingSource);
   },
   parseProvidedValues(values) {
     const patch = normalizeLegacyDraftPatch(values);

--- a/backend/src/agent-skills/structure-type/column/handler.ts
+++ b/backend/src/agent-skills/structure-type/column/handler.ts
@@ -9,6 +9,7 @@ import { projectEngineeringDraftToLegacyPatch } from '../../../agent-runtime/eng
 import { buildInteractionQuestions } from '../../../agent-runtime/fallback.js';
 import { buildStructuralTypeMatch, resolveLegacyStructuralStage } from '../../../agent-runtime/plugin-helpers.js';
 import { buildDefaultReportNarrative } from '../../../agent-runtime/report-template.js';
+import { matchConservativeStructuralRoute } from '../../../agent-runtime/structural-routing.js';
 import type { AppLocale } from '../../../services/locale.js';
 import type {
   DraftExtraction,
@@ -97,12 +98,9 @@ function buildColumnReportNarrative(input: SkillReportNarrativeInput): string {
 
 export const handler: SkillHandler = {
   detectStructuralType({ message, locale }) {
-    const text = message.toLowerCase();
-    if (text.includes('frame') || text.includes('column grid') || message.includes('框架') || message.includes('柱网')) {
-      return null;
-    }
-    if (text.includes('column') || message.includes('柱')) {
-      return buildStructuralTypeMatch('column', 'column', 'column', 'supported', locale);
+    const route = matchConservativeStructuralRoute(message);
+    if (route?.skillId === 'column') {
+      return buildStructuralTypeMatch('column', 'column', 'column', route.supportLevel, locale, undefined, route.routingSource);
     }
     return null;
   },

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/handler.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/handler.test.mjs
@@ -5,7 +5,7 @@ import { mergeConcreteFrameState } from '../../../../../dist/agent-skills/struct
 import { buildConcreteFrameQuestions } from '../../../../../dist/agent-skills/structure-type/concrete-frame/interaction.js';
 
 describe('concrete-frame handler composed modules', () => {
-  test('keeps sticky concrete-frame detection for follow-up messages', () => {
+  test('leaves follow-up sticky routing to the runtime registry', () => {
     const match = detectConcreteFrameStructuralType({
       message: '层高3.6m',
       locale: 'zh',
@@ -17,8 +17,7 @@ describe('concrete-frame handler composed modules', () => {
       },
     });
 
-    expect(match?.skillId).toBe('concrete-frame');
-    expect(match?.mappedType).toBe('frame');
+    expect(match).toBeNull();
   });
 
   test('does not treat material and sections as critical blockers', () => {

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
@@ -718,6 +718,16 @@ describe('detectConcreteFrameStructuralType branches', () => {
     expect(result?.supportLevel).toBe('supported');
   });
 
+  test('routes concrete grade with building and grid context to concrete-frame', () => {
+    const result = detectConcreteFrameStructuralType({
+      message: 'C30办公楼，柱网8m，三层',
+      locale: 'zh',
+    });
+    expect(result?.key).toBe('concrete-frame');
+    expect(result?.mappedType).toBe('frame');
+    expect(result?.supportLevel).toBe('supported');
+  });
+
   test('does not route building and column-grid context without concrete evidence', () => {
     const result = detectConcreteFrameStructuralType({
       message: '办公楼，柱网8m，三层',

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
@@ -708,12 +708,12 @@ describe('detectConcreteFrameStructuralType branches', () => {
     expect(result).toBeNull();
   });
 
-  test('detects frame with building type context', () => {
+  test('does not route building and column-grid context without explicit frame keyword', () => {
     const result = detectConcreteFrameStructuralType({
       message: '办公楼，混凝土柱网，三层',
       locale: 'zh',
     });
-    expect(result?.supportLevel).toBe('supported');
+    expect(result).toBeNull();
   });
 
   test('detects frame with concrete grade and context', () => {
@@ -724,13 +724,13 @@ describe('detectConcreteFrameStructuralType branches', () => {
     expect(result?.supportLevel).toBe('supported');
   });
 
-  test('detects from currentState when message does not match', () => {
+  test('does not apply current-state routing inside the skill handler', () => {
     const result = detectConcreteFrameStructuralType({
       message: '请分析这个结构',
       locale: 'zh',
       currentState: { structuralTypeKey: 'concrete-frame', supportLevel: 'supported' },
     });
-    expect(result?.supportLevel).toBe('supported');
+    expect(result).toBeNull();
   });
 
   test('returns null when no concrete frame evidence', () => {

--- a/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
+++ b/backend/src/agent-skills/structure-type/concrete-frame/__tests__/skill-core.test.mjs
@@ -708,9 +708,19 @@ describe('detectConcreteFrameStructuralType branches', () => {
     expect(result).toBeNull();
   });
 
-  test('does not route building and column-grid context without explicit frame keyword', () => {
+  test('routes concrete building and column-grid context to concrete-frame', () => {
     const result = detectConcreteFrameStructuralType({
       message: '办公楼，混凝土柱网，三层',
+      locale: 'zh',
+    });
+    expect(result?.key).toBe('concrete-frame');
+    expect(result?.mappedType).toBe('frame');
+    expect(result?.supportLevel).toBe('supported');
+  });
+
+  test('does not route building and column-grid context without concrete evidence', () => {
+    const result = detectConcreteFrameStructuralType({
+      message: '办公楼，柱网8m，三层',
       locale: 'zh',
     });
     expect(result).toBeNull();

--- a/backend/src/agent-skills/structure-type/concrete-frame/detect.ts
+++ b/backend/src/agent-skills/structure-type/concrete-frame/detect.ts
@@ -1,60 +1,21 @@
 import { buildStructuralTypeMatch } from '../../../agent-runtime/plugin-helpers.js';
+import { matchConservativeStructuralRoute } from '../../../agent-runtime/structural-routing.js';
 import type { SkillDetectionInput, StructuralTypeMatch } from '../../../agent-runtime/types.js';
 
-function hasRcAbbreviation(text: string): boolean {
-  return /\brc\b/i.test(text);
-}
-
-function hasConcreteCue(text: string): boolean {
-  return text.includes('concrete')
-    || text.includes('混凝土')
-    || text.includes('钢筋砼')
-    || hasRcAbbreviation(text);
-}
-
-export function detectConcreteFrameStructuralType({ message, locale, currentState }: SkillDetectionInput): StructuralTypeMatch | null {
+export function detectConcreteFrameStructuralType({ message, locale }: SkillDetectionInput): StructuralTypeMatch | null {
   const text = message.toLowerCase();
+  const route = matchConservativeStructuralRoute(message);
+  if (route?.skillId !== 'concrete-frame') {
+    return null;
+  }
   if (
     (text.includes('frame') || text.includes('框架') || text.includes('混凝土框架') || text.includes('钢筋混凝土框架')) &&
-    hasConcreteCue(text) &&
     (text.includes('irregular') || text.includes('不规则') || text.includes('退台') || text.includes('缺跨'))
   ) {
     return buildStructuralTypeMatch('concrete-frame', 'frame', 'concrete-frame', 'unsupported', locale, {
       zh: '当前 concrete‑frame skill 只支持规则楼层和规则轴网框架。若结构存在退台、缺跨或明显不规则，请直接提供 JSON 或更具体的节点构件描述。',
       en: 'The current concrete‑frame skill only supports regular stories and regular grids. If the structure has setbacks, missing bays, or strong irregularities, please provide JSON or a more explicit node/member description.',
-    });
+    }, route.routingSource);
   }
-  if (text.includes('concrete frame') || text.includes('混凝土框架') || text.includes('钢筋混凝土框架') || /\brc\s+frame\b/i.test(text)) {
-    return buildStructuralTypeMatch('concrete-frame', 'frame', 'concrete-frame', 'supported', locale);
-  }
-  if (text.includes('frame') || text.includes('框架')) {
-    const isConcrete = hasConcreteCue(text);
-    const isSteel = text.includes('steel') || text.includes('钢');
-    if (isConcrete && !isSteel) {
-      return buildStructuralTypeMatch('concrete-frame', 'frame', 'concrete-frame', 'supported', locale);
-    }
-  }
-  // Common Chinese structural descriptions that imply a concrete frame structure:
-  const isConcrete = hasConcreteCue(text);
-  const hasFrameContext = text.includes('柱网') ||
-    text.includes('办公楼') ||
-    text.includes('住宅楼') ||
-    text.includes('商住') ||
-    text.includes('教学楼') ||
-    text.includes('医院') ||
-    /\d+层.*\d+跨/.test(text) ||
-    /\d+跨.*\d+层/.test(text) ||
-    (text.includes('层') && text.includes('跨'));
-  if (isConcrete && hasFrameContext) {
-    return buildStructuralTypeMatch('concrete-frame', 'frame', 'concrete-frame', 'supported', locale);
-  }
-  // Concrete grade detection
-  const concreteGradePattern = /\bC(?:20|25|30|35|40|45|50|55|60|65|70|75|80)\b/i;
-  if (concreteGradePattern.test(text) && hasFrameContext) {
-    return buildStructuralTypeMatch('concrete-frame', 'frame', 'concrete-frame', 'supported', locale);
-  }
-  if (currentState?.structuralTypeKey === 'concrete-frame' && currentState.supportLevel !== 'unsupported') {
-    return buildStructuralTypeMatch('concrete-frame', 'frame', 'concrete-frame', 'supported', locale);
-  }
-  return null;
+  return buildStructuralTypeMatch('concrete-frame', 'frame', 'concrete-frame', route.supportLevel, locale, undefined, route.routingSource);
 }

--- a/backend/src/agent-skills/structure-type/double-span-beam/handler.ts
+++ b/backend/src/agent-skills/structure-type/double-span-beam/handler.ts
@@ -12,6 +12,7 @@ import { combineDomainKeys, composeStructuralDomainPatch } from '../../../agent-
 import { buildStructuralTypeMatch, resolveLegacyStructuralStage } from '../../../agent-runtime/plugin-helpers.js';
 import { buildInteractionQuestions } from '../../../agent-runtime/fallback.js';
 import { buildDefaultReportNarrative } from '../../../agent-runtime/report-template.js';
+import { matchConservativeStructuralRoute } from '../../../agent-runtime/structural-routing.js';
 import type { AppLocale } from '../../../services/locale.js';
 import type {
   DraftExtraction,
@@ -148,19 +149,17 @@ function buildDoubleSpanReportNarrative(input: SkillReportNarrativeInput): strin
 
 export const handler: SkillHandler = {
   detectStructuralType({ message, locale }) {
-    const text = message.toLowerCase();
-    if (
-      text.includes('double-span')
-      || text.includes('双跨梁')
-      || text.includes('双跨连续梁')
-      || text.includes('连续梁')
-      || text.includes('不等跨连续梁')
-      || /两跨.*连续梁/u.test(text)
-      || /[三四五六七八九十\d]\s*跨.*连续梁/u.test(text)
-      || /(?:two|2)[-\s]?span.*continuous beam/i.test(text)
-      || /(?:multi|three|3)[-\s]?span.*continuous beam/i.test(text)
-    ) {
-      return buildStructuralTypeMatch('double-span-beam', 'double-span-beam', 'double-span-beam', 'supported', locale);
+    const route = matchConservativeStructuralRoute(message);
+    if (route?.skillId === 'double-span-beam') {
+      return buildStructuralTypeMatch(
+        'double-span-beam',
+        'double-span-beam',
+        'double-span-beam',
+        route.supportLevel,
+        locale,
+        undefined,
+        route.routingSource,
+      );
     }
     return null;
   },

--- a/backend/src/agent-skills/structure-type/frame/__tests__/handler.test.mjs
+++ b/backend/src/agent-skills/structure-type/frame/__tests__/handler.test.mjs
@@ -5,7 +5,7 @@ import { mergeFrameState } from '../../../../../dist/agent-skills/structure-type
 import { buildFrameQuestions } from '../../../../../dist/agent-skills/structure-type/frame/interaction.js';
 
 describe('frame handler composed modules', () => {
-  test('keeps sticky frame detection for follow-up messages', () => {
+  test('leaves follow-up sticky routing to the runtime registry', () => {
     const match = detectFrameStructuralType({
       message: '层高3.6m',
       locale: 'zh',
@@ -17,8 +17,7 @@ describe('frame handler composed modules', () => {
       },
     });
 
-    expect(match?.skillId).toBe('frame');
-    expect(match?.mappedType).toBe('frame');
+    expect(match).toBeNull();
   });
 
   test('does not treat material and sections as critical blockers', () => {

--- a/backend/src/agent-skills/structure-type/frame/detect.ts
+++ b/backend/src/agent-skills/structure-type/frame/detect.ts
@@ -1,8 +1,13 @@
 import { buildStructuralTypeMatch } from '../../../agent-runtime/plugin-helpers.js';
+import { matchConservativeStructuralRoute } from '../../../agent-runtime/structural-routing.js';
 import type { SkillDetectionInput, StructuralTypeMatch } from '../../../agent-runtime/types.js';
 
-export function detectFrameStructuralType({ message, locale, currentState }: SkillDetectionInput): StructuralTypeMatch | null {
+export function detectFrameStructuralType({ message, locale }: SkillDetectionInput): StructuralTypeMatch | null {
   const text = message.toLowerCase();
+  const route = matchConservativeStructuralRoute(message);
+  if (route?.skillId !== 'frame') {
+    return null;
+  }
   if (
     (text.includes('frame') || text.includes('框架') || text.includes('钢框架'))
     && (text.includes('irregular') || text.includes('不规则') || text.includes('退台') || text.includes('缺跨'))
@@ -10,39 +15,7 @@ export function detectFrameStructuralType({ message, locale, currentState }: Ski
     return buildStructuralTypeMatch('frame', 'unknown', 'frame', 'unsupported', locale, {
       zh: '当前 frame skill 只支持规则楼层和规则轴网框架。若结构存在退台、缺跨或明显不规则，请直接提供 JSON 或更具体的节点构件描述。',
       en: 'The current frame skill only supports regular stories and regular grids. If the structure has setbacks, missing bays, or strong irregularities, please provide JSON or a more explicit node/member description.',
-    });
+    }, route.routingSource);
   }
-  if (text.includes('concrete frame') || text.includes('混凝土框架') || text.includes('钢筋混凝土框架') || text.includes('rc frame')) {
-    return null;
-  }
-  if (text.includes('steel frame') || text.includes('钢框架')) {
-    return buildStructuralTypeMatch('steel-frame', 'frame', 'frame', 'supported', locale);
-  }
-  if (text.includes('frame') || text.includes('框架')) {
-    return buildStructuralTypeMatch('frame', 'frame', 'frame', 'supported', locale);
-  }
-  // Common Chinese structural descriptions that imply a frame structure:
-  // - 钢结构 + multi-story → steel frame
-  // - 柱网 (column grid) → frame layout
-  // - 办公楼 / 住宅 + multi-story → frame
-  // - N层M跨 pattern → multi-story multi-span frame
-  const isSteel = text.includes('钢结') || text.includes('钢柱') || text.includes('钢梁');
-  const hasFrameContext = text.includes('柱网')
-    || text.includes('办公楼')
-    || text.includes('住宅楼')
-    || text.includes('商住')
-    || /\d+层.*\d+跨/.test(text)
-    || /\d+跨.*\d+层/.test(text)
-    || (text.includes('层') && text.includes('跨'));
-  if (isSteel && hasFrameContext) {
-    return buildStructuralTypeMatch('steel-frame', 'frame', 'frame', 'supported', locale);
-  }
-  if (hasFrameContext) {
-    return buildStructuralTypeMatch('frame', 'frame', 'frame', 'supported', locale);
-  }
-  if (currentState?.inferredType === 'frame' && currentState.supportLevel !== 'unsupported') {
-    const key = (currentState.structuralTypeKey === 'steel-frame' ? 'steel-frame' : 'frame') as StructuralTypeMatch['key'];
-    return buildStructuralTypeMatch(key, 'frame', 'frame', 'supported', locale);
-  }
-  return null;
+  return buildStructuralTypeMatch(route.key as StructuralTypeMatch['key'], 'frame', 'frame', route.supportLevel, locale, undefined, route.routingSource);
 }

--- a/backend/src/agent-skills/structure-type/generic/handler.ts
+++ b/backend/src/agent-skills/structure-type/generic/handler.ts
@@ -182,6 +182,7 @@ export const handler: SkillHandler = {
           zh: '继续使用通用结构类型 skill 处理当前对话。',
           en: 'Continue using the generic structure-type skill for the current conversation.',
         },
+        'current-state',
       );
     }
 
@@ -192,7 +193,7 @@ export const handler: SkillHandler = {
     return buildStructuralTypeMatch('unknown', 'unknown', 'generic', 'fallback', locale, {
       zh: '已切换到通用结构类型 skill，先接住当前问题并继续补参。',
       en: 'Switched to the generic structure-type skill to catch the request and continue clarification.',
-    });
+    }, 'generic-fallback');
   },
 
   parseProvidedValues(values) {

--- a/backend/src/agent-skills/structure-type/portal-frame/handler.ts
+++ b/backend/src/agent-skills/structure-type/portal-frame/handler.ts
@@ -12,6 +12,7 @@ import { combineDomainKeys, composeStructuralDomainPatch } from '../../../agent-
 import { buildStructuralTypeMatch, resolveLegacyStructuralStage } from '../../../agent-runtime/plugin-helpers.js';
 import { buildInteractionQuestions } from '../../../agent-runtime/fallback.js';
 import { buildDefaultReportNarrative } from '../../../agent-runtime/report-template.js';
+import { matchConservativeStructuralRoute } from '../../../agent-runtime/structural-routing.js';
 import type { AppLocale } from '../../../services/locale.js';
 import type {
   DraftExtraction,
@@ -148,15 +149,18 @@ function buildPortalFrameReportNarrative(input: SkillReportNarrativeInput): stri
 
 export const handler: SkillHandler = {
   detectStructuralType({ message, locale }) {
-    const text = message.toLowerCase();
-    if (text.includes('portal frame') || text.includes('门式刚架')) {
-      return buildStructuralTypeMatch('portal-frame', 'portal-frame', 'portal-frame', 'supported', locale);
+    const route = matchConservativeStructuralRoute(message);
+    if (route?.skillId !== 'portal-frame') {
+      return null;
     }
-    if (text.includes('portal') || text.includes('门架') || text.includes('刚架')) {
+    if (route.key === 'portal-frame') {
+      return buildStructuralTypeMatch('portal-frame', 'portal-frame', 'portal-frame', route.supportLevel, locale, undefined, route.routingSource);
+    }
+    if (route.key === 'portal') {
       return buildStructuralTypeMatch('portal', 'portal-frame', 'portal-frame', 'fallback', locale, {
         zh: '已将“门架/刚架”先收敛到门式刚架模板继续补参。',
         en: '“Portal structure” has been narrowed to the portal-frame template for continued guidance.',
-      });
+      }, route.routingSource);
     }
     return null;
   },

--- a/backend/src/agent-skills/structure-type/truss/handler.ts
+++ b/backend/src/agent-skills/structure-type/truss/handler.ts
@@ -12,6 +12,7 @@ import { combineDomainKeys, composeStructuralDomainPatch } from '../../../agent-
 import { buildStructuralTypeMatch, resolveLegacyStructuralStage } from '../../../agent-runtime/plugin-helpers.js';
 import { buildInteractionQuestions } from '../../../agent-runtime/fallback.js';
 import { buildDefaultReportNarrative } from '../../../agent-runtime/report-template.js';
+import { matchConservativeStructuralRoute } from '../../../agent-runtime/structural-routing.js';
 import type { AppLocale } from '../../../services/locale.js';
 import type {
   DraftExtraction,
@@ -265,9 +266,9 @@ function buildTrussReportNarrative(input: SkillReportNarrativeInput): string {
 
 export const handler: SkillHandler = {
   detectStructuralType({ message, locale }) {
-    const text = message.toLowerCase();
-    if (text.includes('truss') || text.includes('桁架') || text.includes('屋架')) {
-      return buildStructuralTypeMatch('truss', 'truss', 'truss', 'supported', locale);
+    const route = matchConservativeStructuralRoute(message);
+    if (route?.skillId === 'truss') {
+      return buildStructuralTypeMatch('truss', 'truss', 'truss', route.supportLevel, locale, undefined, route.routingSource);
     }
     return null;
   },


### PR DESCRIPTION
## Summary

- Problem: conservative rule-first routing could keep an old stable draft, such as a beam, even when the next message was a broad new structure description.
- Why it matters: users using generic/general flows need the model to decide whether a message is a follow-up or a new structural task before rules lock the state.
- What changed: adds an LLM-first structural router with rule hints/guardrails, wires LangGraph detection/extraction through it, and prevents LLM-suggested generic routes from being overwritten by old draft preservation.
- What did NOT change (scope boundary): parameter extraction, model building, analysis engines, and existing rule-only registry routing remain available as fallback/hints.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: structural type routing was rule-first and could return `current-state` before the LLM evaluated whether the latest message was a follow-up or a new task.
- Missing detection / guardrail: there was no regression test for a stable existing draft followed by a broad new structural description.
- Prior context (`git blame`, prior PR, issue, or refactor if known): current branch introduced conservative routing and exposed the current-state preservation edge case.
- Why this regressed now: preserving stable drafts became broader than explicit follow-up handling.
- If unknown, what was ruled out: targeted runtime probes showed the same broad description routes to generic without current state but to beam when an old beam draft exists.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/src/agent-runtime/__tests__/runtime-helpers.test.mjs`
- Scenario the test should lock in: an old beam draft followed by `办公楼，混凝土柱网，三层` can be routed to generic by the LLM router instead of being locked to beam.
- Why this is the smallest reliable guardrail: it exercises the runtime router and draft-preservation decision directly without requiring a live LLM provider.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Structural type routing now requires a configured LLM for user-facing flows. When configured, the LLM decides whether to continue the current draft, switch skills, route to generic, or ask for clarification; deterministic rules are used as hints/guardrails and fallback after an available LLM fails to produce a usable decision.

## Diagram (if applicable)

```text
Before:
[user message] -> [rule router] -> [current-state may lock old draft]

After:
[user message + current draft + rule hints] -> [LLM router] -> [continue/switch/generic/ask]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: structural routing now makes a structured LLM call using the existing configured provider. The prompt contains the current draft summary, available skill metadata, rule hint, and latest user message; no new credentials or permissions are introduced.

## Repro + Verification

### Environment

- OS: Windows / PowerShell
- Runtime/container: backend TypeScript, Node/Jest
- Model/provider: fake router LLM in regression test; no live provider required for tests
- Integration/channel (if any): backend agent runtime and LangGraph tools
- Relevant config (redacted): no config changes; existing LLM configuration is required for runtime routing

### Steps

1. Start from a stable beam draft.
2. Send a broad new structure description: `办公楼，混凝土柱网，三层`.
3. Route through `detectStructuralTypeWithLlm` with an LLM decision of `generic`.

### Expected

- The route is `generic` with `routingSource: llm-suggested`.
- Old beam draft preservation does not override the LLM-suggested generic route.
- A missing LLM raises a clear configuration error.

### Actual

- Matches expected in the added runtime tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

```text
git diff --check
npm run build --prefix backend
npm run lint --prefix backend
npm test --prefix backend -- --runInBand src/agent-runtime/__tests__/runtime-helpers.test.mjs
```

## Human Verification (required)

- Verified scenarios: LLM-suggested generic routing over an old beam draft; null LLM configuration error; LLM-suggested generic route bypasses old draft preservation.
- Edge cases checked: unsupported rule matches still return before LLM routing; low-confidence/failed LLM decisions still fall back to the rule router after an LLM is available.
- What you did **not** verify: full browser/UI chat flow and live provider behavior with a production model.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No for direct runtime callers that pass `null` LLM into LLM-first routing; normal configured agent flows remain compatible.
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) Yes, only for direct callers/tests that expected rule-only routing with `null` LLM.
- If yes, exact upgrade steps: provide a configured LLM to `detectStructuralTypeWithLlm`/`extractDraftParameters`, or call the explicit rule-only `detectStructuralType` fallback helper intentionally.

## Risks and Mitigations

- Risk: the router adds one LLM decision point before extraction, so provider latency or malformed JSON can affect routing.
  - Mitigation: the router validates confidence and schema-like fields, then falls back to rule routing only after an available LLM fails to produce a usable decision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an LLM routing step and changes when drafts are preserved, which affects orchestration and skill selection; mitigated by unsupported-rule guardrails, confidence checks, rule fallback, and new tests.
> 
> **Overview**
> **Structural type routing** now goes through an LLM router before rules lock draft state. User-facing `detect_structure_type` / `extract_draft_params` and `extractDraftParameters` call `detectStructuralTypeWithLlm` (configured chat model, non-streaming). Unsupported rule hits still short-circuit; otherwise the model chooses continue current draft, switch skill, or generic clarification using draft state, skill metadata, and rule hints, with rule-only fallback if the LLM fails or returns low confidence.
> 
> Adds **`routingSource`** (`explicit-keyword`, `current-state`, `llm-suggested`, `generic-fallback`) on matches and draft state. **`shouldPreserveExistingDraftState`** no longer keeps an old draft when the match is `llm-suggested`, fixing broad new descriptions (e.g. office building + column grid) staying on a prior beam draft.
> 
> Rule detection is centralized in **`structural-routing.ts`** (`matchConservativeStructuralRoute`, explicit-switch detection); structure-type skill handlers delegate to it and no longer do follow-up sticky routing in-plugin. Registry drops the broad `looksLikeCurrentDraftUpdate` auto-continue path in favor of stable-draft + explicit-switch rules for the rule-only path.
> 
> **Requires a configured LLM** for LLM-first routing (clear error if missing). Regression tests cover generic fallback, LLM generic over old beam, and preservation bypass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c675093bb3705c7b84e25f1277d1344297a339ee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->