### PR TITLE
fix(backend): map portal frame mezzanine loads

### DIFF
--- a/backend/src/agent-runtime/engineering-draft.ts
+++ b/backend/src/agent-runtime/engineering-draft.ts
@@ -38,6 +38,14 @@ function positiveNumber(value: unknown): number | undefined {
   return parsed !== undefined && parsed > 0 ? parsed : undefined;
 }
 
+function firstPositiveNumber(candidates: readonly unknown[]): number | undefined {
+  for (const candidate of candidates) {
+    const parsed = positiveNumber(candidate);
+    if (parsed !== undefined) return parsed;
+  }
+  return undefined;
+}
+
 function positiveInteger(value: unknown): number | undefined {
   const parsed = positiveNumber(value);
   return parsed === undefined ? undefined : Math.max(1, Math.round(parsed));
@@ -194,6 +202,33 @@ function normalizeEngineeringLoad(value: unknown): EngineeringDraftLoad | undefi
   };
 }
 
+function normalizeMezzanineHeight(rawGeometry: Record<string, unknown>): number | undefined {
+  const direct = firstPositiveNumber([
+    rawGeometry.mezzanineHeightM,
+    rawGeometry.mezzanineHeight,
+    rawGeometry.mezzanineLevelM,
+    rawGeometry.mezzanineElevationM,
+    rawGeometry.platformHeightM,
+    rawGeometry.intermediateFloorHeightM,
+  ]);
+  if (direct !== undefined) return direct;
+
+  const mezzanine = asRecord(rawGeometry.mezzanine);
+  const platform = asRecord(rawGeometry.platform);
+  const intermediateFloor = asRecord(rawGeometry.intermediateFloor);
+  return firstPositiveNumber([
+    mezzanine?.heightM,
+    mezzanine?.height,
+    mezzanine?.elevationM,
+    platform?.heightM,
+    platform?.height,
+    platform?.elevationM,
+    intermediateFloor?.heightM,
+    intermediateFloor?.height,
+    intermediateFloor?.elevationM,
+  ]);
+}
+
 export function normalizeEngineeringDraft(value: unknown): EngineeringDraft | undefined {
   const raw = asRecord(value);
   if (!raw) return undefined;
@@ -202,6 +237,7 @@ export function normalizeEngineeringDraft(value: unknown): EngineeringDraft | un
   const geometry = rawGeometry ? {
     lengthM: positiveNumber(rawGeometry.lengthM),
     heightM: positiveNumber(rawGeometry.heightM),
+    mezzanineHeightM: normalizeMezzanineHeight(rawGeometry),
     spanLengthsM: positiveNumberArray(rawGeometry.spanLengthsM),
     storyHeightsM: positiveNumberArray(rawGeometry.storyHeightsM),
     bayWidthsM: positiveNumberArray(rawGeometry.bayWidthsM),
@@ -337,8 +373,24 @@ function legacyLoadPosition(load: EngineeringDraftLoad): DraftLoadPosition {
 }
 
 function targetIncludes(load: EngineeringDraftLoad, text: string): boolean {
-  return (load.target ?? '').toLowerCase().includes(text);
+  const targetText = [load.target, load.location?.nodeRole]
+    .filter((item): item is string => typeof item === 'string' && item.length > 0)
+    .join(' ')
+    .toLowerCase();
+  return targetText.includes(text.toLowerCase());
 }
+
+function targetMatches(load: EngineeringDraftLoad, terms: readonly string[]): boolean {
+  return terms.some((term) => targetIncludes(load, term));
+}
+
+function isClearPortalTarget(load: EngineeringDraftLoad, includeTerms: readonly string[], excludeTerms: readonly string[]): boolean {
+  return targetMatches(load, includeTerms) && !targetMatches(load, excludeTerms);
+}
+
+const PORTAL_ROOF_TARGETS = ['roof', 'rafter', 'eave', '屋面', '屋顶', '檐梁'];
+const PORTAL_MEZZANINE_TARGETS = ['mezzanine', 'platform', 'intermediate floor', '夹层', '平台'];
+const PORTAL_CRANE_TARGETS = ['crane', '吊车'];
 
 function modelLoadDirection(load: EngineeringDraftLoad): 'fx' | 'fy' | 'fz' {
   if (load.direction === 'globalX') return 'fx';
@@ -614,7 +666,7 @@ export function projectEngineeringDraftToLegacyPatch(
   if (engineeringDraft.boundary?.frameBaseSupportType !== undefined) {
     next.frameBaseSupportType = next.frameBaseSupportType ?? engineeringDraft.boundary.frameBaseSupportType;
   }
-  if (primaryLoad && inferredType !== 'frame') {
+  if (primaryLoad && inferredType !== 'frame' && inferredType !== 'portal-frame') {
     next.loadKN = next.loadKN ?? primaryLoad.magnitude;
     next.loadType = next.loadType ?? legacyLoadType(primaryLoad);
     next.loadPosition = next.loadPosition ?? legacyLoadPosition(primaryLoad);
@@ -755,15 +807,42 @@ export function projectEngineeringDraftToLegacyPatch(
       skillState.portalBaySpansM = spanLengths;
       skillState.portalBayCount = spanLengths.length;
     }
-    const roofLoad = loads.find((load) => isLineLoad(load) && (targetIncludes(load, 'roof') || targetIncludes(load, 'rafter')))
-      ?? loads.find(isLineLoad);
+    if (engineeringDraft.geometry?.mezzanineHeightM !== undefined) {
+      skillState.mezzanineHeightM = engineeringDraft.geometry.mezzanineHeightM;
+    }
+    const mezzanineLoad = loads.find((load) => (
+      isLineLoad(load)
+      && isClearPortalTarget(load, PORTAL_MEZZANINE_TARGETS, PORTAL_ROOF_TARGETS)
+    ));
+    if (mezzanineLoad) {
+      skillState.mezzanineLoadKN = mezzanineLoad.magnitude;
+    }
+    const roofLoad = loads.find((load) => (
+      isLineLoad(load)
+      && isClearPortalTarget(load, PORTAL_ROOF_TARGETS, PORTAL_MEZZANINE_TARGETS)
+    ))
+      ?? loads.find((load) => (
+        isLineLoad(load)
+        && !targetMatches(load, PORTAL_MEZZANINE_TARGETS)
+        && !targetMatches(load, PORTAL_CRANE_TARGETS)
+      ));
     if (roofLoad) {
       skillState.roofLoadKNM = roofLoad.magnitude;
-      next.loadKN = next.loadKN ?? roofLoad.magnitude;
-      next.loadType = next.loadType ?? 'distributed';
-      next.loadPosition = next.loadPosition ?? 'full-span';
+      next.loadKN = roofLoad.magnitude;
+      next.loadType = 'distributed';
+      next.loadPosition = 'full-span';
+    } else {
+      const defaultPortalLoad = loads.find((load) => (
+        !targetMatches(load, PORTAL_MEZZANINE_TARGETS)
+        && !targetMatches(load, PORTAL_CRANE_TARGETS)
+      ));
+      if (defaultPortalLoad) {
+        next.loadKN = next.loadKN ?? defaultPortalLoad.magnitude;
+        next.loadType = next.loadType ?? legacyLoadType(defaultPortalLoad);
+        next.loadPosition = next.loadPosition ?? legacyLoadPosition(defaultPortalLoad);
+      }
     }
-    const craneLoad = loads.find((load) => targetIncludes(load, 'crane'));
+    const craneLoad = loads.find((load) => targetMatches(load, PORTAL_CRANE_TARGETS));
     if (craneLoad) {
       skillState.craneLoadKN = craneLoad.magnitude;
     }

--- a/backend/src/agent-runtime/model-builder.ts
+++ b/backend/src/agent-runtime/model-builder.ts
@@ -880,9 +880,10 @@ function buildPortalFrameModel(state: DraftState, metadata: Record<string, unkno
     }
   }
   if (hasMezzanine) {
-    elements.push({ id: 'MEZ1', type: 'beam', nodes: ['M0', 'M1'], material: '1', section: '1' });
+    const mezzanineElement = { id: 'MEZ1', type: 'beam', nodes: ['M0', 'M1'], material: '1', section: '1' };
+    elements.push(mezzanineElement);
     if (mezzanineLoad !== undefined) {
-      loads.push({ node: 'M1', fz: -mezzanineLoad });
+      loads.push({ type: 'distributed', element: mezzanineElement.id, wz: -mezzanineLoad, wy: 0 });
     }
   }
   if (nodalLoad !== undefined) {

--- a/backend/src/agent-runtime/types.ts
+++ b/backend/src/agent-runtime/types.ts
@@ -15,6 +15,7 @@ export type EngineeringDraftLoadDirection = 'gravity' | 'globalX' | 'globalY' | 
 export interface EngineeringDraftGeometry {
   lengthM?: number;
   heightM?: number;
+  mezzanineHeightM?: number;
   spanLengthsM?: number[];
   storyHeightsM?: number[];
   bayWidthsM?: number[];

--- a/backend/src/agent-skills/structure-type/portal-frame/__tests__/handler.test.mjs
+++ b/backend/src/agent-skills/structure-type/portal-frame/__tests__/handler.test.mjs
@@ -82,7 +82,93 @@ describe('portal-frame handler', () => {
     expect(model.metadata).toEqual(expect.objectContaining({ hasMezzanine: true }));
     expect(model.load_cases[0].loads).toEqual(expect.arrayContaining([
       expect.objectContaining({ element: 'R0', wz: -6 }),
-      { node: 'M1', fz: -4 },
+      expect.objectContaining({ element: 'MEZ1', wz: -4 }),
+    ]));
+  });
+
+  test('maps mezzanine engineeringDraft fields into portal-frame state', () => {
+    const patch = handler.extractDraft({
+      message: '',
+      llmDraftPatch: {
+        engineeringDraft: {
+          structureType: 'portal-frame',
+          geometry: { spanLengthsM: [18], heightM: 7, mezzanineHeightM: '', platform: { heightM: 3 } },
+          loads: [
+            { kind: 'line', magnitude: 4, unit: 'kN/m', direction: 'gravity', target: '夹层梁' },
+            { kind: 'line', magnitude: 6, unit: 'kN/m', direction: 'gravity', target: '屋面' },
+          ],
+        },
+      },
+    });
+    const state = handler.mergeState(undefined, patch);
+    const model = handler.buildModel(state);
+
+    expect(handler.computeMissing(state, 'execution').critical).toEqual([]);
+    expect(state.loadKN).toBe(6);
+    expect(state.skillState).toEqual(expect.objectContaining({
+      portalBaySpansM: [18],
+      roofLoadKNM: 6,
+      mezzanineHeightM: 3,
+      mezzanineLoadKN: 4,
+    }));
+    expect(model.metadata).toEqual(expect.objectContaining({ hasMezzanine: true }));
+    expect(model.load_cases[0].loads).toEqual(expect.arrayContaining([
+      expect.objectContaining({ element: 'R0', wz: -6 }),
+      expect.objectContaining({ element: 'MEZ1', wz: -4 }),
+    ]));
+  });
+
+  test('does not treat mezzanine point loads as distributed beam loads', () => {
+    const patch = handler.extractDraft({
+      message: '',
+      llmDraftPatch: {
+        engineeringDraft: {
+          structureType: 'portal-frame',
+          geometry: { spanLengthsM: [18], heightM: 7, mezzanineHeightM: 3 },
+          loads: [
+            { kind: 'line', magnitude: 6, unit: 'kN/m', direction: 'gravity', target: 'roof' },
+            { kind: 'point', magnitude: 12, unit: 'kN', direction: 'gravity', target: 'mezzanine' },
+          ],
+        },
+      },
+    });
+    const state = handler.mergeState(undefined, patch);
+    const model = handler.buildModel(state);
+
+    expect(state.skillState?.mezzanineLoadKN).toBeUndefined();
+    expect(model.load_cases[0].loads).toEqual(expect.arrayContaining([
+      expect.objectContaining({ element: 'R0', wz: -6 }),
+    ]));
+    expect(model.load_cases[0].loads).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ element: 'MEZ1' }),
+    ]));
+  });
+
+  test('does not duplicate ambiguous roof mezzanine line loads', () => {
+    const patch = handler.extractDraft({
+      message: '',
+      llmDraftPatch: {
+        engineeringDraft: {
+          structureType: 'portal-frame',
+          geometry: { spanLengthsM: [18], heightM: 7, mezzanineHeightM: 3 },
+          loads: [
+            { kind: 'line', magnitude: 5, unit: 'kN/m', direction: 'gravity', target: '屋面夹层' },
+            { kind: 'line', magnitude: 6, unit: 'kN/m', direction: 'gravity', target: '屋面' },
+          ],
+        },
+      },
+    });
+    const state = handler.mergeState(undefined, patch);
+    const model = handler.buildModel(state);
+
+    expect(state.loadKN).toBe(6);
+    expect(state.skillState?.roofLoadKNM).toBe(6);
+    expect(state.skillState?.mezzanineLoadKN).toBeUndefined();
+    expect(model.load_cases[0].loads).toEqual(expect.arrayContaining([
+      expect.objectContaining({ element: 'R0', wz: -6 }),
+    ]));
+    expect(model.load_cases[0].loads).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ element: 'MEZ1' }),
     ]));
   });
 

--- a/backend/src/agent-skills/structure-type/portal-frame/draft.md
+++ b/backend/src/agent-skills/structure-type/portal-frame/draft.md
@@ -23,6 +23,29 @@
 - "集中力" / "point load" / "点荷载" → `"loadType": "point"`
 - 门式刚架默认 `"loadType": "distributed"`
 
+## engineeringDraft（复杂门架优先使用）
+- 复杂几何和多个荷载优先输出顶层 `engineeringDraft`，旧字段可同时输出但不要丢失 `engineeringDraft`。
+- 跨度数组写入 `engineeringDraft.geometry.spanLengthsM`，檐口/柱高写入 `engineeringDraft.geometry.heightM`。
+- 若存在夹层、平台或 intermediate floor，高度写入 `engineeringDraft.geometry.mezzanineHeightM`。
+- 屋面/檩条/刚架梁线荷载作为独立 `engineeringDraft.loads` 条目，`kind: "line"`，`unit: "kN/m"`，`target: "roof"`。
+- 夹层梁/平台梁线荷载作为独立 `engineeringDraft.loads` 条目，`kind: "line"`，`unit: "kN/m"`，`target: "mezzanine"`。
+- 不要把屋面荷载和夹层荷载合并；每个用户明确给出的荷载都必须保留为独立条目。
+
+示例：
+```json
+{
+  "inferredType": "portal-frame",
+  "engineeringDraft": {
+    "structureType": "portal-frame",
+    "geometry": { "spanLengthsM": [18], "heightM": 7, "mezzanineHeightM": 3 },
+    "loads": [
+      { "kind": "line", "magnitude": 6, "unit": "kN/m", "direction": "gravity", "target": "roof" },
+      { "kind": "line", "magnitude": 4, "unit": "kN/m", "direction": "gravity", "target": "mezzanine" }
+    ]
+  }
+}
+```
+
 ## 荷载位置映射
 - 柱顶节点点荷载可映射为 `top-nodes`
 - 檐梁均布荷载可映射为 `full-span`


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: portal-frame extraction could preserve roof loads but had no structured path for mezzanine height/load fields, and the portal-frame builder modeled mezzanine line load as a nodal load.
- Why it matters: benchmark and user prompts that describe mezzanine portal frames can lose the mezzanine semantics or produce a load model that does not match the requested kN/m beam load.
- What changed: added structured mezzanine geometry normalization, mapped portal-frame roof/mezzanine/crane targets separately, applied mezzanine loads as distributed loads on `MEZ1`, and added focused coverage.
- What did NOT change (scope boundary): no raw user-text scraping was added, and non-portal-frame model builders were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: portal-frame semantic projection did not expose mezzanine height/load fields from `engineeringDraft`, and the existing builder simplified mezzanine loading as a point load at `M1`.
- Missing detection / guardrail: no unit test covered a portal-frame `engineeringDraft` containing separate roof and mezzanine line loads.
- Prior context (`git blame`, prior PR, issue, or refactor if known): surfaced while checking the `portal-frame-with-mezzanine` benchmark case.
- Why this regressed now: not confirmed as a recent regression; this was an uncovered capability gap exposed by benchmark expansion.
- If unknown, what was ruled out: the benchmark prompt already stated the mezzanine height and mezzanine beam line load, so this was not only a model-capability issue.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `backend/src/agent-skills/structure-type/portal-frame/__tests__/handler.test.mjs`
- Scenario the test should lock in: a portal-frame `engineeringDraft` with roof and mezzanine line loads, including Chinese target labels and nested platform height aliases.
- Why this is the smallest reliable guardrail: it exercises the semantic projection and portal-frame model builder without requiring an external LLM call.
- Existing test that already covers this (if any): existing mezzanine builder coverage only used manual `skillState`; it did not verify `engineeringDraft` mapping.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Portal-frame requests that include a mezzanine/platform height and mezzanine beam line load can now preserve that information through the skill path and model the mezzanine load as a distributed member load.

## Diagram (if applicable)

```text
Before:
engineeringDraft mezzanine fields -> portal-frame projection drops/underuses fields -> MEZ1 load may become nodal

After:
engineeringDraft mezzanine fields -> portal-frame state -> MEZ1 distributed load -> model matches requested kN/m load
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node/npm backend
- Model/provider: N/A for unit verification
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run backend TypeScript build.
2. Run the portal-frame skill unit tests.
3. Run shared runtime helper tests.
4. Run backend lint.

### Expected

- Portal-frame mezzanine `engineeringDraft` maps roof and mezzanine line loads separately.
- Mezzanine load is represented as a distributed load on `MEZ1`.
- Existing runtime helper coverage remains passing.

### Actual

- All verification commands passed locally.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

```text
npm run build --prefix backend
npm run test:skill:portal-frame --prefix backend
npm test --prefix backend -- --runInBand src/agent-runtime/__tests__/runtime-helpers.test.mjs
npm run lint --prefix backend
git diff --check
```

## Human Verification (required)

- Verified scenarios: portal-frame mezzanine state supplied directly, and `engineeringDraft` with nested platform height plus separate Chinese-target roof/mezzanine loads.
- Edge cases checked: mezzanine line load appears before roof line load; roof load still becomes the primary portal-frame distributed load.
- What you did **not** verify: full 50-case LLM benchmark rerun.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the shared `engineeringDraft` normalizer now accepts additional optional mezzanine aliases.
  - Mitigation: projection changes are scoped to the portal-frame branch, with shared runtime helper tests passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to portal-frame draft projection and model builder; behavior change is intentional for mezzanine semantics with new unit-test guardrails.
> 
> **Overview**
> **Portal-frame `engineeringDraft` now carries mezzanine geometry and separates roof, mezzanine, and crane loads** instead of collapsing everything into a single primary load.
> 
> Normalization adds `mezzanineHeightM` from flat keys and nested `platform` / `mezzanine` / `intermediateFloor` aliases. Portal projection skips the generic primary-load path, maps height into `skillState.mezzanineHeightM`, classifies loads via bilingual target lists (including `nodeRole`), and keeps roof as the legacy `loadKN` when present.
> 
> **The portal-frame model applies mezzanine kN/m as a distributed load on `MEZ1`**, not a nodal force at `M1`. Types, portal-frame `draft.md`, and handler tests cover `engineeringDraft` mapping with Chinese targets and nested platform height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43943f37b7ac112646f6184179e27745638832c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->