### PR TITLE
docs: add arXiv paper citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ If StructureClaw is useful in your research or engineering work, we welcome you 
 
 ```bibtex
 @misc{qin2026structureclaw,
-  title = {{StructureClaw}: Traceable LLM Agents and an Executable Benchmark for Structural Engineering Workflows},
+  title = {{StructureClaw: Traceable LLM Agents and an Executable Benchmark for Structural Engineering Workflows}},
   author = {Sizhong Qin and Yi Gu and Yao Jiang and Ao Cai and Changjian Zhou and Shaoxuan Shuai and Jiachang Wang and Tianhao Shen and Yueqiang Li and Xinhao Li and Li Zeng and Yueshi Chen and Dachen Gao and Genrong Xu and Wenjie Liao and Xinzheng Lu},
   year = {2026},
   eprint = {2607.14896},

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="https://www.npmjs.com/package/@structureclaw/structureclaw"><img alt="npm" src="https://img.shields.io/npm/v/@structureclaw/structureclaw?color=2563eb"></a>
   <a href="https://github.com/structureclaw/structureclaw/actions/workflows/backend-regression.yml"><img alt="backend regression" src="https://github.com/structureclaw/structureclaw/actions/workflows/backend-regression.yml/badge.svg"></a>
   <a href="https://github.com/structureclaw/structureclaw/actions/workflows/analysis-regression.yml"><img alt="analysis regression" src="https://github.com/structureclaw/structureclaw/actions/workflows/analysis-regression.yml/badge.svg"></a>
+  <a href="https://arxiv.org/abs/2607.14896"><img alt="arXiv 2607.14896" src="https://img.shields.io/badge/arXiv-2607.14896-b31b1b.svg"></a>
   <img alt="Node.js 20+" src="https://img.shields.io/badge/node-%3E%3D20-339933">
   <a href="./LICENSE"><img alt="license MIT" src="https://img.shields.io/badge/license-MIT-green"></a>
 </p>
@@ -285,3 +286,20 @@ Please read [CONTRIBUTING.md](./CONTRIBUTING.md) and the organization-level [Cod
 ## License
 
 MIT. See [LICENSE](./LICENSE).
+
+## Citation
+
+If StructureClaw is useful in your research or engineering work, we welcome you to cite our paper:
+
+```bibtex
+@misc{qin2026structureclaw,
+  title = {{StructureClaw}: Traceable LLM Agents and an Executable Benchmark for Structural Engineering Workflows},
+  author = {Sizhong Qin and Yi Gu and Yao Jiang and Ao Cai and Changjian Zhou and Shaoxuan Shuai and Jiachang Wang and Tianhao Shen and Yueqiang Li and Xinhao Li and Li Zeng and Yueshi Chen and Dachen Gao and Genrong Xu and Wenjie Liao and Xinzheng Lu},
+  year = {2026},
+  eprint = {2607.14896},
+  archivePrefix = {arXiv},
+  primaryClass = {cs.SE},
+  doi = {10.48550/arXiv.2607.14896},
+  url = {https://arxiv.org/abs/2607.14896}
+}
+```

--- a/README_CN.md
+++ b/README_CN.md
@@ -8,6 +8,7 @@
   <a href="https://www.npmjs.com/package/@structureclaw/structureclaw"><img alt="npm" src="https://img.shields.io/npm/v/@structureclaw/structureclaw?color=2563eb"></a>
   <a href="https://github.com/structureclaw/structureclaw/actions/workflows/backend-regression.yml"><img alt="backend regression" src="https://github.com/structureclaw/structureclaw/actions/workflows/backend-regression.yml/badge.svg"></a>
   <a href="https://github.com/structureclaw/structureclaw/actions/workflows/analysis-regression.yml"><img alt="analysis regression" src="https://github.com/structureclaw/structureclaw/actions/workflows/analysis-regression.yml/badge.svg"></a>
+  <a href="https://arxiv.org/abs/2607.14896"><img alt="arXiv 2607.14896" src="https://img.shields.io/badge/arXiv-2607.14896-b31b1b.svg"></a>
   <img alt="Node.js 20+" src="https://img.shields.io/badge/node-%3E%3D20-339933">
   <a href="./LICENSE"><img alt="license MIT" src="https://img.shields.io/badge/license-MIT-green"></a>
 </p>
@@ -285,3 +286,20 @@ StructureClaw 1.0 以 `settings.json` 作为用户配置文件。`sclaw doctor` 
 ## 许可证
 
 MIT，详见 [LICENSE](./LICENSE)。
+
+## 引用
+
+如果 StructureClaw 对您的研究或工程工作有所帮助，欢迎引用我们的论文：
+
+```bibtex
+@misc{qin2026structureclaw,
+  title = {{StructureClaw}: Traceable LLM Agents and an Executable Benchmark for Structural Engineering Workflows},
+  author = {Sizhong Qin and Yi Gu and Yao Jiang and Ao Cai and Changjian Zhou and Shaoxuan Shuai and Jiachang Wang and Tianhao Shen and Yueqiang Li and Xinhao Li and Li Zeng and Yueshi Chen and Dachen Gao and Genrong Xu and Wenjie Liao and Xinzheng Lu},
+  year = {2026},
+  eprint = {2607.14896},
+  archivePrefix = {arXiv},
+  primaryClass = {cs.SE},
+  doi = {10.48550/arXiv.2607.14896},
+  url = {https://arxiv.org/abs/2607.14896}
+}
+```

--- a/README_CN.md
+++ b/README_CN.md
@@ -293,7 +293,7 @@ MIT，详见 [LICENSE](./LICENSE)。
 
 ```bibtex
 @misc{qin2026structureclaw,
-  title = {{StructureClaw}: Traceable LLM Agents and an Executable Benchmark for Structural Engineering Workflows},
+  title = {{StructureClaw: Traceable LLM Agents and an Executable Benchmark for Structural Engineering Workflows}},
   author = {Sizhong Qin and Yi Gu and Yao Jiang and Ao Cai and Changjian Zhou and Shaoxuan Shuai and Jiachang Wang and Tianhao Shen and Yueqiang Li and Xinhao Li and Li Zeng and Yueshi Chen and Dachen Gao and Genrong Xu and Wenjie Liao and Xinzheng Lu},
   year = {2026},
   eprint = {2607.14896},


### PR DESCRIPTION
## What changed

- Added a linked arXiv badge for the StructureClaw paper to the English and Chinese README files.
- Added bilingual citation sections with a complete BibTeX entry.

## Why

This makes the project paper easy to discover from the repository landing page and gives users a copy-ready citation format.

## Impacted areas

- Documentation only: `README.md` and `README_CN.md`
- No runtime, API, or dependency changes

## Validation

- `git diff --check`
- Confirmed the paper metadata against arXiv:2607.14896

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to README files; no runtime, API, or dependency changes.
> 
> **Overview**
> Adds discoverability and a standard citation path for the StructureClaw arXiv paper on the repo landing pages.
> 
> **English and Chinese READMEs** now include an **arXiv 2607.14896** badge in the header badge row (linked to `https://arxiv.org/abs/2607.14896`). Each file also gains a new **Citation** / **引用** section after the license block with copy-ready **BibTeX** for `qin2026structureclaw` (title, authors, year, eprint, DOI, URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b0abcfcb0e11c39d15a7e61450ddd524b19c944. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->