### PR TITLE
fix(backend): honor generic LLM declared structure types

### DIFF
--- a/backend/src/agent-skills/structure-type/generic/__tests__/handler.test.mjs
+++ b/backend/src/agent-skills/structure-type/generic/__tests__/handler.test.mjs
@@ -78,18 +78,18 @@ describe('generic structure-type handler', () => {
         engineeringDraft: {
           structureType: 'truss',
           geometry: {
-            lengthM: 18,
-            heightM: 3,
-            spanLengthsM: [3, 3, 3, 3, 3, 3],
+            lengthM: '18',
+            heightM: '3',
+            spanLengthsM: ['3', '3', '3', '3', '3', '3'],
           },
           loads: [
             {
               kind: 'nodal',
-              magnitude: 12,
+              magnitude: '12',
               unit: 'kN',
               direction: 'gravity',
               target: 'top-chord-node',
-              location: { xM: 3 },
+              location: { xM: '3' },
             },
           ],
           analysis: { type: 'static' },
@@ -167,6 +167,58 @@ describe('generic structure-type handler', () => {
     }));
     expect(state.engineeringDraft?.structureType).toBe('steel-frame');
     expect(handler.computeMissing(state, 'execution').critical).toEqual([]);
+  });
+
+  test('maps explicit generic engineeringDraft aliases without scanning user text', () => {
+    const portalPatch = handler.extractDraft({
+      message: 'unused',
+      locale: 'en',
+      llmDraftPatch: {
+        engineeringDraft: {
+          structureType: 'portal',
+          geometry: {
+            spanLengthsM: [18],
+            heightM: 6,
+          },
+          loads: [{ kind: 'line', magnitude: 8, unit: 'kN/m', direction: 'gravity' }],
+        },
+      },
+      structuralTypeMatch: {
+        key: 'unknown',
+        mappedType: 'unknown',
+        skillId: 'generic',
+        supportLevel: 'fallback',
+      },
+    });
+    const girderPatch = handler.extractDraft({
+      message: 'unused',
+      locale: 'en',
+      llmDraftPatch: {
+        engineeringDraft: {
+          structureType: 'girder',
+          geometry: { lengthM: 12 },
+          loads: [{ kind: 'line', magnitude: 5, unit: 'kN/m', direction: 'gravity' }],
+        },
+      },
+      structuralTypeMatch: {
+        key: 'unknown',
+        mappedType: 'unknown',
+        skillId: 'generic',
+        supportLevel: 'fallback',
+      },
+    });
+
+    expect(portalPatch).toEqual(expect.objectContaining({
+      inferredType: 'portal-frame',
+      spanLengthM: 18,
+      heightM: 6,
+      loadKN: 8,
+    }));
+    expect(girderPatch).toEqual(expect.objectContaining({
+      inferredType: 'beam',
+      lengthM: 12,
+      loadKN: 5,
+    }));
   });
 
   test('does not infer draft parameters from the raw message', () => {

--- a/backend/src/agent-skills/structure-type/generic/__tests__/handler.test.mjs
+++ b/backend/src/agent-skills/structure-type/generic/__tests__/handler.test.mjs
@@ -70,6 +70,105 @@ describe('generic structure-type handler', () => {
     expect(missing.critical).toEqual([]);
   });
 
+  test('uses LLM engineeringDraft structure type while staying on generic skill', () => {
+    const patch = handler.extractDraft({
+      message: '这条用户消息不参与参数抽取',
+      locale: 'en',
+      llmDraftPatch: {
+        engineeringDraft: {
+          structureType: 'truss',
+          geometry: {
+            lengthM: 18,
+            heightM: 3,
+            spanLengthsM: [3, 3, 3, 3, 3, 3],
+          },
+          loads: [
+            {
+              kind: 'nodal',
+              magnitude: 12,
+              unit: 'kN',
+              direction: 'gravity',
+              target: 'top-chord-node',
+              location: { xM: 3 },
+            },
+          ],
+          analysis: { type: 'static' },
+        },
+      },
+      structuralTypeMatch: {
+        key: 'unknown',
+        mappedType: 'unknown',
+        skillId: 'generic',
+        supportLevel: 'fallback',
+      },
+    });
+
+    const state = handler.mergeState(undefined, patch);
+    const missing = handler.computeMissing(state, 'execution');
+
+    expect(patch).toEqual(expect.objectContaining({
+      inferredType: 'truss',
+      lengthM: 18,
+      heightM: 3,
+      bayCount: 6,
+      loadKN: 12,
+    }));
+    expect(state).toEqual(expect.objectContaining({
+      inferredType: 'truss',
+      skillId: 'generic',
+      structuralTypeKey: 'truss',
+    }));
+    expect(state.engineeringDraft?.structureType).toBe('truss');
+    expect(state.skillState?.genericDraft).toEqual(expect.objectContaining({
+      engineeringDraft: expect.objectContaining({ structureType: 'truss' }),
+    }));
+    expect(missing.critical).toEqual([]);
+  });
+
+  test('maps LLM steel-frame engineeringDraft to generic frame family', () => {
+    const patch = handler.extractDraft({
+      message: '这条用户消息不参与参数抽取',
+      locale: 'zh',
+      llmDraftPatch: {
+        engineeringDraft: {
+          structureType: 'steel-frame',
+          geometry: {
+            storyHeightsM: [3.3, 3.3],
+            bayWidthsM: [6],
+          },
+          loads: [
+            {
+              kind: 'line',
+              magnitude: 15,
+              unit: 'kN/m',
+              direction: 'gravity',
+              target: 'floor',
+            },
+          ],
+        },
+      },
+      structuralTypeMatch: {
+        key: 'unknown',
+        mappedType: 'unknown',
+        skillId: 'generic',
+        supportLevel: 'fallback',
+      },
+    });
+
+    const state = handler.mergeState(undefined, patch);
+
+    expect(state).toEqual(expect.objectContaining({
+      inferredType: 'frame',
+      skillId: 'generic',
+      structuralTypeKey: 'frame',
+      frameDimension: '2d',
+      storyCount: 2,
+      bayCount: 1,
+    }));
+    expect(state.engineeringDraft?.structureType).toBe('steel-frame');
+    expect(handler.computeMissing(state, 'execution').critical).toEqual([]);
+  });
+
   test('does not infer draft parameters from the raw message', () => {
     const patch = handler.extractDraft({
       message: '简支梁，跨度10m，梁中间荷载1kN',

--- a/backend/src/agent-skills/structure-type/generic/handler.ts
+++ b/backend/src/agent-skills/structure-type/generic/handler.ts
@@ -8,12 +8,14 @@ import {
   normalizeNumber,
   normalizeSupportType,
 } from '../../../agent-runtime/fallback.js';
-import { projectEngineeringDraftToLegacyPatch } from '../../../agent-runtime/engineering-draft.js';
+import {
+  normalizeEngineeringDraft,
+  projectEngineeringDraftToLegacyPatch,
+} from '../../../agent-runtime/engineering-draft.js';
 import { buildStructuralTypeMatch } from '../../../agent-runtime/plugin-helpers.js';
 import type {
   DraftExtraction,
   DraftState,
-  EngineeringDraft,
   InferredModelType,
   SkillHandler,
   SkillReportNarrativeInput,
@@ -55,11 +57,9 @@ function normalizeLlmDeclaredType(value: unknown): InferredModelType | undefined
   ) {
     return 'frame';
   }
+  if (normalizedText === 'portal') return 'portal-frame';
+  if (normalizedText === 'girder') return 'beam';
   return undefined;
-}
-
-function asEngineeringDraft(value: unknown): EngineeringDraft | undefined {
-  return asRecord(value) as EngineeringDraft | undefined;
 }
 
 function draftIssuesFromSource(source: Record<string, unknown>): DraftExtraction['draftIssues'] {
@@ -104,7 +104,7 @@ function normalizeGenericDraftPatch(
   llmDraftPatch: Record<string, unknown> | null | undefined,
 ): DraftExtraction {
   const source = llmDraftPatch ?? {};
-  const engineeringDraft = asEngineeringDraft(source.engineeringDraft);
+  const engineeringDraft = normalizeEngineeringDraft(source.engineeringDraft);
   const pointLoad = firstRecord(source.pointLoads ?? source.point_loads);
   const distributedLoad = firstRecord(source.distributedLoads ?? source.distributed_loads);
   const span = normalizeNumber(source.lengthM ?? source.spanLengthM ?? source.span ?? source.length);

--- a/backend/src/agent-skills/structure-type/generic/handler.ts
+++ b/backend/src/agent-skills/structure-type/generic/handler.ts
@@ -8,10 +8,12 @@ import {
   normalizeNumber,
   normalizeSupportType,
 } from '../../../agent-runtime/fallback.js';
+import { projectEngineeringDraftToLegacyPatch } from '../../../agent-runtime/engineering-draft.js';
 import { buildStructuralTypeMatch } from '../../../agent-runtime/plugin-helpers.js';
 import type {
   DraftExtraction,
   DraftState,
+  EngineeringDraft,
   InferredModelType,
   SkillHandler,
   SkillReportNarrativeInput,
@@ -41,15 +43,41 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === 'string' ? value.trim() : undefined;
 }
 
-function inferTypeFromText(value: unknown): InferredModelType | undefined {
-  const text = stringValue(value)?.toLowerCase();
-  if (!text) return undefined;
-  if (text.includes('column') || text.includes('柱')) return 'column';
-  if (text.includes('beam') || text.includes('梁')) return 'beam';
-  if (text.includes('truss') || text.includes('桁架')) return 'truss';
-  if (text.includes('portal') || text.includes('门式') || text.includes('刚架')) return 'portal-frame';
-  if (text.includes('frame') || text.includes('框架')) return 'frame';
-  return normalizeInferredType(text);
+function normalizeLlmDeclaredType(value: unknown): InferredModelType | undefined {
+  const normalizedText = stringValue(value)?.toLowerCase().trim();
+  if (!normalizedText) return undefined;
+  const normalized = normalizeInferredType(normalizedText);
+  if (normalized && normalized !== 'unknown') return normalized;
+  if (
+    normalizedText === 'steel-frame'
+    || normalizedText === 'concrete-frame'
+    || normalizedText === 'reinforced-concrete-frame'
+  ) {
+    return 'frame';
+  }
+  return undefined;
+}
+
+function asEngineeringDraft(value: unknown): EngineeringDraft | undefined {
+  return asRecord(value) as EngineeringDraft | undefined;
+}
+
+function draftIssuesFromSource(source: Record<string, unknown>): DraftExtraction['draftIssues'] {
+  const issues = source.draftIssues;
+  if (!Array.isArray(issues)) {
+    return undefined;
+  }
+  return issues.filter((issue): issue is NonNullable<DraftExtraction['draftIssues']>[number] => (
+    !!issue && typeof issue === 'object' && !Array.isArray(issue)
+  ));
+}
+
+function genericSkillStateFromSource(source: Record<string, unknown>): Record<string, unknown> {
+  const sourceSkillState = asRecord(source.skillState);
+  return {
+    ...(sourceSkillState ?? {}),
+    genericDraft: source,
+  };
 }
 
 function inferSupportTypeFromText(value: unknown): DraftExtraction['supportType'] {
@@ -76,6 +104,7 @@ function normalizeGenericDraftPatch(
   llmDraftPatch: Record<string, unknown> | null | undefined,
 ): DraftExtraction {
   const source = llmDraftPatch ?? {};
+  const engineeringDraft = asEngineeringDraft(source.engineeringDraft);
   const pointLoad = firstRecord(source.pointLoads ?? source.point_loads);
   const distributedLoad = firstRecord(source.distributedLoads ?? source.distributed_loads);
   const span = normalizeNumber(source.lengthM ?? source.spanLengthM ?? source.span ?? source.length);
@@ -99,13 +128,17 @@ function normalizeGenericDraftPatch(
   const explicitType = normalizeInferredType(source.inferredType);
   const inferredType =
     (explicitType && explicitType !== 'unknown' ? explicitType : undefined)
-    ?? inferTypeFromText(source.componentType)
-    ?? inferTypeFromText(source.structureType)
-    ?? inferTypeFromText(source.structuralType)
-    ?? inferTypeFromText(source.type);
+    ?? normalizeLlmDeclaredType(engineeringDraft?.structureType)
+    ?? normalizeLlmDeclaredType(source.componentType)
+    ?? normalizeLlmDeclaredType(source.structureType)
+    ?? normalizeLlmDeclaredType(source.structuralType)
+    ?? normalizeLlmDeclaredType(source.type);
 
   const patch: DraftExtraction = {};
   if (inferredType) patch.inferredType = inferredType;
+  if (engineeringDraft) patch.engineeringDraft = engineeringDraft;
+  const draftIssues = draftIssuesFromSource(source);
+  if (draftIssues?.length) patch.draftIssues = draftIssues;
   if (span !== undefined) patch.lengthM = span;
   if (loadValue !== undefined) patch.loadKN = loadValue;
   if (loadType) patch.loadType = loadType;
@@ -127,11 +160,9 @@ function normalizeGenericDraftPatch(
   if (loadPositionM !== undefined) patch.loadPositionM = loadPositionM;
 
   if (Object.keys(source).length > 0) {
-    patch.skillState = {
-      genericDraft: source,
-    };
+    patch.skillState = genericSkillStateFromSource(source);
   }
-  return patch;
+  return inferredType ? projectEngineeringDraftToLegacyPatch(patch, inferredType) : patch;
 }
 
 function buildGenericReportNarrative(input: SkillReportNarrativeInput): string {


### PR DESCRIPTION
## Summary

- Problem: generic-only extraction accepted LLM engineering drafts but did not bridge `engineeringDraft.structureType` into the internal `inferredType`, so clear LLM-declared structures stayed `unknown` and stopped at clarification.
- Why it matters: generic-only benchmark cases that the LLM already understood could fail as no-model/no-analysis before generic model building was attempted.
- What changed: the generic handler now accepts explicit LLM-declared structure type enum values from structured output, projects engineering drafts through the existing legacy patch bridge, and preserves `skillId: generic`.
- What did NOT change (scope boundary): this does not route to specialist beam/frame/truss handlers and does not infer structure type from raw user text.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: generic extraction prompt asks the LLM to prefer `engineeringDraft`, but the generic handler only normalized legacy top-level type fields into `inferredType`.
- Missing detection / guardrail: there was no unit test covering LLM output that only declared the type in `engineeringDraft.structureType`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: generic-only benchmark coverage exposed the mismatch between the structured extraction contract and the generic handler adapter.
- If unknown, what was ruled out: checkpoint inspection showed the LLM did declare concrete types such as `truss`, so the failure was not simply an LLM inability to classify the request.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/src/agent-skills/structure-type/generic/__tests__/handler.test.mjs`
- Scenario the test should lock in: generic handler maps explicit LLM `engineeringDraft.structureType` values to internal model families while keeping `skillId: generic`.
- Why this is the smallest reliable guardrail: it exercises the adapter boundary directly without requiring an external model call.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Generic-only structural requests that have an explicit LLM-declared engineering draft type can proceed to generic model building instead of asking for the structural system again.

## Diagram (if applicable)

```text
Before:
LLM engineeringDraft.structureType="truss" -> inferredType="unknown" -> clarification

After:
LLM engineeringDraft.structureType="truss" -> inferredType="truss" with skillId="generic" -> generic build_model
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node.js backend test runner
- Model/provider: `glm-5-turbo` via OpenAI-compatible endpoint for benchmark spot checks
- Integration/channel (if any): generic-only LLM benchmark runner
- Relevant config (redacted): API keys present in local environment, values not included

### Steps

1. Run the generic handler unit test.
2. Run `truss-roof-en#generic-only` as a spot benchmark case.
3. Run `beam-static-with-report#generic-only` as a second spot benchmark case.

### Expected

- LLM-declared engineering draft types should clear `criticalMissing: ["inferredType"]` without switching away from generic.
- Previously no-model cases should proceed to generic build/analyze/report when the LLM supplies enough structured data.

### Actual

- `truss-roof-en#generic-only` now clears `criticalMissing`, builds a generic model, runs analysis, generates a report, and passes.
- `beam-static-with-report#generic-only` now clears `criticalMissing` and builds/analyzes/reports; it still fails model-match on LLM-generated beam discretization (`2 nodes / 1 element` vs expected `>=3 nodes / >=2 elements`).

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `npm test --prefix backend -- --runInBand backend/src/agent-skills/structure-type/generic/__tests__/handler.test.mjs`
  - `npm run experiment -- --suite standard --mode generic-only --scenario truss-roof-en --case-timeout-ms 600000`
  - `npm run experiment -- --suite standard --mode generic-only --scenario beam-static-with-report --case-timeout-ms 600000`
- Edge cases checked: explicit `truss` and `steel-frame` LLM-declared types; confirmed `skillId` remains `generic`.
- What you did **not** verify: full 50-case generic-only benchmark after this patch.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: malformed LLM type aliases could be over-accepted.
  - Mitigation: only explicit enum values and known structured aliases (`steel-frame`, `concrete-frame`, `reinforced-concrete-frame`) are accepted; raw user text is not scanned for type keywords.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped adapter change in generic draft extraction with explicit type allowlisting and no new external surfaces; wrong alias mapping could mis-route generic builds but does not touch auth or data stores.
> 
> **Overview**
> Fixes a mismatch where the generic skill accepted LLM `engineeringDraft` payloads but never mapped `engineeringDraft.structureType` into `inferredType`, so generic-only flows could stall on structural-system clarification even when the model had already classified the structure.
> 
> **`normalizeGenericDraftPatch`** now derives `inferredType` from explicit LLM-declared types via `normalizeLlmDeclaredType` (including `steel-frame` / `concrete-frame` → `frame`), passes through `engineeringDraft` and `draftIssues`, and when a type is known runs **`projectEngineeringDraftToLegacyPatch`** so geometry/loads populate legacy fields (e.g. truss bays, frame story/bay counts) while **`skillId` stays `generic`**. Text-based type inference on LLM string fields is removed in favor of structured declarations only.
> 
> Unit tests lock in truss and steel-frame `engineeringDraft` paths clearing `critical` missing `inferredType`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add40272c8b005e91d43b27da2f5586f1a7b3629. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->