### PR TITLE
fix(backend): handle aborts and detach YJK launcher

### DIFF
--- a/backend/src/agent-langgraph/__tests__/analysis-tool-summary.test.mjs
+++ b/backend/src/agent-langgraph/__tests__/analysis-tool-summary.test.mjs
@@ -77,6 +77,53 @@ describe("analysis tool summary", () => {
     });
   });
 
+  test("does not retry analysis engine requests after abort", async () => {
+    const { createRunAnalysisTool } = await import("../../../dist/agent-langgraph/tools.js");
+    const abortController = new AbortController();
+    const abortError = new Error("analysis aborted");
+    abortError.name = "AbortError";
+    let postCalls = 0;
+    const runAnalysis = createRunAnalysisTool({
+      async executeAnalysisSkill({ postToEngineWithRetry, signal }) {
+        return postToEngineWithRetry("/analyze", {}, {
+          retries: 2,
+          traceId: "test-trace",
+          tool: "run_analysis",
+          signal,
+        });
+      },
+    });
+
+    await expect(runAnalysis.invoke({ analysisType: "static" }, {
+      signal: abortController.signal,
+      toolCall: { id: "call-test" },
+      configurable: {
+        skillScope: ["opensees-static"],
+        agentState: {
+          lastUserMessage: "Run static analysis",
+          model: {
+            schemaVersion: "2.0.0",
+            nodes: [],
+            elements: [],
+            materials: [],
+            sections: [],
+            loadCases: [],
+            loadCombinations: [],
+          },
+        },
+        engineClient: {
+          post() {
+            postCalls += 1;
+            abortController.abort(abortError);
+            throw abortError;
+          },
+        },
+      },
+    })).rejects.toThrow("analysis aborted");
+
+    expect(postCalls).toBe(1);
+  });
+
   test("surfaces failed analysis artifact feedback to the model", async () => {
     const { buildAnalysisToolSummary } = await import("../../../dist/agent-langgraph/tools.js");
 

--- a/backend/src/agent-langgraph/agent-service.ts
+++ b/backend/src/agent-langgraph/agent-service.ts
@@ -361,6 +361,7 @@ export class LangGraphAgentService {
   private buildGraphRuntimeConfig(input?: LangGraphRunInput, traceId?: string, conversationId?: string) {
     return {
       recursionLimit: getLangGraphRecursionLimit(config.agentMaxToolCallsPerTurn),
+      signal: input?.signal,
       configurable: {
         thread_id: conversationId,
         ...this.buildConfigurable(input, traceId, conversationId),

--- a/backend/src/agent-langgraph/tools.ts
+++ b/backend/src/agent-langgraph/tools.ts
@@ -1297,11 +1297,14 @@ export function createRunAnalysisTool(skillRuntime: AgentSkillRuntime) {
       ) => {
         let lastError: unknown;
         for (let attempt = 0; attempt <= opts.retries; attempt++) {
+          if (opts.signal?.aborted) {
+            throw opts.signal.reason ?? new Error('Analysis request aborted');
+          }
           try {
             return await engineClient.post(p, payload, { signal: opts.signal });
           } catch (error) {
             lastError = error;
-            if (attempt === opts.retries) throw error;
+            if (opts.signal?.aborted || attempt === opts.retries) throw error;
           }
         }
         throw lastError;
@@ -1319,6 +1322,7 @@ export function createRunAnalysisTool(skillRuntime: AgentSkillRuntime) {
         analysisSkillId: requestedAnalysisSkillId,
         skillIds,
         postToEngineWithRetry,
+        signal: config.signal,
       });
 
       // Store analysis result in graph state via Command.

--- a/backend/src/agent-skills/analysis/yjk-static/yjk_driver.py
+++ b/backend/src/agent-skills/analysis/yjk-static/yjk_driver.py
@@ -377,9 +377,22 @@ def _stop_process(pid: int) -> bool:
         return False
 
 
-def _prewarm_yjk_launcher(yjks_root: str, steps: list[dict]) -> bool:
+def _popen_gui_detached(args: list[str], cwd: str):
     import subprocess
 
+    kwargs = {
+        "cwd": cwd,
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "close_fds": True,
+    }
+    if os.name == "nt":
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    return subprocess.Popen(args, **kwargs)
+
+
+def _prewarm_yjk_launcher(yjks_root: str, steps: list[dict]) -> bool:
     launcher = _find_yjk_launcher(yjks_root)
     if not launcher:
         _record_step(
@@ -398,7 +411,7 @@ def _prewarm_yjk_launcher(yjks_root: str, steps: list[dict]) -> bool:
     cwd = _env_path("YJK_LAUNCHER_CWD") or yjks_root
     try:
         if existing_pid <= 0:
-            proc = subprocess.Popen([launcher], cwd=cwd)
+            proc = _popen_gui_detached([launcher], cwd)
             pid = proc.pid
             message = "Started official YJK launcher and kept it alive for authorization."
         else:
@@ -613,8 +626,6 @@ def _launch_yjk_with_launcher_and_attach(
     yjks_control: object,
     steps: list[dict],
 ) -> str | None:
-    import subprocess
-
     launcher = _find_yjk_launcher(yjks_root)
     if not launcher:
         _record_step(
@@ -635,7 +646,7 @@ def _launch_yjk_with_launcher_and_attach(
     started_at = time.monotonic()
     cwd = _env_path("YJK_LAUNCHER_CWD") or yjks_root
     try:
-        subprocess.Popen([launcher], cwd=cwd)
+        _popen_gui_detached([launcher], cwd)
     except Exception as exc:
         _record_step(
             steps,


### PR DESCRIPTION
## Summary

- Problem: Aborted benchmark or chat runs can leave analysis requests running, and YJK GUI launcher subprocesses can inherit backend pipes.
- Why it matters: Lingering analysis calls make supervised runs harder to stop cleanly, while inherited launcher pipes can keep parent processes or log readers attached longer than intended.
- What changed: Propagated the run `AbortSignal` into LangGraph runtime config and `run_analysis`, and detached YJK launcher stdin/stdout/stderr when launching GUI processes.
- What did NOT change (scope boundary): No benchmark fixtures, model-building behavior, skill routing, frontend UI, or runtime configuration defaults are changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The request abort signal was available at the chat entry point but was not passed all the way into graph runtime and analysis tool execution. The YJK launcher was started as a normal child process with inherited pipes.
- Missing detection / guardrail: Existing checks did not cover cancellation propagation through the LangGraph tool path or GUI launcher pipe ownership.
- Prior context (`git blame`, prior PR, issue, or refactor if known): These fixes were present only on the fork `master`; this PR isolates them from merge-only history so upstream can review the actual changes.
- Why this regressed now: Benchmark supervision and YJK launcher handling exposed lifecycle cleanup gaps that normal successful runs do not exercise.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/src/agent-langgraph/__tests__/analysis-tool-summary.test.mjs`, plus a future Windows YJK launcher integration check.
- Scenario the test should lock in: Aborting a run cancels downstream analysis requests, and launching YJK does not attach backend stdio pipes.
- Why this is the smallest reliable guardrail: These behaviors depend on runtime cancellation and OS process handling rather than pure data transforms.
- Existing test that already covers this (if any): None identified.
- If no new test is added, why not: The PR preserves existing small fixes from the fork; local validation used backend TypeScript build, while CI covers backend regression and install smoke paths.

## User-visible / Behavior Changes

No UI or API contract changes. Aborted runs should stop more cleanly, and YJK launcher startup should be less likely to hold backend process pipes open.

## Diagram (if applicable)

```text
Before:
[request abort] -> [graph run stops] -> [analysis request may continue]
[YJK launch] -> [launcher inherits backend pipes]

After:
[request abort] -> [graph runtime signal] -> [run_analysis signal] -> [analysis request can abort]
[YJK launch] -> [detached launcher stdio] -> [parent process can exit cleanly]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows / PowerShell
- Runtime/container: Local Node.js backend build
- Model/provider: N/A
- Integration/channel (if any): LangGraph runtime and YJK static analysis launcher path
- Relevant config (redacted): N/A

### Steps

1. Create a clean branch from `upstream/master`.
2. Cherry-pick only the two runtime lifecycle fixes from the fork.
3. Run backend TypeScript build.

### Expected

- PR contains only the two intended runtime lifecycle fixes.
- Backend TypeScript build passes.

### Actual

- PR diff is limited to `backend/src/agent-langgraph/agent-service.ts`, `backend/src/agent-langgraph/tools.ts`, and `backend/src/agent-skills/analysis/yjk-static/yjk_driver.py`.
- `npm run build --prefix backend` passed.`n- `npm test --prefix backend -- --runInBand src/agent-langgraph/__tests__/analysis-tool-summary.test.mjs` passed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Confirmed the branch contains only two cherry-picked commits, ran `npm run build --prefix backend`, and ran the targeted `analysis-tool-summary.test.mjs` Jest file.
- Edge cases checked: PR branch is based on `upstream/master`, not fork `master`, so merge-only commits are excluded.
- What you did **not** verify: Manual YJK GUI launcher behavior on a YJK-installed machine, full benchmark cancellation behavior, or full backend regression suite locally. GitHub Actions passed the backend regression, analysis regression, and native install smoke checks.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Cancellation propagation relies on downstream clients honoring `AbortSignal`.
  - Mitigation: The signal is passed through existing runtime/tool option paths without changing normal successful execution.
- Risk: YJK launcher behavior can vary by Windows environment.
  - Mitigation: The change only detaches stdio and process group ownership; launcher command and working directory discovery remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration cancellation and Windows subprocess lifecycle for YJK; behavior depends on downstream honoring AbortSignal and local YJK launcher environments.
> 
> **Overview**
> **Aborted chat/benchmark runs** can now cancel in-flight analysis instead of leaving engine calls running after the graph stops. The request **`AbortSignal`** is wired from **`buildGraphRuntimeConfig`** into LangGraph invoke/stream config and from **`run_analysis`** into **`executeAnalysisSkill`** / engine **`post`** retries.
> 
> **YJK GUI launcher** startup no longer inherits the backend’s stdin/stdout/stderr. **`_popen_gui_detached`** redirects those streams to **`DEVNULL`**, uses **`close_fds`**, and on Windows sets **`CREATE_NEW_PROCESS_GROUP`** for both launcher prewarm and launcher attach paths in **`yjk_driver.py`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f81d7a2c9ae4fb57df46cc0a9333f6d896a86d3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->