### PR TITLE
docs: add 1.1.1 rc changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to StructureClaw are documented in this file.
 
+## [1.1.1-rc.0] - 2026-06-30
+
+### Added
+
+- Anthropic-compatible chat provider support for Claude model endpoints.
+- Concrete-frame skill core implementation, including staged extraction and model building.
+- YJK concrete design result extraction for benchmarked concrete workflows.
+
+### Changed
+
+- Structural routing now follows an LLM-first path, with rule logic kept as auxiliary support.
+- Structural skills use semantic draft data more consistently across extraction and model building.
+- LLM benchmark assets were extracted into a standalone submodule.
+
+### Fixed
+
+- Generic and frame workflows now preserve declared structure types, coordinates, line loads, and normalized load data more reliably.
+- Portal-frame mezzanine loads, panelized truss model generation, and PKPM steel-frame material persistence were corrected.
+- Vision attachments are parsed separately before agent execution.
+- YJK benchmark runs now detach launcher handling, close YJK after benchmark execution, and handle aborts more cleanly.
+- LLM temperature may be omitted for providers that do not accept explicit temperature settings.
+
 ## [1.0.0] - 2026-04-27
 
 ### Added — npm Packaging & Distribution


### PR DESCRIPTION
## Summary
- Add the 1.1.1-rc.0 changelog entry.
- Summarize the changes since v1.1.0 across provider support, concrete-frame/YJK work, LLM-first routing, benchmark extraction, and workflow fixes.

## Impacted Areas
- docs

## Validation
- npm install
- npm install --prefix backend
- npm install --prefix frontend
- npm run lint --prefix backend
- npm test --prefix backend -- --runInBand
- npm run type-check --prefix frontend
- npm run build --prefix backend
- npm run build --prefix frontend
- node scripts/prepare-package.js
- npm version --allow-same-version 1.1.1-rc.0 --no-git-tag-version; node scripts/prepare-package.js; npm pack --dry-run; git restore package.json package-lock.json

## Notes
- This PR is required because upstream master blocks direct pushes.
- After merge, tag v1.1.1-rc.0 should be pushed to upstream to trigger the npm rc publish workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to CHANGELOG.md with no runtime or security impact.
> 
> **Overview**
> Documents the **1.1.1-rc.0** release in `CHANGELOG.md` with dated sections for **Added**, **Changed**, and **Fixed**.
> 
> The new entry captures product-facing notes since v1.1.0: Anthropic-compatible chat providers, concrete-frame skill and YJK concrete design extraction, LLM-first structural routing with rules as auxiliary support, benchmark assets moved to a submodule, and a set of workflow fixes (structure types, loads, vision attachment parsing, YJK benchmark lifecycle, optional LLM temperature).
> 
> No application code is modified—only release documentation for reviewers and publish/tag workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4755d13e59ceb933e37982e343ecc32ee694db88. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->