### PR TITLE
feat: improve generic model coordinate handling

### DIFF
--- a/backend/src/agent-skills/structure-type/generic/__tests__/llm-model-builder.test.mjs
+++ b/backend/src/agent-skills/structure-type/generic/__tests__/llm-model-builder.test.mjs
@@ -14,6 +14,9 @@ describe('generic LLM model builder', () => {
     expect(prompt).toContain('"schema_version":"2.0.0"');
     expect(prompt).toContain('point forces are kN');
     expect(prompt).toContain('distributed member loads are kN/m');
+    expect(prompt).toContain('global-z-up coordinates');
+    expect(prompt).toContain('Create explicit nodes at supports');
+    expect(prompt).toContain('check the total applied load');
     expect(prompt).not.toContain('StructureModel v1');
     expect(prompt).not.toContain('-10000');
   });
@@ -83,6 +86,63 @@ describe('generic LLM model builder', () => {
       node: 'N1',
       fz: '   ',
       unit: 'kN',
+    });
+  });
+
+  test('repairs likely 2D y-up coordinates without moving valid z loads', async () => {
+    const fakeLlm = {
+      async invoke() {
+        return {
+          content: JSON.stringify({
+            schema_version: '2.0.0',
+            unit_system: 'SI',
+            nodes: [
+              { id: 'N1', x: 0, y: 0, z: 0, restraints: [true, true, false, false, false, true] },
+              { id: 'N2', x: 6, y: 0, z: 0 },
+              { id: 'N3', x: 0, y: 4 },
+              { id: 'N4', x: 6, y: 4, z: 0 },
+            ],
+            elements: [
+              { id: 'E1', type: 'beam', nodes: ['N1', 'N3'], material: 'M1', section: 'S1' },
+              { id: 'E2', type: 'beam', nodes: ['N2', 'N4'], material: 'M1', section: 'S1' },
+              { id: 'E3', type: 'beam', nodes: ['N3', 'N4'], material: 'M1', section: 'S1' },
+            ],
+            load_cases: [
+              {
+                id: 'LC1',
+                type: 'other',
+                loads: [
+                  { type: 'nodal', node: 'N4', fx: 50, fy: 0, fz: 0 },
+                  { type: 'distributed', element: 'E3', wy: -8, wz: 0 },
+                  { type: 'nodal', node: 'N3', fy: 0, fz: -10 },
+                  { type: 'nodal', node: 'N4', mz: 5, my: 0 },
+                ],
+              },
+            ],
+          }),
+        };
+      },
+    };
+
+    const model = await tryBuildGenericModelWithLlm(
+      fakeLlm,
+      'Single-bay lateral frame, span 6m, height 4m, lateral 50kN.',
+      { inferredType: 'generic', updatedAt: 0 },
+      'en',
+    );
+
+    expect(model.nodes).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'N1', x: 0, y: 0, z: 0, restraints: [true, false, true, false, true, false] }),
+      expect.objectContaining({ id: 'N3', x: 0, y: 0, z: 4 }),
+      expect.objectContaining({ id: 'N4', x: 6, y: 0, z: 4 }),
+    ]));
+    expect(model.load_cases[0].loads[0]).toMatchObject({ fx: 50, fy: 0, fz: 0 });
+    expect(model.load_cases[0].loads[1]).toMatchObject({ wy: 0, wz: -8 });
+    expect(model.load_cases[0].loads[2]).toMatchObject({ fy: 0, fz: -10 });
+    expect(model.load_cases[0].loads[3]).toMatchObject({ mz: 0, my: 5 });
+    expect(model.metadata).toMatchObject({
+      coordinateSemantics: 'global-z-up',
+      coordinateRepair: 'swapped-y-z-for-2d-vertical-model',
     });
   });
 });

--- a/backend/src/agent-skills/structure-type/generic/llm-model-builder.ts
+++ b/backend/src/agent-skills/structure-type/generic/llm-model-builder.ts
@@ -93,6 +93,7 @@ export async function tryBuildGenericModelWithLlm(
 function canonicalizeGenericModel(model: Record<string, unknown>): void {
   model.schema_version = '2.0.0';
   model.unit_system = 'SI';
+  normalizeLikely2DVerticalAxis(model);
   if (!Array.isArray(model.load_cases)) {
     return;
   }
@@ -108,6 +109,108 @@ function canonicalizeGenericModel(model: Record<string, unknown>): void {
         : [],
     };
   });
+}
+
+function normalizeLikely2DVerticalAxis(model: Record<string, unknown>): void {
+  if (!shouldSwapYzFor2DVerticalModel(model)) {
+    return;
+  }
+
+  const rawNodes = model.nodes;
+  if (!Array.isArray(rawNodes)) {
+    return;
+  }
+  rawNodes.forEach((node) => {
+    if (!node || typeof node !== 'object' || Array.isArray(node)) {
+      return;
+    }
+    const record = node as Record<string, unknown>;
+    const y = coordinateValueOrZero(record.y);
+    const z = coordinateValueOrZero(record.z);
+    record.y = z;
+    record.z = y;
+    normalizeRestraintsVerticalAxis(record);
+  });
+
+  if (Array.isArray(model.load_cases)) {
+    model.load_cases.forEach((loadCase) => {
+      if (!loadCase || typeof loadCase !== 'object' || Array.isArray(loadCase)) {
+        return;
+      }
+      const loads = (loadCase as Record<string, unknown>).loads;
+      if (!Array.isArray(loads)) {
+        return;
+      }
+      loads.forEach(normalizeLoadVerticalAxis);
+    });
+  }
+
+  const metadata = (
+    model.metadata && typeof model.metadata === 'object' && !Array.isArray(model.metadata)
+      ? model.metadata as Record<string, unknown>
+      : {}
+  );
+  metadata.coordinateRepair = 'swapped-y-z-for-2d-vertical-model';
+  model.metadata = metadata;
+}
+
+function shouldSwapYzFor2DVerticalModel(model: Record<string, unknown>): boolean {
+  if (!Array.isArray(model.nodes)) {
+    return false;
+  }
+
+  const nodes = model.nodes.filter((node): node is Record<string, unknown> => (
+    !!node && typeof node === 'object' && !Array.isArray(node)
+  ));
+  if (nodes.length < 2) {
+    return false;
+  }
+
+  const yValues = nodes.map((node) => coordinateValueOrZero(node.y)).filter((value): value is number => value !== null);
+  const zValues = nodes.map((node) => coordinateValueOrZero(node.z)).filter((value): value is number => value !== null);
+  if (yValues.length !== nodes.length || zValues.length !== nodes.length) {
+    return false;
+  }
+
+  const ySpan = valueSpan(yValues);
+  const zSpan = valueSpan(zValues);
+  return ySpan > 0.1 && zSpan < 1e-6;
+}
+
+function normalizeLoadVerticalAxis(load: unknown): void {
+  if (!load || typeof load !== 'object' || Array.isArray(load)) {
+    return;
+  }
+  const record = load as Record<string, unknown>;
+  moveVerticalComponentIfNeeded(record, 'fy', 'fz');
+  moveVerticalComponentIfNeeded(record, 'wy', 'wz');
+  moveVerticalComponentIfNeeded(record, 'qy', 'qz');
+  moveVerticalComponentIfNeeded(record, 'py', 'pz');
+  moveVerticalComponentIfNeeded(record, 'mz', 'my');
+}
+
+function normalizeRestraintsVerticalAxis(record: Record<string, unknown>): void {
+  const restraints = record.restraints;
+  if (!Array.isArray(restraints) || restraints.length !== 6) {
+    return;
+  }
+  swapArrayItems(restraints, 1, 2);
+  swapArrayItems(restraints, 4, 5);
+}
+
+function swapArrayItems(values: unknown[], left: number, right: number): void {
+  const value = values[left];
+  values[left] = values[right];
+  values[right] = value;
+}
+
+function moveVerticalComponentIfNeeded(record: Record<string, unknown>, yKey: string, zKey: string): void {
+  const yValue = toFiniteNumber(record[yKey]);
+  const zValue = toFiniteNumber(record[zKey]);
+  if (yValue !== null && Math.abs(yValue) > 1e-9 && (zValue === null || Math.abs(zValue) <= 1e-9)) {
+    record[zKey] = record[yKey];
+    record[yKey] = typeof record[yKey] === 'string' ? '0' : 0;
+  }
 }
 
 function normalizeLoadRecord(load: unknown): unknown {
@@ -276,6 +379,14 @@ function inferFrameDimension(model: Record<string, unknown>): '2d' | '3d' {
   });
 
   return yValues.size > 1 && zValues.size > 1 ? '3d' : '2d';
+}
+
+function valueSpan(values: number[]): number {
+  return Math.max(...values) - Math.min(...values);
+}
+
+function coordinateValueOrZero(value: unknown): number | null {
+  return value === undefined || value === null ? 0 : toFiniteNumber(value);
 }
 
 function toFiniteNumber(value: unknown): number | null {

--- a/backend/src/agent-skills/structure-type/generic/llm-model-prompt-fragments.ts
+++ b/backend/src/agent-skills/structure-type/generic/llm-model-prompt-fragments.ts
@@ -29,17 +29,23 @@ const STRUCTURE_MODEL_V2_TEMPLATE = JSON.stringify({
 
 const COMMON_CONSTRAINTS_EN = [
   'Output StructureModel V2 with schema_version exactly "2.0.0" and unit_system exactly "SI".',
+  'Use global-z-up coordinates: x is the main horizontal span, z is vertical height, and y is the out-of-plane direction. Put 2D structures in the x-z plane with y=0.',
   'All lengths are meters, point forces are kN, and distributed member loads are kN/m. Never output N or N/m values and never multiply kN values by 1000.',
   'Output only the fields shown in the template. load_case.type must be dead, live, wind, seismic, or other.',
   'Prohibited alternate field names: material_id->material, section_id->section, coordinates->x/y/z, boundary_conditions->restraints, elastic_modulus->E, poisson_ratio->nu, density->rho, yield_strength->fy.',
+  'Create explicit nodes at supports, concentrated loads, span boundaries, member intersections, and geometry break points so analysis result locations are computable.',
+  'Before output, check the total applied load against the user request. Do not apply the same physical load twice as both nodal and distributed loads.',
   'For partial-span distributed loads, split the member into separate elements. Only use nodal and distributed as load types; do not use nodal_force, line_load, element_uniform_load, or uniform_load.',
 ];
 
 const COMMON_CONSTRAINTS_ZH = [
   '输出 StructureModel V2，schema_version 必须是 "2.0.0"，unit_system 必须是 "SI"。',
+  '使用 global-z-up 坐标：x 为主要水平跨度，z 为竖向高度，y 为平面外方向。二维结构应位于 x-z 平面，y=0。',
   '所有长度使用 m，集中力使用 kN，构件均布荷载使用 kN/m。不要输出 N 或 N/m，也不要把 kN 数值乘以 1000。',
   '严格输出模板中的字段和层级。load_case.type 只能是 dead/live/wind/seismic/other。',
   '禁止替代字段名：material_id->material, section_id->section, coordinates->x/y/z, boundary_conditions->restraints, elastic_modulus->E, poisson_ratio->nu, density->rho, yield_strength->fy。',
+  '在支座、集中荷载、跨界、构件交点和几何转折处建立显式节点，保证分析结果位置可计算。',
+  '输出前核对总施加荷载与用户描述是否一致。不要把同一个物理荷载同时作为节点荷载和构件均布荷载重复施加。',
   '局部均布荷载不要在单元内设起止位置，应拆分单元后对目标单元施加 distributed 荷载。只使用 nodal 和 distributed，不要使用 nodal_force/line_load/element_uniform_load/uniform_load 等类型名。',
 ];
 


### PR DESCRIPTION
## Summary

- Problem: Generic-only model generation could emit 2D engineering models with `y` as the vertical axis, while the runtime and benchmark assertions expect global `z` up.
- Why it matters: This made otherwise reasonable generic LLM outputs fail model matching and could produce misleading analysis geometry.
- What changed: The generic model prompt now states global-z-up coordinates, explicit node placement, and load total checks; canonicalization now repairs likely 2D y-up outputs and preserves already-correct z loads.
- What did NOT change (scope boundary): No specialist extraction rules, benchmark fixtures, benchmark results, routing behavior, or submodule pointer changes are included.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The generic LLM model prompt did not make the runtime coordinate convention explicit enough, and canonicalization accepted likely 2D y-up outputs as-is.
- Missing detection / guardrail: There was no focused unit test for y-up generic output being normalized into the z-up model contract.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Observed while comparing standard_workflow generic-only benchmark failures after benchmark assertions were cleaned up.
- Why this regressed now: The issue became visible when generic-only scenarios were evaluated without specialist skills and benchmark checks enforced y-span/height semantics.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/src/agent-skills/structure-type/generic/__tests__/llm-model-builder.test.mjs`
- Scenario the test should lock in: A likely 2D y-up model has node coordinates swapped to z-up, y vertical loads moved to z only when z is absent, and valid existing z loads preserved.
- Why this is the smallest reliable guardrail: The bug is in generic model prompt/canonicalization, so a direct builder test isolates the contract without depending on live LLM variance.
- Existing test that already covers this (if any): Existing generic builder tests covered schema prompt constraints and load normalization, but not coordinate-axis repair.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Generic-only structural modeling is more likely to produce z-up 2D models that match runtime analysis expectations. No UI, API, or configuration changes.

## Diagram (if applicable)

N/A

```text
Before:
[user prompt] -> [generic LLM emits y-up 2D model] -> [runtime keeps y-up geometry] -> [height/y-span mismatch]

After:
[user prompt] -> [generic LLM instructed to emit z-up model] -> [likely y-up output repaired] -> [z-up analysis model]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows / PowerShell
- Runtime/container: Local Node.js backend test runner and benchmark runner
- Model/provider: `glm-5-turbo` via OpenAI-compatible Zhipu endpoint for probe runs; `DeepSeek-V4-Pro` judge where benchmark runner used judge config
- Integration/channel (if any): `standard_workflow` benchmark, `generic-only` mode
- Relevant config (redacted): LLM API keys present through environment variables; no config changes in this PR

### Steps

1. Run backend TypeScript build.
2. Run focused generic model builder and handler tests.
3. Probe three previously failing generic-only benchmark scenarios.

### Expected

- Generic model builder tests pass.
- Previously failing y/z-axis examples produce z-up geometry and pass model matching.

### Actual

- `npm run build --prefix backend` passed.
- `npm test --prefix backend -- --runInBand src/agent-skills/structure-type/generic/__tests__/llm-model-builder.test.mjs` passed.
- `npm test --prefix backend -- --runInBand src/agent-skills/structure-type/generic/__tests__/handler.test.mjs` passed.
- `std-generic-single-bay-lateral#generic-only` passed.
- `portal-frame-static-18m#generic-only` passed.
- `truss-roof-en#generic-only` passed with `y-span: 0.0/0.0m`, `height: 3.0/3.0m`, and `load: 60/60kN`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Focused backend build/tests plus three generic-only benchmark probes: `std-generic-single-bay-lateral`, `portal-frame-static-18m`, and `truss-roof-en`.
- Edge cases checked: Existing z-axis loads are preserved when a y-up coordinate repair is applied; y-axis load components are moved only when the z component is absent or zero.
- What you did **not** verify: Full 50-scenario standard benchmark rerun after this code change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A rare intentional 2D y-vertical model with flat z coordinates could be interpreted as a y-up mistake.
  - Mitigation: The repair is limited to models where all nodes are finite, y has span, z is effectively flat, and load components are moved only when the z component is missing or zero. The prompt also makes the expected z-up convention explicit so compliant outputs do not need repair.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Heuristic y/z repair could mis-handle rare intentional flat-z y-vertical models, though triggers are narrow and metadata records when repair runs.
> 
> **Overview**
> Generic-only LLM structural models now align with the runtime **global-z-up** convention instead of often emitting 2D **y-up** geometry that broke benchmarks and analysis.
> 
> **Prompt** constraints (EN/ZH) now require **global-z-up** (2D in the x–z plane), explicit nodes at supports/loads/break points, and a sanity check that total applied load matches the user request without double-counting.
> 
> **Canonicalization** in `canonicalizeGenericModel` detects likely 2D y-vertical models (y span, flat z), swaps node **y/z**, adjusts six-DOF **restraints**, moves vertical load/moment components from y to z only when z is missing/zero, and records `metadata.coordinateRepair`. Existing z loads are left unchanged.
> 
> New unit tests cover the expanded prompt text and the repair path for a lateral frame example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19962eedac5108d4a5b231213ce5b6af42e4c4e0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->