### PR TITLE
fix(backend): allow omitting LLM temperature

### DIFF
--- a/backend/src/utils/__tests__/llm-options.test.mjs
+++ b/backend/src/utils/__tests__/llm-options.test.mjs
@@ -15,8 +15,33 @@ describe('LLM model options', () => {
 
     const options = buildChatModelOptions(baseConfig, 0.2);
 
+    expect(options.temperature).toBe(0.2);
     expect(options.disableStreaming).toBe(false);
     expect(options.streaming).toBeUndefined();
+  });
+
+  test('can omit temperature for configured OpenAI-compatible model aliases', async () => {
+    const previous = process.env.LLM_OMIT_TEMPERATURE_MODELS;
+    process.env.LLM_OMIT_TEMPERATURE_MODELS = 'claude-opus-4-8';
+    try {
+      const { buildChatModelOptions, shouldOmitTemperature } = await import('../../../dist/utils/llm.js');
+
+      const claudeOptions = buildChatModelOptions({
+        ...baseConfig,
+        llmModel: 'claude-opus-4-8',
+      }, 0);
+      const glmOptions = buildChatModelOptions(baseConfig, 0);
+
+      expect(shouldOmitTemperature('claude-opus-4-8')).toBe(true);
+      expect(claudeOptions).not.toHaveProperty('temperature');
+      expect(glmOptions.temperature).toBe(0);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.LLM_OMIT_TEMPERATURE_MODELS;
+      } else {
+        process.env.LLM_OMIT_TEMPERATURE_MODELS = previous;
+      }
+    }
   });
 
   test('can disable LangChain invoke streaming for graph-state correctness', async () => {

--- a/backend/src/utils/__tests__/llm-options.test.mjs
+++ b/backend/src/utils/__tests__/llm-options.test.mjs
@@ -44,6 +44,38 @@ describe('LLM model options', () => {
     }
   });
 
+  test('does not omit temperature for broad substring-only alias matches', async () => {
+    const previous = process.env.LLM_OMIT_TEMPERATURE_MODELS;
+    process.env.LLM_OMIT_TEMPERATURE_MODELS = 'claude,gpt,a';
+    try {
+      const { buildChatModelOptions, shouldOmitTemperature } = await import('../../../dist/utils/llm.js');
+
+      const claudeOptions = buildChatModelOptions({
+        ...baseConfig,
+        llmModel: 'claude-opus-4-8',
+      }, 0);
+      const wrappedClaudeOptions = buildChatModelOptions({
+        ...baseConfig,
+        llmModel: 'my-claude-wrapper',
+      }, 0);
+      const broadSubstringOptions = buildChatModelOptions({
+        ...baseConfig,
+        llmModel: 'paratera-model',
+      }, 0);
+
+      expect(shouldOmitTemperature('claude-opus-4-8')).toBe(true);
+      expect(claudeOptions).not.toHaveProperty('temperature');
+      expect(wrappedClaudeOptions.temperature).toBe(0);
+      expect(broadSubstringOptions.temperature).toBe(0);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.LLM_OMIT_TEMPERATURE_MODELS;
+      } else {
+        process.env.LLM_OMIT_TEMPERATURE_MODELS = previous;
+      }
+    }
+  });
+
   test('can disable LangChain invoke streaming for graph-state correctness', async () => {
     const { buildChatModelOptions } = await import('../../../dist/utils/llm.js');
 

--- a/backend/src/utils/llm.ts
+++ b/backend/src/utils/llm.ts
@@ -13,15 +13,33 @@ export interface ChatModelRuntimeOptions {
   disableStreaming?: boolean;
 }
 
+function envListMatchesModel(rawValue: string | undefined, modelName: string | undefined): boolean {
+  const raw = rawValue?.trim().toLowerCase();
+  if (!raw) return false;
+  if (['1', 'true', 'yes', 'on', '*', 'all'].includes(raw)) return true;
+
+  const normalizedModel = modelName?.trim().toLowerCase() ?? '';
+  if (!normalizedModel) return false;
+
+  return raw
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .some((item) => normalizedModel === item || normalizedModel.includes(item));
+}
+
+export function shouldOmitTemperature(modelName: string | undefined): boolean {
+  return envListMatchesModel(process.env.LLM_OMIT_TEMPERATURE_MODELS, modelName);
+}
+
 export function buildChatModelOptions(
   modelConfig: ChatModelConfigLike,
   temperature: number,
   runtimeOptions: ChatModelRuntimeOptions = {},
 ) {
   const disableStreaming = runtimeOptions.disableStreaming ?? false;
-  return {
+  const options = {
     modelName: modelConfig.llmModel,
-    temperature,
     timeout: modelConfig.llmTimeoutMs,
     maxRetries: modelConfig.llmMaxRetries,
     apiKey: modelConfig.llmApiKey,
@@ -31,6 +49,10 @@ export function buildChatModelOptions(
       baseURL: modelConfig.llmBaseUrl,
     },
   };
+
+  return shouldOmitTemperature(modelConfig.llmModel)
+    ? options
+    : { ...options, temperature };
 }
 
 type ChatCompletionRequestLike = {

--- a/backend/src/utils/llm.ts
+++ b/backend/src/utils/llm.ts
@@ -16,16 +16,17 @@ export interface ChatModelRuntimeOptions {
 function envListMatchesModel(rawValue: string | undefined, modelName: string | undefined): boolean {
   const raw = rawValue?.trim().toLowerCase();
   if (!raw) return false;
-  if (['1', 'true', 'yes', 'on', '*', 'all'].includes(raw)) return true;
 
   const normalizedModel = modelName?.trim().toLowerCase() ?? '';
   if (!normalizedModel) return false;
+
+  if (['1', 'true', 'yes', 'on', '*', 'all'].includes(raw)) return true;
 
   return raw
     .split(',')
     .map((item) => item.trim())
     .filter(Boolean)
-    .some((item) => normalizedModel === item || normalizedModel.includes(item));
+    .some((item) => normalizedModel === item || normalizedModel.startsWith(`${item}-`));
 }
 
 export function shouldOmitTemperature(modelName: string | undefined): boolean {


### PR DESCRIPTION
## Summary

- Problem: Some OpenAI-compatible model endpoints reject or deprecate the `temperature` option even when the rest of the chat-completions interface is compatible.
- Why it matters: Those providers fail before the agent can run, despite otherwise supporting the benchmark/runtime request shape.
- What changed: Added an opt-in `LLM_OMIT_TEMPERATURE_MODELS` matcher and skipped `temperature` only for matching model aliases.
- What did NOT change (scope boundary): Existing models still receive the configured `temperature` by default; no settings schema, UI, prompt, or benchmark assertions changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `buildChatModelOptions` always passed `temperature` into the OpenAI-compatible chat model options, but at least one compatible endpoint rejects that parameter for the selected model.
- Missing detection / guardrail: Unit coverage asserted streaming flags but did not lock in default `temperature` behavior or a provider-specific opt-out path.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Runtime support for multiple OpenAI-compatible providers exposed a provider difference that the shared option builder did not handle.
- Why this regressed now: Newly tested Claude-compatible model aliases use the same OpenAI-compatible wrapper but do not accept `temperature`.
- If unknown, what was ruled out: The base URL and API key path were validated separately; the remaining failure was the rejected `temperature` option.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/src/utils/__tests__/llm-options.test.mjs`
- Scenario the test should lock in: Default models keep `temperature`, while configured aliases omit it.
- Why this is the smallest reliable guardrail: The behavior is centralized in `buildChatModelOptions`, so a focused option-builder test covers all callers.
- Existing test that already covers this (if any): Existing tests covered streaming option behavior only.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

An optional environment variable is available for OpenAI-compatible providers that reject `temperature`:

```text
LLM_OMIT_TEMPERATURE_MODELS=claude-opus-4-8
```

Comma-separated aliases are supported. `1`, `true`, `yes`, `on`, `*`, or `all` omit `temperature` for all configured model names.

## Diagram (if applicable)

N/A

```text
Before:
createChatModel -> buildChatModelOptions -> always includes temperature -> provider may reject request

After:
createChatModel -> buildChatModelOptions -> omit temperature only when model matches opt-out env -> provider accepts request
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node/backend test runner
- Model/provider: OpenAI-compatible providers; Claude-compatible alias used for the rejected-temperature case
- Integration/channel (if any): benchmark runner local config
- Relevant config (redacted): `LLM_OMIT_TEMPERATURE_MODELS=claude-opus-4-8`

### Steps

1. Configure a model alias in `LLM_OMIT_TEMPERATURE_MODELS`.
2. Build chat model options for that alias.
3. Build chat model options for a normal model alias.

### Expected

- Matching aliases omit `temperature`.
- Non-matching aliases keep the existing `temperature` value.

### Actual

- Matching aliases omit `temperature`.
- Non-matching aliases keep the existing `temperature` value.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run locally:

```text
npm test --prefix backend -- --runInBand backend/src/utils/__tests__/llm-options.test.mjs
# Test Suites: 1 passed, 1 total
# Tests: 5 passed, 5 total
```

Also ran:

```text
git diff --check HEAD~1 HEAD
```

Manual smoke before opening the PR confirmed the Claude-compatible alias can run once `temperature` is omitted; Gemini smoke also passed with the corrected OpenAI-compatible `/v1` base URL in local benchmark config.

## Human Verification (required)

- Verified scenarios: Default model options still include `temperature`; configured model aliases omit it; related backend test passes.
- Edge cases checked: Empty env var, exact model alias, non-matching model alias.
- What you did **not** verify: Full 50-case benchmark was not rerun for this small option-builder change; no additional Claude benchmark was run after the initial smoke to avoid unnecessary provider cost.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes, optional `LLM_OMIT_TEMPERATURE_MODELS`
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: Set `LLM_OMIT_TEMPERATURE_MODELS` only for model aliases whose provider rejects `temperature`.

## Risks and Mitigations

- Risk: A broad opt-out value such as `all` may remove temperature from providers that support it.
  - Mitigation: Default behavior is unchanged; normal usage should set comma-separated model aliases instead of broad opt-out values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, centralized change to LLM request options with backward-compatible defaults; only affects models explicitly listed in the env var.
> 
> **Overview**
> **`buildChatModelOptions`** no longer always sends **`temperature`**. It now skips that field when the configured model matches **`LLM_OMIT_TEMPERATURE_MODELS`**, so OpenAI-compatible endpoints that reject **`temperature`** can still run.
> 
> The env matcher supports comma-separated aliases (exact or substring), plus broad values like **`all`** / **`true`**. **`shouldOmitTemperature`** is exported for tests. Default behavior is unchanged: non-matching models still get the caller’s **`temperature`**.
> 
> Unit tests lock in default **`temperature`**, opt-out for a Claude-style alias, and unchanged streaming options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f09cb2aaf8d4bc3ea0919ffca7440fff59b20c2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->